### PR TITLE
[dev-env] support windows db import

### DIFF
--- a/__tests__/lib/dev-environment/dev-environment-core.js
+++ b/__tests__/lib/dev-environment/dev-environment-core.js
@@ -254,7 +254,7 @@ describe( 'lib/dev-environment/dev-environment-core', () => {
 			await expect( promise ).resolves.toEqual(
 				{
 					resolvedPath: path.resolve( 'testfile.sql' ),
-					dockerPath: path.resolve( 'testfile.sql' ).replace( os.homedir(), '/user' ),
+					inContainerPath: path.resolve( 'testfile.sql' ).replace( os.homedir(), '/user' ),
 				}
 			);
 		} );
@@ -280,7 +280,7 @@ describe( 'lib/dev-environment/dev-environment-core', () => {
 
 			await expect( promise ).resolves.toEqual( {
 				resolvedPath: expectedPath,
-				dockerPath: expectedPath,
+				inContainerPath: expectedPath,
 			} );
 		} );
 

--- a/__tests__/lib/dev-environment/dev-environment-core.js
+++ b/__tests__/lib/dev-environment/dev-environment-core.js
@@ -22,11 +22,13 @@ import { getEnvironmentPath,
 	resolveImportPath,
 } from '../../../src/lib/dev-environment/dev-environment-core';
 import { searchAndReplace } from '../../../src/lib/search-and-replace';
+import { resolvePath } from '../../../src/lib/dev-environment/dev-environment-cli';
 
 jest.mock( 'xdg-basedir', () => ( {} ) );
 jest.mock( 'fs' );
 jest.mock( '../../../src/lib/api/app' );
 jest.mock( '../../../src/lib/search-and-replace' );
