### PR TITLE
PIE-3147: Added vip prefix for Pendo tracking

### DIFF
--- a/src/lib/analytics/clients/pendo.js
+++ b/src/lib/analytics/clients/pendo.js
@@ -10,6 +10,7 @@ const debug = require( 'debug' )( '@automattic/vip:analytics:clients:pendo' );
  */
 import type { AnalyticsClient } from './client';
 import http from 'lib/api/http';
+import { checkIfUserIsVip } from '../../cli/apiConfig';
 
 /**
  * Pendo analytics client.
@@ -50,12 +51,14 @@ export default class Pendo implements AnalyticsClient {
 
 		debug( 'trackEvent()', eventProps );
 
+		const isVIP = await checkIfUserIsVip( this.userId );
+
 		this.context = {
 			...this.context,
 			org_id: eventProps.org_slug,
 			org_slug: eventProps.org_slug,
 			userAgent: this.userAgent,
-			userId: this.userId,
+			userId: `${ isVIP ? 'vip-' : '' }${ this.userId }`,
 		};
 
 		try {

--- a/src/lib/tracker.js
+++ b/src/lib/tracker.js
@@ -15,7 +15,7 @@ import env from './env';
 
 let analytics = null;
 
-async function init(): Promise<Analytics> {
+async function init(): Promise< Analytics > {
 	const uuid = await Token.uuid();
 
 	const clients = [];
@@ -26,11 +26,13 @@ async function init(): Promise<Analytics> {
 	if ( tracksUserType && tracksEventPrefix ) {
 		clients.push( new Tracks( uuid, tracksUserType, tracksEventPrefix, env ) );
 
-		clients.push( new Pendo( {
-			env,
-			eventPrefix: tracksEventPrefix,
-			userId: uuid,
-		} ) );
+		clients.push(
+			new Pendo( {
+				env,
+				eventPrefix: tracksEventPrefix,
+				userId: uuid,
+			} )
+		);
 	}
 
 	analytics = new Analytics( { clients } );
@@ -38,7 +40,7 @@ async function init(): Promise<Analytics> {
 	return analytics;
 }
 
-async function getInstance(): Promise<Analytics> {
+async function getInstance(): Promise< Analytics > {
 	if ( analytics ) {
 		return analytics;
 	}
@@ -48,7 +50,7 @@ async function getInstance(): Promise<Analytics> {
 	return analytics;
 }
 
-export async function trackEvent( ...args ): Promise<Response> {
+export async function trackEvent( ...args ): Promise< Response > {
 	try {
 		await Token.uuid();
 		const client = await getInstance();
@@ -58,10 +60,14 @@ export async function trackEvent( ...args ): Promise<Response> {
 	}
 }
 
-export async function aliasUser( vipUserId ): Promise<Response> {
+export async function aliasUser( vipUserId ): Promise< Response > {
 	try {
 		if ( vipUserId ) {
-			await trackEvent( '_alias_user', { ui: vipUserId, _ut: config.tracksUserType, anonid: Token.uuid() } );
+			await trackEvent( '_alias_user', {
+				ui: `vip-${ vipUserId }`,
+				_ut: config.tracksUserType,
+				anonid: Token.uuid(),
+			} );
 			Token.setUuid( vipUserId );
 		}
 	} catch ( err ) {
@@ -69,6 +75,11 @@ export async function aliasUser( vipUserId ): Promise<Response> {
 	}
 }
 
-export async function trackEventWithEnv( appId, envId, eventName, eventProps = {} ): Promise<Response> {
+export async function trackEventWithEnv(
+	appId,
+	envId,
+	eventName,
+	eventProps = {}
+): Promise< Response > {
 	return trackEvent( eventName, { ...eventProps, app_id: appId, env_id: envId } );
 }

--- a/src/lib/tracker.js
+++ b/src/lib/tracker.js
@@ -61,8 +61,9 @@ export async function trackEvent( ...args ): Promise<Response> {
 export async function aliasUser( vipUserId ): Promise<Response> {
 	try {
 		if ( vipUserId ) {
-			await trackEvent( '_alias_user', { ui: `vip-${ vipUserId }`, _ut: config.tracksUserType, anonid: Token.uuid() } );
-			Token.setUuid( vipUserId );
+			const prefixedVipUserId = `vip-${ vipUserId }`;
+			await trackEvent( '_alias_user', { ui: prefixedVipUserId, _ut: config.tracksUserType, anonid: Token.uuid() } );
+			Token.setUuid( prefixedVipUserId );
 		}
 	} catch ( err ) {
 		debug( 'aliasUser() failed', err );

--- a/src/lib/tracker.js
+++ b/src/lib/tracker.js
@@ -61,9 +61,8 @@ export async function trackEvent( ...args ): Promise<Response> {
 export async function aliasUser( vipUserId ): Promise<Response> {
 	try {
 		if ( vipUserId ) {
-			const prefixedVipUserId = `vip-${ vipUserId }`;
-			await trackEvent( '_alias_user', { ui: prefixedVipUserId, _ut: config.tracksUserType, anonid: Token.uuid() } );
-			Token.setUuid( prefixedVipUserId );
+			await trackEvent( '_alias_user', { ui: vipUserId, _ut: config.tracksUserType, anonid: Token.uuid() } );
+			Token.setUuid( vipUserId );
 		}
 	} catch ( err ) {
 		debug( 'aliasUser() failed', err );

--- a/src/lib/tracker.js
+++ b/src/lib/tracker.js
@@ -15,7 +15,7 @@ import env from './env';
 
 let analytics = null;
 
-async function init(): Promise< Analytics > {
+async function init(): Promise<Analytics> {
 	const uuid = await Token.uuid();
 
 	const clients = [];
@@ -26,13 +26,11 @@ async function init(): Promise< Analytics > {
 	if ( tracksUserType && tracksEventPrefix ) {
 		clients.push( new Tracks( uuid, tracksUserType, tracksEventPrefix, env ) );
 
-		clients.push(
-			new Pendo( {
-				env,
-				eventPrefix: tracksEventPrefix,
-				userId: uuid,
-			} )
-		);
+		clients.push( new Pendo( {
+			env,
+			eventPrefix: tracksEventPrefix,
+			userId: uuid,
+		} ) );
 	}
 
 	analytics = new Analytics( { clients } );
@@ -40,7 +38,7 @@ async function init(): Promise< Analytics > {
 	return analytics;
 }
 
-async function getInstance(): Promise< Analytics > {
+async function getInstance(): Promise<Analytics> {
 	if ( analytics ) {
 		return analytics;
 	}
@@ -50,7 +48,7 @@ async function getInstance(): Promise< Analytics > {
 	return analytics;
 }
 
-export async function trackEvent( ...args ): Promise< Response > {
+export async function trackEvent( ...args ): Promise<Response> {
 	try {
 		await Token.uuid();
 		const client = await getInstance();
@@ -60,14 +58,10 @@ export async function trackEvent( ...args ): Promise< Response > {
 	}
 }
 
-export async function aliasUser( vipUserId ): Promise< Response > {
+export async function aliasUser( vipUserId ): Promise<Response> {
 	try {
 		if ( vipUserId ) {
-			await trackEvent( '_alias_user', {
-				ui: `vip-${ vipUserId }`,
-				_ut: config.tracksUserType,
-				anonid: Token.uuid(),
-			} );
+			await trackEvent( '_alias_user', { ui: `vip-${ vipUserId }`, _ut: config.tracksUserType, anonid: Token.uuid() } );
 			Token.setUuid( vipUserId );
 		}
 	} catch ( err ) {
@@ -75,11 +69,6 @@ export async function aliasUser( vipUserId ): Promise< Response > {
 	}
 }
 
-export async function trackEventWithEnv(
-	appId,
-	envId,
-	eventName,
-	eventProps = {}
-): Promise< Response > {
+export async function trackEventWithEnv( appId, envId, eventName, eventProps = {} ): Promise<Response> {
 	return trackEvent( eventName, { ...eventProps, app_id: appId, env_id: envId } );
 }


### PR DESCRIPTION
## Description

Added a `vip` prefix for VIP users for better Pendo tracking.

## Steps to Test
Make sure VIP is prefixed to VIP users
1. Check out PR.
2. Run `npm run build`
3. Login using VIP account `./dist/bin/vip.js login`
4. Run `./dist/bin/vip-whoami.js -d`
5. Verify that debug message `pendo send()` contains updated `vip-<id>`

Make sure there is no VIP prefixed to non-VIP users
1. Login using non VIP account `./dist/bin/vip.js login`
2. Run `./dist/bin/vip-whoami.js -d`
3. Verify that debug message `pendo send()` does  NOT contain `vip-` prefix