### PR TITLE
Dev-env: Fix ES service reference

### DIFF
--- a/src/lib/dev-environment/dev-environment-lando.js
+++ b/src/lib/dev-environment/dev-environment-lando.js
@@ -297,7 +297,7 @@ export async function landoInfo( lando: Lando, instancePath: string ) {
 
 const extraServiceDisplayConfiguration = [
 	{
-		name: 'vip-search',
+		name: 'elasticsearch',
 		label: 'enterprise search',
 		protocol: 'http',
 	},


### PR DESCRIPTION
## Description
The service used to be named `vip-search` at one point, but we've changed it to `elasticsearch`, so that means the table no longer displays the expected formatting when we do `vip dev-env info`:

```
 SLUG              es-site
 LOCATION          /Users/rebasaurus/.local/share/vip/dev-environment/es-site
 SERVICES          devtools, nginx, php, database, memcached, elasticsearch, wordpress
 NGINX URLS        http://es-site.vipdev.lndo.site/
                   https://es-site.vipdev.lndo.site/
 ELASTICSEARCH     127.0.0.1:50492
 DATABASE          127.0.0.1:50491
 STATUS            UP
 LOGIN URL         http://es-site.vipdev.lndo.site/wp-admin/
 DEFAULT USERNAME  vipgo
 DEFAULT PASSWORD  password
 DOCUMENTATION     https://docs.wpvip.com/technical-references/vip-local-development-environment/
```
Note how it says `ELASTICSEARCH` rather than `ENTERPRISE SEARCH` in the row label ^ and is also missing the `http` protocol
## Steps to Test

1. Apply PR
2. Run `npm run build`
3. `./dist/bin/vip-dev-env-info.js` should yield:
```
╰─$ ./dist/bin/vip-dev-env-info.js
Running validation steps...
✓ Check for docker installation
✓ Check for docker-compose installation
✓ Check access to docker for current user
✓ Check DNS resolution
 SLUG               es-site
 LOCATION           /Users/rebasaurus/.local/share/vip/dev-environment/es-site
 SERVICES           devtools, nginx, php, database, memcached, elasticsearch, wordpress
 NGINX URLS         http://es-site.vipdev.lndo.site/
                    https://es-site.vipdev.lndo.site/
 ENTERPRISE SEARCH  http://127.0.0.1:50492
 DATABASE           127.0.0.1:50491
 STATUS             UP
 LOGIN URL          http://es-site.vipdev.lndo.site/wp-admin/
 DEFAULT USERNAME   vipgo
 DEFAULT PASSWORD   password
 DOCUMENTATION      https://docs.wpvip.com/technical-references/vip-local-development-environment/
```
