### PR TITLE
FORNO-942: Dont mark import as failed until restore has completed

### DIFF
--- a/src/lib/site-import/status.js
+++ b/src/lib/site-import/status.js
@@ -262,7 +262,7 @@ ${ maybeExitPrompt }
 							};
 						} );
 
-						if ( statusSteps.some( ( { result } ) => result === 'failed' ) ) {
+						if ( statusSteps.some( ( { result } ) => result === 'failed' ) && ! statusSteps.find( ( { name, result } ) => name === 'restore_db' && ! result ) ) {
 							jobStatus = 'error';
 						} else 	if ( statusSteps.every( ( { result } ) => result === 'success' ) ) {
 							jobStatus = 'success';


### PR DESCRIPTION
## Description

When an SQL Import fails, we try to restore DB to latest backup in some cases. Due to this, we don't want to mark import status as failed, until the restore has completed.

## Steps to Test

1. Check out PR.
2 Run `npm run build`
3. Run an SQL import that will trigger a DB restore
4. Verify that DB Import step shows as failed, but the status is still running until restore finishes

