### PR TITLE
[dev-env] Proxy fix + healthchecks

### DIFF
--- a/assets/dev-env.lando.template.yml.ejs
+++ b/assets/dev-env.lando.template.yml.ejs
@@ -60,6 +60,8 @@ services:
       command: docker-entrypoint.sh mysqld
       ports:
         - ":3306"
+      healthcheck:
+        test: 'mysql -uroot --silent --execute "SHOW DATABASES;"'
       environment:
         MARIADB_ALLOW_EMPTY_ROOT_PASSWORD: 'true'
       volumes:

--- a/assets/dev-env.lando.template.yml.ejs
+++ b/assets/dev-env.lando.template.yml.ejs
@@ -84,9 +84,8 @@ services:
 <% } %>
 
   vip-search:
-    type: elasticsearch:custom
-    portforward: true
-    overrides:
+    type: compose
+    services:
       image: elasticsearch:<%= elasticsearch %>
       command: /usr/local/bin/docker-entrypoint.sh
       environment:
@@ -95,6 +94,10 @@ services:
         ELASTICSEARCH_NODE_NAME: 'lando'
         ELASTICSEARCH_PORT_NUMBER: 9200
         discovery.type: 'single-node'
+      ports:
+        - ":9200"
+      healthcheck:
+        test: "curl --noproxy '*' -XGET localhost:9200"
       volumes:
         - search_data:/usr/share/elasticsearch/data
     volumes:

--- a/src/lib/dev-environment/dev-environment-lando.js
+++ b/src/lib/dev-environment/dev-environment-lando.js
@@ -12,6 +12,7 @@ import Lando from 'lando/lib/lando';
 import landoUtils from 'lando/plugins/lando-core/lib/utils';
 import landoBuildTask from 'lando/plugins/lando-tooling/lib/build';
 import chalk from 'chalk';
+import App from 'lando/lib/app';
 
 /**
  * Internal dependencies
@@ -53,6 +54,8 @@ export async function landoStart( instancePath: string ) {
 	const app = lando.getApp( instancePath );
 	await app.init();
 
+	addHooks( app, lando );
+
 	await app.start();
 }
 
@@ -67,7 +70,35 @@ export async function landoRebuild( instancePath: string ) {
 
 	await ensureNoOrphantProxyContainer( lando );
 
+	addHooks( app, lando );
+
 	await app.rebuild();
+}
+
+function addHooks( app: App, lando: Lando ) {
+	app.events.on( 'post-start', 1, () => healthcheckHook( app, lando ) );
+}
+
+async function healthcheckHook( app: App, lando: Lando ) {
+	try {
+		await lando.Promise.retry( async () => {
+			const list = await lando.engine.list( { project: app.project } );
+
+			const containersWithHealthCheck = list.filter( container => container.status.includes( 'health' ) );
+			const notHealthyContainers = containersWithHealthCheck.filter( container => ! container.status.includes( 'healthy' ) );
+
+			if ( notHealthyContainers.length ) {
+				for ( const container of notHealthyContainers ) {
+					console.log( `Waiting for service ${ container.service } ...` );
+				}
+				return Promise.reject( notHealthyContainers );
+			}
+		}, { max: 20, backoff: 1000 } );
+	} catch ( containersWithFailingHealthCheck ) {
+		for ( const container of containersWithFailingHealthCheck ) {
+			console.log( chalk.yellow( 'WARNING:' ) + ` Service ${ container.service } failed healthcheck` );
+		}
+	}
 }
 
 export async function landoStop( instancePath: string ) {


### PR DESCRIPTION
## Description

When http_proxy is configured for docker `vip_search` would try to route its healthcheck to that addres as it is doing `curl localhot:9200`.

That doesn't work as we need to reach out to the container's own localhost.

This change switches from using lando's own healthcheck system to the docker's + added hook that checks those states before proceeding with the setup. 

The change also brings DB health check back.

## Steps to Test

1) `npm run build && ./dist/bin/vip-dev-env-create.js --slug test`
2) `npm run build && ./dist/bin/vip-dev-env-start.js --slug test`
3) See ... 
```
Waiting for service vip-search ...
Waiting for service database ...
Waiting for service vip-search ...
Waiting for service database ...
```