### PR TITLE
Add browser support for token lib

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3012,7 +3012,8 @@
     "graceful-fs": {
       "version": "4.1.11",
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
-      "integrity": "sha1-Dovf5NHduIVNZOBOp8AOKgJuVlg="
+      "integrity": "sha1-Dovf5NHduIVNZOBOp8AOKgJuVlg=",
+      "dev": true
     },
     "growly": {
       "version": "1.3.0",
@@ -3195,7 +3196,8 @@
     "imurmurhash": {
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
-      "integrity": "sha1-khi5srkoojixPcT7a21XbyMUU+o="
+      "integrity": "sha1-khi5srkoojixPcT7a21XbyMUU+o=",
+      "dev": true
     },
     "inflight": {
       "version": "1.0.6",
@@ -4447,26 +4449,6 @@
       "integrity": "sha1-h6kGXNs1XTGC2PlM4RGIuCXGijs=",
       "dev": true
     },
-    "node-localstorage": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/node-localstorage/-/node-localstorage-1.3.0.tgz",
-      "integrity": "sha1-LkNqro3Mms6XtDxlwWwNV3vgpVw=",
-      "requires": {
-        "write-file-atomic": "1.3.4"
-      },
-      "dependencies": {
-        "write-file-atomic": {
-          "version": "1.3.4",
-          "resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-1.3.4.tgz",
-          "integrity": "sha1-+Aek8LHZ6ROuekgRLmzDrxmRtF8=",
-          "requires": {
-            "graceful-fs": "4.1.11",
-            "imurmurhash": "0.1.4",
-            "slide": "1.1.6"
-          }
-        }
-      }
-    },
     "node-notifier": {
       "version": "5.2.1",
       "resolved": "https://registry.npmjs.org/node-notifier/-/node-notifier-5.2.1.tgz",
@@ -5280,11 +5262,6 @@
       "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-0.0.4.tgz",
       "integrity": "sha1-7b+JA/ZvfOL46v1s7tZeJkyDGzU=",
       "dev": true
-    },
-    "slide": {
-      "version": "1.1.6",
-      "resolved": "https://registry.npmjs.org/slide/-/slide-1.1.6.tgz",
-      "integrity": "sha1-VusCfWW00tzmyy4tMsTUr8nh1wc="
     },
     "sntp": {
       "version": "2.1.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -3012,8 +3012,7 @@
     "graceful-fs": {
       "version": "4.1.11",
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
-      "integrity": "sha1-Dovf5NHduIVNZOBOp8AOKgJuVlg=",
-      "dev": true
+      "integrity": "sha1-Dovf5NHduIVNZOBOp8AOKgJuVlg="
     },
     "growly": {
       "version": "1.3.0",
@@ -3196,8 +3195,7 @@
     "imurmurhash": {
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
-      "integrity": "sha1-khi5srkoojixPcT7a21XbyMUU+o=",
-      "dev": true
+      "integrity": "sha1-khi5srkoojixPcT7a21XbyMUU+o="
     },
     "inflight": {
       "version": "1.0.6",
@@ -4189,14 +4187,6 @@
       "resolved": "https://registry.npmjs.org/jwt-decode/-/jwt-decode-2.2.0.tgz",
       "integrity": "sha1-fYa9VmefWM5qhHBKZX3TkruoGnk="
     },
-    "keytar": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/keytar/-/keytar-4.1.0.tgz",
-      "integrity": "sha512-L3KqiSMtpVitlug4uuI+K5XLne9SAVEFWE8SCQIhQiH0IA/CTbon5v5prVLKK0Ken54o2O8V9HceKagpwJum+Q==",
-      "requires": {
-        "nan": "2.5.1"
-      }
-    },
     "kind-of": {
       "version": "3.2.2",
       "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
@@ -4432,7 +4422,9 @@
     "nan": {
       "version": "2.5.1",
       "resolved": "https://registry.npmjs.org/nan/-/nan-2.5.1.tgz",
-      "integrity": "sha1-1bAWkSUzJql6K77p5hxV2NYDUeI="
+      "integrity": "sha1-1bAWkSUzJql6K77p5hxV2NYDUeI=",
+      "dev": true,
+      "optional": true
     },
     "natural-compare": {
       "version": "1.4.0",
@@ -4454,6 +4446,26 @@
       "resolved": "https://registry.npmjs.org/node-int64/-/node-int64-0.4.0.tgz",
       "integrity": "sha1-h6kGXNs1XTGC2PlM4RGIuCXGijs=",
       "dev": true
+    },
+    "node-localstorage": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/node-localstorage/-/node-localstorage-1.3.0.tgz",
+      "integrity": "sha1-LkNqro3Mms6XtDxlwWwNV3vgpVw=",
+      "requires": {
+        "write-file-atomic": "1.3.4"
+      },
+      "dependencies": {
+        "write-file-atomic": {
+          "version": "1.3.4",
+          "resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-1.3.4.tgz",
+          "integrity": "sha1-+Aek8LHZ6ROuekgRLmzDrxmRtF8=",
+          "requires": {
+            "graceful-fs": "4.1.11",
+            "imurmurhash": "0.1.4",
+            "slide": "1.1.6"
+          }
+        }
+      }
     },
     "node-notifier": {
       "version": "5.2.1",
@@ -5268,6 +5280,11 @@
       "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-0.0.4.tgz",
       "integrity": "sha1-7b+JA/ZvfOL46v1s7tZeJkyDGzU=",
       "dev": true
+    },
+    "slide": {
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/slide/-/slide-1.1.6.tgz",
+      "integrity": "sha1-VusCfWW00tzmyy4tMsTUr8nh1wc="
     },
     "sntp": {
       "version": "2.1.0",

--- a/package.json
+++ b/package.json
@@ -58,7 +58,6 @@
     "isomorphic-fetch": "^2.2.1",
     "json2csv": "^3.11.5",
     "jwt-decode": "^2.2.0",
-    "node-localstorage": "^1.3.0",
     "promptly": "^2.2.0"
   },
   "eslintConfig": {

--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
     "isomorphic-fetch": "^2.2.1",
     "json2csv": "^3.11.5",
     "jwt-decode": "^2.2.0",
-    "keytar": "^4.1.0",
+    "node-localstorage": "^1.3.0",
     "promptly": "^2.2.0"
   },
   "eslintConfig": {
@@ -85,7 +85,8 @@
       "beforeEach": true,
       "afterEach": true,
       "beforeAll": true,
-      "afterAll": true
+      "afterAll": true,
+      "window": true
     },
     "rules": {
       "camelcase": [

--- a/src/lib/keychain.js
+++ b/src/lib/keychain.js
@@ -3,20 +3,41 @@ module.exports = {};
 if ( typeof window === 'undefined' || typeof window.localStorage === 'undefined' ) {
 	// node
 
+	const fs = require( 'fs' );
 	const os = require( 'os' );
-	const LocalStorage = require( 'node-localstorage' ).LocalStorage;
-	const localStorage = new LocalStorage( os.tmpdir() );
+
+	// read-only perms
+	const rw = 0o600;
+
+	let stat;
+	const file = os.tmpdir() + '/vip-go-cli';
+	try {
+		// Ensure the file exists
+		stat = fs.statSync( file );
+	} catch ( e ) {
+		const fd = fs.openSync( file, 'w+', rw );
+		fs.closeSync( fd );
+		stat = fs.statSync( file );
+	}
+
+	// Get file perms (last 3 bits of stat.mode)
+	const perms = stat.mode & 0o777;
+
+	// Ensure permissions are what we expect
+	if ( !! ( perms & ~rw ) ) {
+		throw 'Invalid permissions on access token file: ' + file;
+	}
 
 	module.exports.setPassword = function( service, password ) {
-		return localStorage.setItem( service, password );
+		return fs.writeFileSync( file, password );
 	};
 
 	module.exports.getPassword = function( service ) {
-		return localStorage.getItem( service );
+		return fs.readFileSync( file, 'utf8' );
 	};
 
 	module.exports.deletePassword = function( service ) {
-		return localStorage.removeItem( service );
+		return fs.unlinkSync( file );
 	};
 } else {
 	// browser

--- a/src/lib/keychain.js
+++ b/src/lib/keychain.js
@@ -1,0 +1,35 @@
+module.exports = {};
+
+if ( typeof window === 'undefined' || typeof window.localStorage === 'undefined' ) {
+	// node
+
+	const os = require( 'os' );
+	const LocalStorage = require( 'node-localstorage' ).LocalStorage;
+	const localStorage = new LocalStorage( os.tmpdir() );
+
+	module.exports.setPassword = function( service, password ) {
+		return localStorage.setItem( service, password );
+	};
+
+	module.exports.getPassword = function( service ) {
+		return localStorage.getItem( service );
+	};
+
+	module.exports.deletePassword = function( service ) {
+		return localStorage.removeItem( service );
+	};
+} else {
+	// browser
+
+	module.exports.setPassword = function( service, password ) {
+		return window.localStorage.setItem( service, password );
+	};
+
+	module.exports.getPassword = function( service ) {
+		return window.localStorage.getItem( service );
+	};
+
+	module.exports.deletePassword = function( service ) {
+		return window.localStorage.removeItem( service );
+	};
+}

--- a/src/lib/token.js
+++ b/src/lib/token.js
@@ -1,5 +1,7 @@
-const keytar = require( 'keytar' );
 const jwtDecode = require( 'jwt-decode' );
+
+// ours
+const keychain = require( './keychain' );
 
 // Config
 const SERVICE = 'vip-go-cli';
@@ -27,11 +29,11 @@ class Token {
 module.exports = Token;
 
 module.exports.set = function( token ) {
-	return keytar.setPassword( SERVICE, SERVICE, token );
+	return keychain.setPassword( SERVICE, token );
 };
 
 module.exports.get = async function() {
-	const token = await keytar.getPassword( SERVICE, SERVICE );
+	const token = await keychain.getPassword( SERVICE );
 	try {
 		return new Token( token );
 	} catch ( e ) {
@@ -40,6 +42,5 @@ module.exports.get = async function() {
 };
 
 module.exports.purge = async function() {
-	const credentials = await keytar.findCredentials( SERVICE );
-	credentials.forEach( c => keytar.deletePassword( SERVICE, c.account ) );
+	keychain.deletePassword( SERVICE );
 };


### PR DESCRIPTION
We can now store tokens in localStorage in browsers or on disk in Node.
This also removes the dependency on node-keytar, which was being used
for securely storing tokens on systems that support keychains.
Unfortunately, it also adds a dependency on a C compiler.

Fixes #9