### PR TITLE
[dev-env] Fix duplicate shortcuts

### DIFF
--- a/src/bin/vip-dev-env-import-sql.js
+++ b/src/bin/vip-dev-env-import-sql.js
@@ -43,7 +43,7 @@ command( {
 	requiredArgs: 1,
 } )
 	.option( 'slug', 'Custom name of the dev environment' )
-	.option( 'search-replace', 'Perform Search and Replace on the specified SQL file' )
+	.option( [ 'r', 'search-replace' ], 'Perform Search and Replace on the specified SQL file' )
 	.option( 'in-place', 'Search and Replace explicitly on the given input file' )
 	.option( 'skip-validate', 'Do not perform file validation.' )
 	.examples( examples )


### PR DESCRIPTION
## Description

`vip dev-env import sql` would have a multiple options under shortcut `-S`. This change switches `--search-replace` to `-r` to avoid this conflict.

## Steps to Test

```
npm run build && ./dist/bin/vip-dev-env-import-sql.js --help
...
  Usage: vip dev-env-import-sql.js [options] 
  
  Options:
    -d, --debug           Activate debug output
    -h, --help            Output the help for the (sub)command
    -i, --in-place        Search and Replace explicitly on the given input file
    -r, --search-replace  Perform Search and Replace on the specified SQL file
    -S, --skip-validate   Do not perform file validation.
    -s, --slug            Custom name of the dev environment
    -v, --version         Output the version number
```
