### PR TITLE
Fix MariaDB healthcheck

### DIFF
--- a/assets/dev-environment.lando.template.yml.ejs
+++ b/assets/dev-environment.lando.template.yml.ejs
@@ -48,12 +48,17 @@ services:
       - sh /dev-tools/setup.sh database root "http://<%= siteSlug %>.vipdev.lndo.site/" "<%= wpTitle %>" <% if ( multisite ) { %> <%= siteSlug %>.vipdev.lndo.site <% } %>
 
   database:
-    type: compose
-    services:
+    type: mariadb:custom
+    overrides:
       image: mariadb:<%= mariadb %>
       command: docker-entrypoint.sh mysqld
       environment:
         MARIADB_ALLOW_EMPTY_ROOT_PASSWORD: 'true'
+        MARIADB_DATABASE: 'database'
+        MYSQL_DATABASE: 'database'
+        MARIADB_PASSWORD: 'mariadb'
+        MARIADB_USER: 'mariadb'
+        LANDO_NEEDS_EXEC: 'DOEEET'
 
   memcached:
     type: memcached:1.5.12


### PR DESCRIPTION
## Description

Fixes how the MariaDB image is being created in order for the healthcheck to be detected and make sure the database can be initiated at the right moment.

## Steps to Test

1. Check out PR.
2. Create a new environment
3. Check that the database works correctly.
