### PR TITLE
Fix rmdir deprecation warning

### DIFF
--- a/src/bin/vip-dev-env-destroy.js
+++ b/src/bin/vip-dev-env-destroy.js
@@ -46,7 +46,7 @@ command()
 			const removeFiles = ! ( opt.soft || false );
 			await destroyEnvironment( slug, removeFiles );
 
-			const message = chalk.green( '✓' ) + ' environment destroyed.\n';
+			const message = chalk.green( '✓' ) + ' Environment destroyed.\n';
 			console.log( message );
 		} catch ( error ) {
 			exit.withError( error.message );

--- a/src/lib/dev-environment/dev-environment-core.js
+++ b/src/lib/dev-environment/dev-environment-core.js
@@ -10,7 +10,6 @@ import debugLib from 'debug';
 import xdgBasedir from 'xdg-basedir';
 import os from 'os';
 import fs from 'fs';
-import fsPromises from 'fs/promises';
 import ejs from 'ejs';
 import path from 'path';
 import chalk from 'chalk';
@@ -129,7 +128,7 @@ export async function destroyEnvironment( slug: string, removeFiles: boolean ) {
 	await landoDestroy( instancePath );
 
 	if ( removeFiles ) {
-		await fsPromises.rm( instancePath, { recursive: true } );
+		await fs.promises.rm( instancePath, { recursive: true } );
 		console.log( `${ chalk.green( '✓' ) } Environment files deleted successfully.` );
 	}
 }

--- a/src/lib/dev-environment/dev-environment-core.js
+++ b/src/lib/dev-environment/dev-environment-core.js
@@ -128,8 +128,14 @@ export async function destroyEnvironment( slug: string, removeFiles: boolean ) {
 	await landoDestroy( instancePath );
 
 	if ( removeFiles ) {
-		// $FlowFixMe: Seems like a Flow issue, recursive is a valid option and it won't work without it.
-		fs.rmdirSync( instancePath, { recursive: true } );
+		fs.rm( instancePath, { recursive: true }, err => {
+			if ( err ) {
+				console.log( `${ chalk.red( '✕' ) } Could not delete the environment files.` );
+				console.log( err );
+			} else {
+				console.log( `${ chalk.green( '✓' ) } Environment files deleted successfully.` );
+			}
+		} );
 	}
 }
 

--- a/src/lib/dev-environment/dev-environment-core.js
+++ b/src/lib/dev-environment/dev-environment-core.js
@@ -10,6 +10,7 @@ import debugLib from 'debug';
 import xdgBasedir from 'xdg-basedir';
 import os from 'os';
 import fs from 'fs';
+import fsPromises from 'fs/promises';
 import ejs from 'ejs';
 import path from 'path';
 import chalk from 'chalk';
@@ -128,14 +129,8 @@ export async function destroyEnvironment( slug: string, removeFiles: boolean ) {
 	await landoDestroy( instancePath );
 
 	if ( removeFiles ) {
-		fs.rm( instancePath, { recursive: true }, err => {
-			if ( err ) {
-				console.log( `${ chalk.red( '✕' ) } Could not delete the environment files.` );
-				console.log( err );
-			} else {
-				console.log( `${ chalk.green( '✓' ) } Environment files deleted successfully.` );
-			}
-		} );
+		await fsPromises.rm( instancePath, { recursive: true } );
+		console.log( `${ chalk.green( '✓' ) } Environment files deleted successfully.` );
 	}
 }
 


### PR DESCRIPTION
## Description

With Node 14, the `rmdir` method is deprecated and it will likely be removed in subsequent Node releases. We are anticipating that by replacing it by an equivalent non-deprectaed method, `rm`. This is the deprecation warning you'd get:

```
(node:23769) [DEP0147] DeprecationWarning: In future versions of Node.js, fs.rmdir(path, { recursive: true }) will be removed. Use fs.rm(path, { recursive: true }) instead
(Use `node --trace-deprecation ...` to show where the warning was created)
```

Notice that we are adding a callback function to tell the user if the deletion process went well or something failed.

## Steps to Test

1. Check out PR and run it in Node 16 (prior versions only had the method deprecated in the docs).
2. Run `npm run build` and `npm link`.
3. Destroy any environment.
4. See that you get a success/error message but you don't get the deprecation warning.