### PR TITLE
Fix non-expiring tokens

### DIFF
--- a/__tests__/lib/token.js
+++ b/__tests__/lib/token.js
@@ -6,11 +6,16 @@ import Token from 'lib/token';
 
 describe( 'token tests', () => {
 	test( 'should correctly validate token', () => {
-		// Expires in 2050
-		const t = 'eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJpc3MiOiJPbmxpbmUgSldUIEJ1aWxkZXIiLCJpYXQiOjE1MTYxMzUyNzYsImV4cCI6MjUyNDYwODAwMCwiYXVkIjoiIiwic3ViIjoiIn0.seD8rBKJS0usjYApigqizitlNcmzcrYlGt9DyCm3I4c';
+		// Does not expire
+		const t = 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwiaWQiOjcsImlhdCI6MTUxNjIzOTAyMn0.RTJMXHhhiaCxQberZ5Pre7SBU3Ci8EvCyaOXoqG3pNA';
 		const token = new Token( t );
 		expect( token.valid() ).toEqual( true );
 		expect( token.expired() ).toEqual( false );
+	} );
+	test( 'should correctly validate token missing an id', () => {
+		const t = 'eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJpc3MiOiJPbmxpbmUgSldUIEJ1aWxkZXIiLCJpYXQiOjE1MTYxMzUyNzYsImV4cCI6MjUyNDYwODAwMCwiYXVkIjoiIiwic3ViIjoiIn0.seD8rBKJS0usjYApigqizitlNcmzcrYlGt9DyCm3I4c';
+		const token = new Token( t );
+		expect( token.valid() ).toEqual( false );
 	} );
 	test( 'should error for invalid token', () => {
 		const t = 'eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiYWRtaW4iOnRydWUsImp0aSI6IjRhM2RmYjE5LTBhMWQtNDE3YS05ODM2LTdjZWIwZTBkM2Q4NSIsImlhdCI6MTUxNjEyMzU1NywiZXhwIjoxNTE2MTI3zM4fQ.atx1YhxB6SQoW99aL97tXNlyJlXWEPZ3Cf1zyfxizvs';

--- a/src/lib/token.js
+++ b/src/lib/token.js
@@ -26,17 +26,42 @@ export default class Token {
 
 		const t = jwtDecode( token );
 		this.raw = token;
-		this.id = t.id;
-		this.iat = new Date( t.iat * 1000 );
-		this.exp = new Date( t.exp * 1000 );
+
+		if ( t.id ) {
+			this.id = t.id;
+		}
+
+		if ( t.iat ) {
+			this.iat = new Date( t.iat * 1000 );
+		}
+
+		if ( t.exp ) {
+			this.exp = new Date( t.exp * 1000 );
+		}
 	}
 
 	valid(): boolean {
+		if ( ! this.id ) {
+			return false;
+		}
+
+		if ( ! this.iat ) {
+			return false;
+		}
+
 		const now = new Date();
+		if ( ! this.exp ) {
+			return now > this.iat;
+		}
+
 		return now > this.iat && now < this.exp;
 	}
 
 	expired(): boolean {
+		if ( ! this.exp ) {
+			return false;
+		}
+
 		const now = new Date();
 		return now > this.exp;
 	}


### PR DESCRIPTION
Expiration dates aren't required on tokens. If the expiration date is
not set, expired() is always false and valid() doesn't depend on the
expiration date.