### PR TITLE
Fixes the hardcoded path separator

### DIFF
--- a/src/lib/keychain/insecure.js
+++ b/src/lib/keychain/insecure.js
@@ -19,7 +19,7 @@ export default class Secure implements Keychain {
 		const rw = 0o600;
 
 		let stat;
-		const tmpfile = os.tmpdir() + '/' + file;
+		const tmpfile = os.tmpdir() + path.sep + file;
 		try {
 			// Ensure the file exists
 			stat = fs.statSync( tmpfile );

--- a/src/lib/keychain/insecure.js
+++ b/src/lib/keychain/insecure.js
@@ -5,6 +5,7 @@
  */
 import fs from 'fs';
 import os from 'os';
+import path from 'path';
 
 /**
  * Internal dependencies


### PR DESCRIPTION
Some operating systems (Windows) use `\` as a directory separator, while others use `/`.  This should allow the separator to be dynamic on each system to match.