### PR TITLE
Fix/use relative paths

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,7 +1,7 @@
 const api = require( './dist/lib/api' );
-const token = require( './dist/lib/token' );
+const Token = require( './dist/lib/token' );
 
 module.exports = {
 	api,
-	token,
+	Token,
 };

--- a/index.js
+++ b/index.js
@@ -1,5 +1,5 @@
-const api = require( 'dist/lib/api' );
-const token = require( 'dist/lib/token' );
+const api = require( './dist/lib/api' );
+const token = require( './dist/lib/token' );
 
 module.exports = {
 	api,

--- a/index.js
+++ b/index.js
@@ -1,7 +1,7 @@
-const api = require( './dist/lib/api' );
+const API = require( './dist/lib/api' );
 const Token = require( './dist/lib/token' );
 
 module.exports = {
-	api,
+	API,
 	Token,
 };


### PR DESCRIPTION
Otherwise you get:

```
./node_modules/@automattic/vip/index.js
Module not found: Can't resolve 'dist/lib/api' in 'node_modules/@automattic/vip'
```

when using as a dependency.