### PR TITLE
fix(dev-env): Do not use a temporary directory for Lando

### DIFF
--- a/__tests__/devenv-e2e/007-info.spec.js
+++ b/__tests__/devenv-e2e/007-info.spec.js
@@ -64,7 +64,7 @@ describe( 'vip dev-env info', () => {
 		expect( result.rc ).toBe( 0 );
 		expect( result.stdout ).toMatch( new RegExp( `SLUG\\s+${ slug }` ) );
 		expect( result.stdout ).toMatch( /STATUS\s+DOWN/ );
-		[ 'LOCATION', 'SERVICES', 'NGINX URLS', 'LOGIN URL', 'DEFAULT USERNAME', 'DEFAULT PASSWORD' ]
+		[ 'LOCATION', 'SERVICES' ]
 			.forEach( str => expect( result.stdout ).toContain( str ) );
 	} );
 


### PR DESCRIPTION
## Description

Related: #1191, #1198

This PR updates Lando configuration so that Lando's configuration perists reboots. Among other things (like faster warm bootstrap), this allows us to use the same certificate authority for all development environments, eliminating the need to trust the CA every time `/tmp/lando` disappears.

## Steps to Test

1. Create and start a test environment; stop it.
2. Apply the patch and start the test environment again; it should work.

*NB:* it may be necessary to restart all running environments after applying the patch.
