### PR TITLE
dev-env: Fix Mailhog being undefined in instance data from older versisons of VIP-CLI

### DIFF
--- a/src/lib/dev-environment/dev-environment-core.js
+++ b/src/lib/dev-environment/dev-environment-core.js
@@ -173,6 +173,11 @@ function preProcessInstanceData( instanceData: InstanceData ): InstanceData {
 		newInstanceData.xdebugConfig = '';
 	}
 
+	// Mailhog migration
+	if ( ! newInstanceData.mailhog ) {
+		newInstanceData.mailhog = false;
+	}
+
 	return newInstanceData;
 }
 


### PR DESCRIPTION
## Description

Whenever there's an older version of WP being used on environment we prompt for upgrade, in case a user picks a fresher version we regenerate the `.lando.yml`, but because it misses the mailhog property template compilation fails. 

This PR fixes the issue by introducing a migration in `preProcessInstanceData` and checks if the properry is falsy we explicitly set it to `false`

We should make sure to do this for every new property or find a better way in the `.ejs` file. 


## Steps to Test

Before checking out the PR modify your instance data to look something like: 

```json
{
  "wpTitle": "VIP Dev",
  "multisite": false,
  "elasticsearch": false,
  "php": "ghcr.io/automattic/vip-container-images/php-fpm:8.0",
  "mariadb": "10.3",
  "mediaRedirectDomain": "",
  "wordpress": {
    "mode": "image",
    "tag": "6.0",
  },
  "muPlugins": {
    "mode": "image"
  },
  "appCode": {
    "mode": "image"
  },
  "statsd": false,
  "phpmyadmin": false,
  "xdebug": false,
  "xdebugConfig": "",
  "siteSlug": "vip-local",
  "pullAfter": 1672342816447
}
```

Note 6.0,  and missing `mailhog`. Start the environment

`vip dev-env start --slug vip-local`

During the upgrade prompt pick a new version, 6.1.1, observe the crash.

Apply the PR, repeat the steps, verify it starts properly. 

