### PR TITLE
dev-env: Update error message for directory prompt

### DIFF
--- a/src/lib/dev-environment/dev-environment-cli.js
+++ b/src/lib/dev-environment/dev-environment-cli.js
@@ -189,7 +189,7 @@ async function processComponent( component: string, option: string ) {
 		if ( isDirectory && ! isEmpty ) {
 			break;
 		} else {
-			const message = `Provided path "${ resolvedPath }" does not point to a non-empty directory.`;
+			const message = `Provided path "${ resolvedPath }" does not point to a valid or existing directory.`;
 			console.log( chalk.yellow( 'Warning:' ), message );
 			result = await promptForComponent( component );
 		}


### PR DESCRIPTION
## Description

Currently, the error message is `Provided path "${ resolvedPath }" does not point to a non-empty directory.`. This reads to be confusing to me because it is a [double-negative](https://en.wikipedia.org/wiki/Double_negative).

I think it would be clearer to state that the directory inputted is invalid or doesn't exist.
