### PR TITLE
Add some additional info on installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ First, install the package:
 npm install -g @automattic/vip
 ```
 
-The above command may fail if you do not have `make` and `g++` installed. In that case, install them first:
+The above command may fail in linux if you do not have `make` and `g++` installed. In that case, install them first:
 
 ```
 sudo apt install make g++

--- a/README.md
+++ b/README.md
@@ -8,6 +8,12 @@ First, install the package:
 npm install -g @automattic/vip
 ```
 
+The above command may fail if you do not have `make` and `g++` installed. In that case, install them first:
+
+```
+sudo apt install make g++
+```
+
 Then, launch the command and follow the prompts:
 
 ```


### PR DESCRIPTION
## Description

The installation command `npm install -g @automattic/vip` fails if the system does not have `make` and `g++` libraries installed. We are adding information about that in the README.md

