### PR TITLE
Bypass args helper function for auto-login

### DIFF
--- a/src/bin/vip.js
+++ b/src/bin/vip.js
@@ -4,6 +4,7 @@
 const promptly = require( 'promptly' );
 
 // ours
+const _args = require( 'args' );
 const args = require( '../lib/cli/command' );
 const Token = require( '../lib/token' );
 
@@ -17,7 +18,8 @@ const rootCmd = async function() {
 			.command( 'sync', 'Sync production to a development environment' )
 			.argv( process.argv );
 	} else {
-		args().argv( process.argv );
+		// Bypass helper function
+		_args.parse( process.argv );
 
 		const t = await promptly.password( 'Access Token:' );
 

--- a/src/lib/token.js
+++ b/src/lib/token.js
@@ -14,7 +14,7 @@ class Token {
 	exp: Date;
 
 	constructor( token: string ): void {
-		if ( ! token.length ) {
+		if ( ! token || ! token.length ) {
 			return;
 		}
 


### PR DESCRIPTION
The helper function always runs the sub-command if it exists. In this
case, we always want to run the login code if we don't have a valid
token.

Fixes #21