### PR TITLE
Make sync prompt more clear

### DIFF
--- a/src/bin/vip-sync.js
+++ b/src/bin/vip-sync.js
@@ -22,7 +22,12 @@ const appQuery = `id,name,environments{
 	}
 }`;
 
-command( { appContext: true, appQuery: appQuery, childEnvContext: true, requireConfirm: 'Are you sure you want to sync?' } )
+command( {
+	appContext: true,
+	appQuery: appQuery,
+	childEnvContext: true,
+	requireConfirm: 'Are you sure you want to sync from production?'
+} )
 	.argv( process.argv, async ( arg, opts ) => {
 		const api = await API();
 		let syncing = false;


### PR DESCRIPTION
We're always syncing from production. This is intended to make that more
clear at the point where you're prompted to continue.

Fixes #72