### PR TITLE
fix(dev-env): Inherit stdio descriptors for 'dev-env exec'

### DIFF
--- a/__tests__/devenv-e2e/008-exec.spec.js
+++ b/__tests__/devenv-e2e/008-exec.spec.js
@@ -94,6 +94,13 @@ describe( 'vip dev-env exec', () => {
 			expect( result.stdout.trim() ).toBe( `http://${ slug }.vipdev.lndo.site` );
 		} );
 
+		it( 'should not be verbose on non-zero exit code', async () => {
+			const result = await cliTest.spawn( [ process.argv[ 0 ], vipDevEnvExec, '--slug', slug, '--quiet', '--', 'wp', 'config', 'has', 'this constant does not exist' ], { env } );
+			expect( result.rc ).toBeGreaterThan( 0 );
+			expect( result.stdout ).toBe( '' );
+			expect( result.stderr ).toBe( '' );
+		} );
+
 		it.todo( 'vip dev-env exec --force' );
 	} );
 } );

--- a/__tests__/devenv-e2e/008-exec.spec.js
+++ b/__tests__/devenv-e2e/008-exec.spec.js
@@ -85,7 +85,7 @@ describe( 'vip dev-env exec', () => {
 		it( 'should fail on unknown commands', async () => {
 			const result = await cliTest.spawn( [ process.argv[ 0 ], vipDevEnvExec, '--slug', slug, '--', 'ls' ], { env } );
 			expect( result.rc ).toBeGreaterThan( 0 );
-			expect( result.stderr ).toContain( 'Error: ls is not a known lando task' );
+			expect( result.stderr ).toContain( 'Error:  ls is not a known lando task' );
 		} );
 
 		it( 'should not produce superfluous output in silent mode', async () => {

--- a/src/bin/vip-dev-env-exec.js
+++ b/src/bin/vip-dev-env-exec.js
@@ -6,10 +6,6 @@
  */
 
 /**
- * External dependencies
- */
-
-/**
  * Internal dependencies
  */
 import { trackEvent } from '../lib/tracker';
@@ -72,6 +68,10 @@ command( { wildcardCommand: true } )
 			try {
 				await exec( lando, slug, arg, { stdio: 'inherit' } );
 			} catch ( error ) {
+				if ( error instanceof UserError ) {
+					throw error;
+				}
+
 				// Unfortunately, we are unable to get the exit code from Lando :-(
 				process.exitCode = 1;
 			}

--- a/src/bin/vip-dev-env-exec.js
+++ b/src/bin/vip-dev-env-exec.js
@@ -69,8 +69,13 @@ command( { wildcardCommand: true } )
 				}
 			}
 
-			const options = { force: opt.force };
-			await exec( lando, slug, arg, options );
+			try {
+				await exec( lando, slug, arg, { stdio: 'inherit' } );
+			} catch ( error ) {
+				// Unfortunately, we are unable to get the exit code from Lando :-(
+				process.exitCode = 1;
+			}
+
 			await trackEvent( 'dev_env_exec_command_success', trackingInfo );
 		} catch ( error ) {
 			await handleCLIException( error, 'dev_env_exec_command_error', trackingInfo );

--- a/src/lib/dev-environment/dev-environment-core.js
+++ b/src/lib/dev-environment/dev-environment-core.js
@@ -253,7 +253,7 @@ export async function printEnvironmentInfo( lando: Lando, slug: string, options:
 	printTable( appInfo );
 }
 
-export async function exec( lando: Lando, slug: string, args: Array<string>, options: any = {} ) {
+export function exec( lando: Lando, slug: string, args: Array<string>, options: any = {} ): Promise<*> {
 	debug( 'Will run a wp command on env', slug, 'with args', args, ' and options', options );
 
 	const instancePath = getEnvironmentPath( slug );
@@ -261,7 +261,7 @@ export async function exec( lando: Lando, slug: string, args: Array<string>, opt
 	debug( 'Instance path for', slug, 'is:', instancePath );
 
 	const [ command, ...commandArgs ] = args;
-	await landoExec( lando, instancePath, command, commandArgs, options );
+	return landoExec( lando, instancePath, command, commandArgs, options );
 }
 
 export function doesEnvironmentExist( instancePath: string ): boolean {

--- a/src/lib/dev-environment/dev-environment-lando.js
+++ b/src/lib/dev-environment/dev-environment-lando.js
@@ -21,6 +21,7 @@ import dns from 'dns';
  */
 import { doesEnvironmentExist, readEnvironmentData, writeEnvironmentData } from './dev-environment-core';
 import { DEV_ENVIRONMENT_NOT_FOUND } from '../constants/dev-environment';
+import UserError from '../user-error';
 
 /**
  * This file will hold all the interactions with lando library
@@ -359,7 +360,7 @@ export async function landoExec( lando: Lando, instancePath: string, toolName: s
 
 	const tool = app.config.tooling[ toolName ];
 	if ( ! tool ) {
-		throw new Error( `${ toolName } is not a known lando task` );
+		throw new UserError( `${ toolName } is not a known lando task` );
 	}
 
 	const savedArgv = process.argv;


### PR DESCRIPTION
## Description

When the command exits with a non-zero exit code, `vip dev-env exec` is too verbose:

```
$ vip dev-env exec -- wp config has VIP_ENABLE_VIP_SEARCH_QUERY_INTEGRATION
Running validation steps...
✓ Check for docker installation 
✓ Check for docker-compose installation 
✓ Check access to docker for current user 
✓ Check DNS resolution 
Error: 

Please re-run the command with "--debug @automattic/vip:bin:dev-environment" appended to it and provide the stack trace on the support ticket.

Example:

vip dev-env <command> <arguments> --debug @automattic/vip:bin:dev-environment 
```

This PR updates the exec functionality so that stdin, stdout, and stderr are inherited by the spawned process, and a non-zero exit code does not result in extra error messages:
```
$ ./dist/bin/vip-dev-env-exec.js --quiet -- wp config has VIP_ENABLE_VIP_SEARCH_QUERY_INTEGRATION; echo $?
1
```

Unfortunately, Lando does not tell us what the exit code really was, so we use `1` as the exit code.

## Steps to Test

See above :-)
