### PR TITLE
fix(tests): do not fail when `DO_NOT_TRACK` is set

### DIFF
--- a/__tests__/lib/analytics/index.js
+++ b/__tests__/lib/analytics/index.js
@@ -13,6 +13,7 @@ describe( 'lib/analytics', () => {
 		} );
 
 		it( 'should track events for all clients', async () => {
+			delete process.env.DO_NOT_TRACK;
 			const stubClient1 = new AnalyticsClientStub();
 			const stubClient1Spy = jest.spyOn( stubClient1, 'trackEvent' );
 			const stubClient2 = new AnalyticsClientStub();


### PR DESCRIPTION
## Description

`npm test` fails if the `DO_NOT_TRACK` environment variable is set prior to running tests:

```
DO_NOT_TRACK=1 npx jest
...
 FAIL  __tests__/lib/analytics/index.js
  ● lib/analytics › .trackEvent() › should track events for all clients

    expect(received).resolves.toStrictEqual(expected) // deep equality

    Expected: [true, true]
    Received: "Skipping trackEvent for test_event (DO_NOT_TRACK)"

      28 |                      const result = analytics.trackEvent( 'test_event', {} );
      29 |
    > 30 |                      await expect( result ).resolves.toStrictEqual( [ true, true ] );
         |                                                      ^
      31 |                      expect( stubClient1Spy ).toHaveBeenCalledTimes( 1 );
      32 |                      expect( stubClient2Spy ).toHaveBeenCalledTimes( 1 );
      33 |              } );

      at Object.toStrictEqual (node_modules/expect/build/index.js:166:22)
      at Object.toStrictEqual (__tests__/lib/analytics/index.js:30:36)
```

This PR fixes that test by explicitly removing `DO_NOT_TRACK` from the environment.

## Steps to Test

See above.
