### PR TITLE
Log wp-cli single quote usage to Rollbar to track frequency of occurrences

### DIFF
--- a/src/bin/vip-wp.js
+++ b/src/bin/vip-wp.js
@@ -333,6 +333,10 @@ commandWrapper( {
 
 			const { data: { triggerWPCLICommandOnAppEnvironment: { command: cliCommand, inputToken } } } = result;
 
+			if ( line.includes( "'" ) ) {
+				rollbar.info( 'WP-CLI Command containing single quotes', { custom: { code: 'wp-cli-single-quotes', commandGuid: cliCommand.guid } } );
+			}
+
 			currentJob = await launchCommandAndGetStreams( {
 				guid: cliCommand.guid,
 				inputToken: inputToken,


### PR DESCRIPTION
##Description

Track commands that contain single quotes to rollbar so we know how often this is a use case

## Steps to Test
1. Check out PR.
2. Run `npm run build`
3. Run `API_HOST=http://localhost:4000 ./dist/bin/vip-wp.js --app=<test_site_id --yes -- option update blogdescription "Tes't'ing quotes32"`
4. Verify error appears in Rollbar dashboard

