### PR TITLE
[dev-env] Proxy config change

### DIFF
--- a/src/lib/dev-environment/dev-environment-lando.js
+++ b/src/lib/dev-environment/dev-environment-lando.js
@@ -41,11 +41,6 @@ function getLandoConfig() {
 			},
 		],
 		proxyName: 'vip-dev-env-proxy',
-		// This is a way to make lando config merging actually not include any of its fallback
-		// Each item in the array will overwrite one fallback port. And there are 4 default fallbacks
-		// for both http an https each.
-		proxyHttpFallbacks: [ '80', '80', '80', '80' ],
-		proxyHttpsFallbacks: [ '443', '443', '443', '443' ],
 	};
 }
 

--- a/src/lib/dev-environment/dev-environment-lando.js
+++ b/src/lib/dev-environment/dev-environment-lando.js
@@ -40,6 +40,12 @@ function getLandoConfig() {
 				subdir: '.',
 			},
 		],
+		proxyName: 'vip-dev-env-proxy',
+		// This is a way to make lando config merging actually not include any of its fallback
+		// Each item in the array will overwrite one fallback port. And there are 4 default fallbacks
+		// for both http an https each.
+		proxyHttpFallbacks: [ '80', '80', '80', '80' ],
+		proxyHttpsFallbacks: [ '443', '443', '443', '443' ],
 	};
 }
 


### PR DESCRIPTION
After the change in images, we can now support non-standard ports. 

This PR now only changes the proxy name so we switched to `vip-dev-env-proxy` (instead of arguably way cooler `landoproxyhyperion5000gandalfedition`)


## Steps to Test

1) Stop your dev-env
2) Check your proxy name in docker 