### PR TITLE
fix(dev-env): Perform ES healthcheck properly

### DIFF
--- a/src/lib/dev-environment/dev-environment-lando.js
+++ b/src/lib/dev-environment/dev-environment-lando.js
@@ -187,7 +187,7 @@ function addHooks( app: App, lando: Lando ) {
 
 const healthChecks = {
 	database: 'mysql -uroot --silent --execute "SHOW DATABASES;"',
-	'vip-search': "curl -s --noproxy '*' -XGET localhost:9200",
+	elasticsearch: "curl -s --noproxy '*' -XGET localhost:9200",
 	php: '[[ -f /wp/wp-includes/pomo/mo.php ]]',
 };
 


### PR DESCRIPTION
## Description

The ES service in the dev env is named `elasticsearch`, not `vip-search`. This PR updates healthchecks to reference the proper service.

## Steps to Test

It's not trivial as this really depends on many factors including how powerful the computer is. Ideally you should be able to see the "Waiting for service elasticsearch ..." message when starting the dev environment with ES enabled.
