### PR TITLE
Use App ID to identify parent environments

### DIFF
--- a/src/lib/cli/command.js
+++ b/src/lib/cli/command.js
@@ -193,7 +193,7 @@ args.argv = async function( argv, cb ): Promise<any> {
 		}
 
 		if ( _opts.childEnvContext ) {
-			options.app.environments = options.app.environments.filter( cur => cur.name.toLowerCase() !== 'production' );
+			options.app.environments = options.app.environments.filter( cur => cur.id !== options.app.id );
 		}
 	}
 


### PR DESCRIPTION
Using the environment name to identify parent environments has some edge
cases. For example, some parent environments are 'testing' instead of
'production'.

Fixes #64