### PR TITLE
chore: Update dot files

### DIFF
--- a/.flowconfig
+++ b/.flowconfig
@@ -10,3 +10,4 @@ src
 [options]
 module.system.node.resolve_dirname=node_modules
 module.system.node.resolve_dirname=src
+server.max_workers=2

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -2,7 +2,7 @@ name: "CodeQL"
 
 on:
   push:
-    branches: [ develop, master ]
+    branches: [ develop, trunk ]
   pull_request:
     # The branches below must be a subset of the branches above
     branches: [ develop ]

--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,4 @@ node_modules/
 coverage
 
 .DS_Store
+.vscode

--- a/.npmignore
+++ b/.npmignore
@@ -6,6 +6,7 @@ __fixtures__
 __tests__
 jest.config.js
 jest.setup.js
+jest.setupMocks.js
 .travis.yml
 appveyor.yml
 coverage
@@ -28,6 +29,7 @@ node_modules/
 .nvmrc
 .ackrc
 .publishrc
+.prettierrc
 
 # Liniting rules
 .eslintrc.json
@@ -37,3 +39,5 @@ node_modules/
 babel.config.js
 renovate.json
 .github
+
+.vscode

--- a/.publishrc
+++ b/.publishrc
@@ -4,7 +4,7 @@
     "uncommittedChanges": true,
     "untrackedFiles": true,
     "sensitiveData": true,
-    "branch": "master",
+    "branch": "trunk",
     "gitTag": false
   },
   "confirm": true,

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -73,13 +73,13 @@ New libraries should generally support both CLI and web contexts, though some ca
 
 Our release flow for VIP CLI follows this pattern:
 
-**_feature branch -> develop branch -> master branch -> NPM release_**
+**_feature branch -> develop branch -> trunk branch -> NPM release_**
 
 - For feature branches, please follow A8C branch naming conventions (e.g.- `add/data-sync-command`, `fix/subsite-launch-command`, etc.)
 - Include a Changelog for all npm version releases, including any minor or major versions
 - This is a public repository. Please do not include any internal links in PRs, changelogs, testing instructions, etc.
 - Merge changes from your feature branch to the `develop` branch
-- If you are ready to release your changes publicly, merge your changes from the `develop` branch to the `master` branch. All changes that are not ready to be public should be feature flagged or stay in the `develop` branch to avoid conflicts when releasing urgent fixes (not recommended).
+- If you are ready to release your changes publicly, merge your changes from the `develop` branch to the `trunk` branch. All changes that are not ready to be public should be feature flagged or stay in the `develop` branch to avoid conflicts when releasing urgent fixes (not recommended).
 - Finally, release your changes as a new minor or major NPM version. Ping in the #vip-platform channel to notify folks of a new release, but please feel free to release your changes without any blockers from the team. Any team member that is part of the Automattic NPM organization can release a new version; if you aren't a member, generic credentials are available in the Secret Store.
 
 ### Changelogs
@@ -108,7 +108,7 @@ Prepare the release by making sure that:
 
 1. All relevant PRs have been merged.
 1. The release has been tested across macOS, Windows, and Linux.
-1. The [changelog](https://github.com/Automattic/vip/blob/master/CHANGELOG.md) has been updated on `master`.
+1. The [changelog](https://github.com/Automattic/vip/blob/trunk/CHANGELOG.md) has been updated on `trunk`.
 1. All tests pass and your working directory is clean (we have pre-publish checks to catch this, just-in-case).
 
 #### Changelog Generator Hint:
@@ -120,15 +120,15 @@ gh pr list --search "is:merged sort:updated-desc closed:>$LAST_RELEASE_DATE" | s
 
 Then, let's publish:
 
-1. Make sure master branch is up to date `git pull`
+1. Make sure trunk branch is up to date `git pull`
 1. Set the version (via `npm version minor` or `npm version major` or `npm version patch`)
 1. For most regular releases, this will be `npm version minor`.
 1. Push the tag to GitHub (`git push --tags`)
-1. Push the master branch `git push`
+1. Push the trunk branch `git push`
 1. Make sure you're part of the Automattic organization in npm
 1. Publish the release to npm (`npm run publish-please --access public`) the script will do some extra checks (npm version, branch, etc) to ensure everything is correct. If all looks good, proceed.
 1. Edit [the release on GitHub](https://github.com/Automattic/vip/releases) to include a description of the changes and publish (this can just copy the details from the changelog).
-1. Push `master` changes (mostly the version bump) to `develop` (`git checkout develop && git merge master` )
+1. Push `trunk` changes (mostly the version bump) to `develop` (`git checkout develop && git merge trunk` )
 
 Once released, it's worth running `npm i -g @automattic/vip` to install / upgrade the released version to make sure everything looks good.
 
@@ -141,14 +141,14 @@ In order to do that, please follow this:
 1. Manually change the version in `package.json` and `package-lock.json` to a dev version. Example: `1.4.0-dev1`
 2. Go to publish-please's config in `.publishrc`
 3. Change the `publishTag` to `next` and `gitTag` to `false` (publish-please will expect the latest commit to have a git tag, but we don't want it in this case)
-4. Commit your changes to `master`
+4. Commit your changes to `trunk`
 5. Run `npm run publish-please`
 
 You can repeat this with every new version until you're happy with your version and ready to a public release. We currently don't support multiple branches for multiple versions. When it's the case, this process needs to be done for every version in every branch.
 
 ### Patching Old Releases
 
-There may be times when we need to push out a critical fix to the most recent release (or several past releases) such as for patching security issues or major bugs. This can be complicated by the fact that we may have some larger changes already merged into the `master` branch.
+There may be times when we need to push out a critical fix to the most recent release (or several past releases) such as for patching security issues or major bugs. This can be complicated by the fact that we may have some larger changes already merged into the `trunk` branch.
 
 For these cases:
 

--- a/package.json
+++ b/package.json
@@ -148,5 +148,8 @@
   },
   "optionalDependencies": {
     "keytar": "7.7.0"
+  },
+  "publishConfig": {
+    "access": "public"
   }
 }


### PR DESCRIPTION
## Description

This PR:
* replaces `master` with `trunk` in our files;
* updates `.gitignore` and `.npmignore` (mostly with the missing dotfiles and `.vscode`);
* adds `publishConfig` to `package.json` (so that we don't have to type `--access public` when publishing the package);
* limits the number of workers for Flow (on 22 cores, this is a disaster).

## Steps to Test

No testable changes.