+jest.mock( '../../../src/lib/dev-environment/dev-environment-cli' );
 
 describe( 'lib/dev-environment/dev-environment-core', () => {
 	beforeEach( () => {
@@ -232,6 +234,10 @@ describe( 'lib/dev-environment/dev-environment-core', () => {
 		} );
 	} );
 	describe( 'resolveImportPath', () => {
+		afterEach( () => {
+			path.sep = '/';
+		} );
+
 		it( 'should throw if file does not exist', async () => {
 			fs.existsSync.mockReturnValue( false );
 
@@ -246,6 +252,8 @@ describe( 'lib/dev-environment/dev-environment-core', () => {
 
 		it( 'should resolve the path and replace it with /user', async () => {
 			fs.existsSync.mockReturnValue( true );
+			const resolvedPath = `${ os.homedir() }/testfile.sql`;
+			resolvePath.mockReturnValue( resolvedPath );
 
 			const promise = resolveImportPath( 'foo', 'testfile.sql', null, false );
 
@@ -253,8 +261,24 @@ describe( 'lib/dev-environment/dev-environment-core', () => {
 
 			await expect( promise ).resolves.toEqual(
 				{
-					resolvedPath: path.resolve( 'testfile.sql' ),
-					inContainerPath: path.resolve( 'testfile.sql' ).replace( os.homedir(), '/user' ),
+					resolvedPath: resolvedPath,
+					inContainerPath: resolvedPath.replace( os.homedir(), '/user' ),
+				}
+			);
+		} );
+
+		it( 'should handle windows path correctly', async () => {
+			path.sep = '\\';
+			fs.existsSync.mockReturnValue( true );
+			const resolvedPath = `${ os.homedir() }\\somewhere\\testfile.sql`;
+			resolvePath.mockReturnValue( resolvedPath );
+
+			const promise = resolveImportPath( 'foo', 'testfile.sql', null, false );
+
+			await expect( promise ).resolves.toEqual(
+				{
+					resolvedPath: resolvedPath,
+					inContainerPath: '/user/somewhere/testfile.sql',
 				}
 			);
 		} );
@@ -263,8 +287,9 @@ describe( 'lib/dev-environment/dev-environment-core', () => {
 			searchAndReplace.mockReturnValue( {
 				outputFileName: 'testfile.sql',
 			} );
+			const resolvedPath = `${ os.homedir() }/testfile.sql`;
+			resolvePath.mockReturnValue( resolvedPath );
 
-			const resolvedPath = path.resolve( 'testfile.sql' );
 			const searchReplace = 'testsite.com,testsite.net';
 
 			const promise = resolveImportPath( 'foo', 'testfile.sql', searchReplace, false );
@@ -285,7 +310,8 @@ describe( 'lib/dev-environment/dev-environment-core', () => {
 		} );
 
 		it( 'should call search and replace in place with the proper arguments', async () => {
-			const resolvedPath = path.resolve( 'testfile.sql' );
+			const resolvedPath = `${ os.homedir() }/testfile.sql`;
+			resolvePath.mockReturnValue( resolvedPath );
 			const searchReplace = 'testsite.com,testsite.net';
 
 			await resolveImportPath( 'foo', 'testfile.sql', searchReplace, true );

--- a/src/bin/vip-dev-env-import-sql.js
+++ b/src/bin/vip-dev-env-import-sql.js
@@ -50,8 +50,9 @@ command( {
 		const slug = getEnvironmentName( opt );
 
 		try {
-			const { resolvedPath, dockerPath } = await resolveImportPath( slug, fileName, searchReplace, inPlace );
-			const importArg = [ 'wp', 'db', 'import', dockerPath ];
+			const { resolvedPath, inContainerPath } = await resolveImportPath( slug, fileName, searchReplace, inPlace );
+
+			const importArg = [ 'wp', 'db', 'import', inContainerPath ];
 			await exec( slug, importArg );
 
 			if ( searchReplace && searchReplace.length && ! inPlace ) {

--- a/src/lib/dev-environment/dev-environment-core.js
+++ b/src/lib/dev-environment/dev-environment-core.js
@@ -322,9 +322,8 @@ export async function resolveImportPath( slug: string, fileName: string, searchR
 	/**
 	 * Docker container does not have acces to the host filesystem.
 	 * However lando maps os.homedir() to /user in the container. So if we replace the path in the same way
-	 * docker container will get the file from within the mapped volume under /user.
+	 * in the Docker container will get the file from within the mapped volume under /user.
 	 */
-
 	let inContainerPath = resolvedPath.replace( os.homedir(), homeDirPathInsideContainers );
 	if ( path.sep === '\\' ) {
 		// Because the file path generated for windows will have \ instead of / we need to replace that as well so that the path inside the container (unix) still works.

--- a/src/lib/dev-environment/dev-environment-core.js
+++ b/src/lib/dev-environment/dev-environment-core.js
@@ -329,7 +329,7 @@ export async function resolveImportPath( slug: string, fileName: string, searchR
 	let inContainerPath;
 	if ( path.sep === '\\' ) {
 		// Because the file path generated for windows will have \ instead of / we need to replace that as well so that the path inside the container (unix) still works.
-		inContainerPath = homeDirPathInsideContainers + pathWithoutHome.replace( /\\/g, '/');
+		inContainerPath = homeDirPathInsideContainers + pathWithoutHome.replace( /\\/g, '/' );
 	} else {
 		inContainerPath = homeDirPathInsideContainers + pathWithoutHome;
 	}

--- a/src/lib/dev-environment/dev-environment-core.js
+++ b/src/lib/dev-environment/dev-environment-core.js
@@ -325,14 +325,16 @@ export async function resolveImportPath( slug: string, fileName: string, searchR
 	 * docker container will get the file from within the mapped volume under /user.
 	 */
 
-	const pathWithoutHome = resolvedPath.replace( os.homedir(), '' )
-	let inContainerPath = ''
-	if (path.sep === '\\') {
+	const pathWithoutHome = resolvedPath.replace( os.homedir(), '' );
+	let inContainerPath;
+	if ( path.sep === '\\' ) {
 		// Because the file path generated for windows will have \ instead of / we need to replace that as well so that the path inside the container (unix) still works.
 		inContainerPath = homeDirPathInsideContainers + pathWithoutHome.replace( /\\/g, '/');
 	} else {
 		inContainerPath = homeDirPathInsideContainers + pathWithoutHome;
 	}
+
+	debug( `Import file path ${ resolvedPath } will be mapped to ${ inContainerPath }` );
 	return {
 		resolvedPath,
 		inContainerPath,

--- a/src/lib/dev-environment/dev-environment-core.js
+++ b/src/lib/dev-environment/dev-environment-core.js
@@ -325,13 +325,10 @@ export async function resolveImportPath( slug: string, fileName: string, searchR
 	 * docker container will get the file from within the mapped volume under /user.
 	 */
 
-	const pathWithoutHome = resolvedPath.replace( os.homedir(), '' );
-	let inContainerPath;
+	let inContainerPath = resolvedPath.replace( os.homedir(), homeDirPathInsideContainers );
 	if ( path.sep === '\\' ) {
 		// Because the file path generated for windows will have \ instead of / we need to replace that as well so that the path inside the container (unix) still works.
-		inContainerPath = homeDirPathInsideContainers + pathWithoutHome.replace( /\\/g, '/' );
-	} else {
-		inContainerPath = homeDirPathInsideContainers + pathWithoutHome;
+		inContainerPath = inContainerPath.replace( /\\/g, '/' );
 	}
 
 	debug( `Import file path ${ resolvedPath } will be mapped to ${ inContainerPath }` );

--- a/src/lib/dev-environment/dev-environment-core.js
+++ b/src/lib/dev-environment/dev-environment-core.js
@@ -31,6 +31,8 @@ const nginxFileTemplatePath = path.join( __dirname, '..', '..', '..', 'assets', 
 const landoFileName = '.lando.yml';
 const nginxFileName = 'extra.conf';
 
+const homeDirPathInsideContainers = '/user';
+
 const uploadPathString = 'uploads';
 const nginxPathString = 'nginx';
 
@@ -40,7 +42,7 @@ type StartEnvironmentOptions = {
 
 type SQLImportPaths = {
 	resolvedPath: string,
-	dockerPath: string
+	inContainerPath: string
 }
 
 export async function startEnvironment( slug: string, options: StartEnvironmentOptions ) {
@@ -317,10 +319,23 @@ export async function resolveImportPath( slug: string, fileName: string, searchR
 		fs.renameSync( outputFileName, resolvedPath );
 	}
 
-	const dockerPath = resolvedPath.replace( os.homedir(), '/user' );
+	/**
+	 * Docker container does not have acces to the host filesystem.
+	 * However lando maps os.homedir() to /user in the container. So if we replace the path in the same way
+	 * docker container will get the file from within the mapped volume under /user.
+	 */
+
+	const pathWithoutHome = resolvedPath.replace( os.homedir(), '' )
+	let inContainerPath = ''
+	if (path.sep === '\\') {
+		// Because the file path generated for windows will have \ instead of / we need to replace that as well so that the path inside the container (unix) still works.
+		inContainerPath = homeDirPathInsideContainers + pathWithoutHome.replace( /\\/g, '/');
+	} else {
+		inContainerPath = homeDirPathInsideContainers + pathWithoutHome;
+	}
 	return {
 		resolvedPath,
-		dockerPath,
+		inContainerPath,
 	};
 }
 


### PR DESCRIPTION

## Description

When trying to import on Windows machine - `vip dev-env imposrt sql \Users\<user>\dump.sql` we encounter an error resolving the path. Due to the way this works we need to construct in container path to the import file which doesn't work if `\` instead of `/` are systems path separators.

This change does the manual conversion of `\` to `/` to address that.

One note there is a limitation due to the way the file is processed that the file needs to be under home directory. I will try to document that more in public docs.

## Steps to Test


Example:

1. Downgrade to Windows
1. Run `vip dev-env import sql <path to file>`
2. It works

