### PR TITLE
fix(dev-env): Make environment existence check more robust

### DIFF
--- a/__tests__/devenv-e2e/001-create.spec.js
+++ b/__tests__/devenv-e2e/001-create.spec.js
@@ -38,28 +38,28 @@ describe( 'vip dev-env create', () => {
 
 	it( 'should create a new environment', async () => {
 		const expectedSlug = getProjectSlug();
-		expect( checkEnvExists( expectedSlug ) ).toBe( false );
+		expect( await checkEnvExists( expectedSlug ) ).toBe( false );
 
 		const result = await cliTest.spawn( [ process.argv[ 0 ], vipDevEnvCreate, '--slug', expectedSlug ], { env }, true );
 		expect( result.rc ).toBe( 0 );
 		expect( result.stdout ).toContain( `vip dev-env start --slug ${ expectedSlug }` );
 		expect( result.stderr ).toBe( '' );
 
-		expect( checkEnvExists( expectedSlug ) ).toBe( true );
+		return expect( checkEnvExists( expectedSlug ) ).resolves.toBe( true );
 	} );
 
 	it( 'should fail on duplicate slugs', async () => {
 		const slug = getProjectSlug();
-		expect( checkEnvExists( slug ) ).toBe( false );
+		expect( await checkEnvExists( slug ) ).toBe( false );
 
 		const result1 = await cliTest.spawn( [ process.argv[ 0 ], vipDevEnvCreate, '--slug', slug ], { env }, true );
 		expect( result1.rc ).toBe( 0 );
-		expect( checkEnvExists( slug ) ).toBe( true );
+		expect( await checkEnvExists( slug ) ).toBe( true );
 
 		const result2 = await cliTest.spawn( [ process.argv[ 0 ], vipDevEnvCreate, '--slug', slug ], { env } );
 		expect( result2.rc ).toBeGreaterThan( 0 );
 		expect( result2.stderr ).toContain( 'Error:  Environment already exists' );
-		expect( checkEnvExists( slug ) ).toBe( true );
+		return expect( checkEnvExists( slug ) ).resolves.toBe( true );
 	} );
 
 	it( 'should use sane defaults', async () => {
@@ -69,11 +69,11 @@ describe( 'vip dev-env create', () => {
 		const expectedElasticSearch = false;
 		const expectedMailHog = false;
 
-		expect( checkEnvExists( slug ) ).toBe( false );
+		expect( await checkEnvExists( slug ) ).toBe( false );
 
 		const result = await cliTest.spawn( [ process.argv[ 0 ], vipDevEnvCreate, '--slug', slug ], { env }, true );
 		expect( result.rc ).toBe( 0 );
-		expect( checkEnvExists( slug ) ).toBe( true );
+		expect( await checkEnvExists( slug ) ).toBe( true );
 
 		const data = readEnvironmentData( slug );
 		expect( data ).toMatchObject( {
@@ -107,7 +107,7 @@ describe( 'vip dev-env create', () => {
 		const expectedXDebug = true;
 		const expectedMailHog = true;
 
-		expect( checkEnvExists( slug ) ).toBe( false );
+		expect( await checkEnvExists( slug ) ).toBe( false );
 
 		const result = await cliTest.spawn( [
 			process.argv[ 0 ],
@@ -125,7 +125,7 @@ describe( 'vip dev-env create', () => {
 			'--mailhog', `${ expectedMailHog }`,
 		], { env }, true );
 		expect( result.rc ).toBe( 0 );
-		expect( checkEnvExists( slug ) ).toBe( true );
+		expect( await checkEnvExists( slug ) ).toBe( true );
 
 		const data = readEnvironmentData( slug );
 		expect( data ).toMatchObject( {

--- a/__tests__/devenv-e2e/002-destroy.spec.js
+++ b/__tests__/devenv-e2e/002-destroy.spec.js
@@ -45,33 +45,33 @@ describe( 'vip dev-env destroy', () => {
 
 	it( 'should fail if environment does not exist', async () => {
 		const slug = getProjectSlug();
-		expect( checkEnvExists( slug ) ).toBe( false );
+		expect( await checkEnvExists( slug ) ).toBe( false );
 
 		const result = await cliTest.spawn( [ process.argv[ 0 ], vipDevEnvDestroy, '--slug', slug ], { env } );
 		expect( result.rc ).toBeGreaterThan( 0 );
 		expect( result.stderr ).toContain( 'Error: Environment doesn\'t exist.' );
 
-		expect( checkEnvExists( slug ) ).toBe( false );
+		return expect( checkEnvExists( slug ) ).resolves.toBe( false );
 	} );
 
 	it( 'should remove existing environment', async () => {
 		const slug = getProjectSlug();
-		expect( checkEnvExists( slug ) ).toBe( false );
+		expect( await checkEnvExists( slug ) ).toBe( false );
 
 		const result = await cliTest.spawn( [ process.argv[ 0 ], vipDevEnvCreate, '--slug', slug ], { env }, true );
 		expect( result.rc ).toBe( 0 );
-		expect( checkEnvExists( slug ) ).toBe( true );
+		expect( await checkEnvExists( slug ) ).toBe( true );
 
 		await destroyEnvironment( cliTest, slug, env );
 	} );
 
 	it( 'should remove existing environment even without landofile', async () => {
 		const slug = getProjectSlug();
-		expect( checkEnvExists( slug ) ).toBe( false );
+		expect( await checkEnvExists( slug ) ).toBe( false );
 
 		const result = await cliTest.spawn( [ process.argv[ 0 ], vipDevEnvCreate, '--slug', slug ], { env }, true );
 		expect( result.rc ).toBe( 0 );
-		expect( checkEnvExists( slug ) ).toBe( true );
+		expect( await checkEnvExists( slug ) ).toBe( true );
 
 		const landoFile = path.join( getEnvironmentPath( slug ), '.lando.yml' );
 		await expect( access( landoFile ) ).resolves.toBeUndefined();
@@ -82,11 +82,11 @@ describe( 'vip dev-env destroy', () => {
 
 	it( 'should keep the files when asked to', async () => {
 		const slug = getProjectSlug();
-		expect( checkEnvExists( slug ) ).toBe( false );
+		expect( await checkEnvExists( slug ) ).toBe( false );
 
 		let result = await cliTest.spawn( [ process.argv[ 0 ], vipDevEnvCreate, '--slug', slug ], { env }, true );
 		expect( result.rc ).toBe( 0 );
-		expect( checkEnvExists( slug ) ).toBe( true );
+		expect( await checkEnvExists( slug ) ).toBe( true );
 
 		result = await cliTest.spawn( [ process.argv[ 0 ], vipDevEnvDestroy, '--slug', slug, '--soft' ], { env }, true );
 		expect( result.rc ).toBe( 0 );
@@ -96,7 +96,7 @@ describe( 'vip dev-env destroy', () => {
 		// BUG BUG BUG: this means that `vip dev-env destroy --soft` does not destroy the environment
 		const landoFile = path.join( getEnvironmentPath( slug ), '.lando.yml' );
 		await expect( access( landoFile ) ).resolves.toBeUndefined();
-		expect( checkEnvExists( slug ) ).toBe( true );
+		return expect( checkEnvExists( slug ) ).resolves.toBe( true );
 	} );
 
 	describe( 'if the environment is running', () => {
@@ -113,7 +113,7 @@ describe( 'vip dev-env destroy', () => {
 
 		it( 'should stop and destroy it', async () => {
 			slug = getProjectSlug();
-			expect( checkEnvExists( slug ) ).toBe( false );
+			expect( await checkEnvExists( slug ) ).toBe( false );
 
 			await createAndStartEnvironment( cliTest, slug, env );
 			await destroyEnvironment( cliTest, slug, env );

--- a/__tests__/devenv-e2e/003-start.spec.js
+++ b/__tests__/devenv-e2e/003-start.spec.js
@@ -52,13 +52,13 @@ describe( 'vip dev-env start', () => {
 
 	it( 'should fail if environment does not exist', async () => {
 		slug = getProjectSlug();
-		expect( checkEnvExists( slug ) ).toBe( false );
+		expect( await checkEnvExists( slug ) ).toBe( false );
 
 		const result = await cliTest.spawn( [ process.argv[ 0 ], vipDevEnvStart, '--slug', slug ], { env } );
 		expect( result.rc ).toBeGreaterThan( 0 );
 		expect( result.stderr ).toContain( 'Error: Environment doesn\'t exist.' );
 
-		expect( checkEnvExists( slug ) ).toBe( false );
+		return expect( checkEnvExists( slug ) ).resolves.toBe( false );
 	} );
 
 	it( 'should start an environment', async () => {

--- a/__tests__/devenv-e2e/004-stop.spec.js
+++ b/__tests__/devenv-e2e/004-stop.spec.js
@@ -52,13 +52,13 @@ describe( 'vip dev-env stop', () => {
 
 	it( 'should fail if environment does not exist', async () => {
 		slug = getProjectSlug();
-		expect( checkEnvExists( slug ) ).toBe( false );
+		expect( await checkEnvExists( slug ) ).toBe( false );
 
 		const result = await cliTest.spawn( [ process.argv[ 0 ], vipDevEnvStop, '--slug', slug ], { env } );
 		expect( result.rc ).toBeGreaterThan( 0 );
 		expect( result.stderr ).toContain( 'Error: Environment doesn\'t exist.' );
 
-		expect( checkEnvExists( slug ) ).toBe( false );
+		return expect( checkEnvExists( slug ) ).resolves.toBe( false );
 	} );
 
 	it( 'should stop a running environment', async () => {

--- a/__tests__/devenv-e2e/005-update.spec.js
+++ b/__tests__/devenv-e2e/005-update.spec.js
@@ -38,20 +38,20 @@ describe( 'vip dev-env update', () => {
 
 	it( 'should fail if the environment does not exist', async () => {
 		const slug = getProjectSlug();
-		expect( checkEnvExists( slug ) ).toBe( false );
+		expect( await checkEnvExists( slug ) ).toBe( false );
 		const result = await cliTest.spawn( [ process.argv[ 0 ], vipDevEnvUpdate, '--slug', slug ], { env } );
 		expect( result.rc ).toBeGreaterThan( 0 );
 		expect( result.stderr ).toContain( 'Error: Environment doesn\'t exist.' );
-		expect( checkEnvExists( slug ) ).toBe( false );
+		expect( await checkEnvExists( slug ) ).toBe( false );
 	} );
 
 	it( 'should not update the environment if there are no changes', async () => {
 		const slug = getProjectSlug();
-		expect( checkEnvExists( slug ) ).toBe( false );
+		expect( await checkEnvExists( slug ) ).toBe( false );
 
 		let result = await cliTest.spawn( [ process.argv[ 0 ], vipDevEnvCreate, '--slug', slug ], { env }, true );
 		expect( result.rc ).toBe( 0 );
-		expect( checkEnvExists( slug ) ).toBe( true );
+		expect( await checkEnvExists( slug ) ).toBe( true );
 
 		const dataBefore = readEnvironmentData( slug );
 
@@ -70,11 +70,11 @@ describe( 'vip dev-env update', () => {
 		const expectedXDebug = false;
 		const expectedMailHog = false;
 
-		expect( checkEnvExists( slug ) ).toBe( false );
+		expect( await checkEnvExists( slug ) ).toBe( false );
 
 		let result = await cliTest.spawn( [ process.argv[ 0 ], vipDevEnvCreate, '--slug', slug ], { env }, true );
 		expect( result.rc ).toBe( 0 );
-		expect( checkEnvExists( slug ) ).toBe( true );
+		expect( await checkEnvExists( slug ) ).toBe( true );
 
 		const dataBefore = readEnvironmentData( slug );
 		expect( dataBefore ).toMatchObject( {
@@ -96,7 +96,7 @@ describe( 'vip dev-env update', () => {
 			'--mailhog', `${ ! expectedMailHog }`,
 		], { env }, true );
 		expect( result.rc ).toBe( 0 );
-		expect( checkEnvExists( slug ) ).toBe( true );
+		expect( await checkEnvExists( slug ) ).toBe( true );
 
 		const dataAfter = readEnvironmentData( slug );
 		expect( dataAfter ).toMatchObject( {
@@ -112,7 +112,7 @@ describe( 'vip dev-env update', () => {
 		const slug = getProjectSlug();
 		const expectedMultiSite = true;
 
-		expect( checkEnvExists( slug ) ).toBe( false );
+		expect( await checkEnvExists( slug ) ).toBe( false );
 
 		let result = await cliTest.spawn( [
 			process.argv[ 0 ], vipDevEnvCreate,
@@ -120,7 +120,7 @@ describe( 'vip dev-env update', () => {
 			'--multisite', `${ expectedMultiSite }`,
 		], { env }, true );
 		expect( result.rc ).toBe( 0 );
-		expect( checkEnvExists( slug ) ).toBe( true );
+		expect( await checkEnvExists( slug ) ).toBe( true );
 
 		const dataBefore = readEnvironmentData( slug );
 		expect( dataBefore ).toMatchObject( {
@@ -134,7 +134,7 @@ describe( 'vip dev-env update', () => {
 			'--multisite', `${ ! expectedMultiSite }`,
 		], { env }, true );
 		expect( result.rc ).toBe( 0 );
-		expect( checkEnvExists( slug ) ).toBe( true );
+		expect( await checkEnvExists( slug ) ).toBe( true );
 
 		const dataAfter = readEnvironmentData( slug );
 		expect( dataAfter ).toMatchObject( {

--- a/__tests__/devenv-e2e/006-list.spec.js
+++ b/__tests__/devenv-e2e/006-list.spec.js
@@ -54,18 +54,18 @@ describe( 'vip dev-env list', () => {
 	it( 'should list multiple environments', async () => {
 		const slug1 = getProjectSlug();
 		const slug2 = getProjectSlug();
-		expect( checkEnvExists( slug1 ) ).toBe( false );
-		expect( checkEnvExists( slug2 ) ).toBe( false );
+		expect( await checkEnvExists( slug1 ) ).toBe( false );
+		expect( await checkEnvExists( slug2 ) ).toBe( false );
 
 		let result = await cliTest.spawn( [ process.argv[ 0 ], vipDevEnvCreate, '--slug', slug1 ], { env }, true );
 		expect( result.rc ).toBe( 0 );
 		expect( result.stdout ).toContain( `vip dev-env start --slug ${ slug1 }` );
-		expect( checkEnvExists( slug1 ) ).toBe( true );
+		expect( await checkEnvExists( slug1 ) ).toBe( true );
 
 		result = await cliTest.spawn( [ process.argv[ 0 ], vipDevEnvCreate, '--slug', slug2 ], { env }, true );
 		expect( result.rc ).toBe( 0 );
 		expect( result.stdout ).toContain( `vip dev-env start --slug ${ slug2 }` );
-		expect( checkEnvExists( slug2 ) ).toBe( true );
+		expect( await checkEnvExists( slug2 ) ).toBe( true );
 
 		result = await cliTest.spawn( [ process.argv[ 0 ], vipDevEnvList ], { env }, true );
 		expect( result.rc ).toBe( 0 );

--- a/__tests__/devenv-e2e/008-exec.spec.js
+++ b/__tests__/devenv-e2e/008-exec.spec.js
@@ -45,13 +45,13 @@ describe( 'vip dev-env exec', () => {
 	describe( 'if the environment does not exist', () => {
 		it( 'should fail', async () => {
 			const slug = getProjectSlug();
-			expect( checkEnvExists( slug ) ).toBe( false );
+			expect( await checkEnvExists( slug ) ).toBe( false );
 
 			const result = await cliTest.spawn( [ process.argv[ 0 ], vipDevEnvExec, '--slug', slug ], { env } );
 			expect( result.rc ).toBeGreaterThan( 0 );
 			expect( result.stderr ).toContain( 'Error: Environment doesn\'t exist.' );
 
-			expect( checkEnvExists( slug ) ).toBe( false );
+			expect( await checkEnvExists( slug ) ).toBe( false );
 		} );
 	} );
 

--- a/__tests__/devenv-e2e/008-exec.spec.js
+++ b/__tests__/devenv-e2e/008-exec.spec.js
@@ -51,7 +51,7 @@ describe( 'vip dev-env exec', () => {
 			expect( result.rc ).toBeGreaterThan( 0 );
 			expect( result.stderr ).toContain( 'Error: Environment doesn\'t exist.' );
 
-			expect( await checkEnvExists( slug ) ).toBe( false );
+			return expect( checkEnvExists( slug ) ).resolves.toBe( false );
 		} );
 	} );
 

--- a/__tests__/devenv-e2e/009-import-media.spec.js
+++ b/__tests__/devenv-e2e/009-import-media.spec.js
@@ -38,7 +38,7 @@ describe( 'vip dev-env import media', () => {
 
 	it( 'should fail if environment does not exist', async () => {
 		const slug = getProjectSlug();
-		expect( checkEnvExists( slug ) ).toBe( false );
+		expect( await checkEnvExists( slug ) ).toBe( false );
 
 		const result = await cliTest.spawn( [ process.argv[ 0 ], vipDevEnvImportMedia, '--slug', slug, __dirname ], { env } );
 		expect( result.rc ).toBeGreaterThan( 0 );
@@ -47,11 +47,11 @@ describe( 'vip dev-env import media', () => {
 
 	it( 'should copy files if environment exists', async () => {
 		const slug = getProjectSlug();
-		expect( checkEnvExists( slug ) ).toBe( false );
+		expect( await checkEnvExists( slug ) ).toBe( false );
 
 		let result = await cliTest.spawn( [ process.argv[ 0 ], vipDevEnvCreate, '--slug', slug ], { env }, true );
 		expect( result.rc ).toBe( 0 );
-		expect( checkEnvExists( slug ) ).toBe( true );
+		expect( await checkEnvExists( slug ) ).toBe( true );
 
 		result = await cliTest.spawn( [ process.argv[ 0 ], vipDevEnvImportMedia, '--slug', slug, __dirname ], { env }, true );
 		expect( result.rc ).toBe( 0 );

--- a/__tests__/devenv-e2e/010-import-sql.spec.js
+++ b/__tests__/devenv-e2e/010-import-sql.spec.js
@@ -45,14 +45,14 @@ describe( 'vip dev-env import sql', () => {
 	describe( 'if the environment does not exist', () => {
 		it( 'should fail', async () => {
 			const slug = getProjectSlug();
-			expect( checkEnvExists( slug ) ).toBe( false );
+			expect( await checkEnvExists( slug ) ).toBe( false );
 
 			const file = path.join( __dirname, '../../__fixtures__/dev-env-e2e/empty.sql' );
 			const result = await cliTest.spawn( [ process.argv[ 0 ], vipDevEnvImportSQL, '--slug', slug, file, '--skip-validate' ], { env } );
 			expect( result.rc ).toBeGreaterThan( 0 );
 			expect( result.stderr ).toContain( 'Error: Environment doesn\'t exist.' );
 
-			expect( checkEnvExists( slug ) ).toBe( false );
+			expect( await checkEnvExists( slug ) ).toBe( false );
 		} );
 	} );
 

--- a/__tests__/devenv-e2e/010-import-sql.spec.js
+++ b/__tests__/devenv-e2e/010-import-sql.spec.js
@@ -52,7 +52,7 @@ describe( 'vip dev-env import sql', () => {
 			expect( result.rc ).toBeGreaterThan( 0 );
 			expect( result.stderr ).toContain( 'Error: Environment doesn\'t exist.' );
 
-			expect( await checkEnvExists( slug ) ).toBe( false );
+			return expect( checkEnvExists( slug ) ).resolves.toBe( false );
 		} );
 	} );
 

--- a/__tests__/devenv-e2e/helpers/utils.js
+++ b/__tests__/devenv-e2e/helpers/utils.js
@@ -46,7 +46,7 @@ export function prepareEnvironment( xdgDataHome ) {
 
 /**
  * @param {string} slug Environment slug
- * @returns {boolean} Whether the environment exists
+ * @returns {Promise<boolean>} Whether the environment exists
  */
 export function checkEnvExists( slug ) {
 	return doesEnvironmentExist( getEnvironmentPath( slug ) );
@@ -62,7 +62,7 @@ export async function createAndStartEnvironment( cliTest, slug, env, options = [
 	let result = await cliTest.spawn( [ process.argv[ 0 ], vipDevEnvCreate, '--slug', slug ].concat( options ), { env }, true );
 	expect( result.rc ).toBe( 0 );
 	expect( result.stdout ).toContain( `vip dev-env start --slug ${ slug }` );
-	expect( checkEnvExists( slug ) ).toBe( true );
+	expect( await checkEnvExists( slug ) ).toBe( true );
 
 	result = await cliTest.spawn( [ process.argv[ 0 ], vipDevEnvStart, '--slug', slug ], { env }, true );
 	expect( result.rc ).toBe( 0 );
@@ -79,5 +79,5 @@ export async function destroyEnvironment( cliTest, slug, env ) {
 	expect( result.rc ).toBe( 0 );
 	expect( result.stdout ).toContain( 'Environment files deleted successfully' );
 	expect( result.stdout ).toContain( 'Environment destroyed' );
-	expect( checkEnvExists( slug ) ).toBe( false );
+	expect( await checkEnvExists( slug ) ).toBe( false );
 }

--- a/src/bin/vip-dev-env-create.js
+++ b/src/bin/vip-dev-env-create.js
@@ -93,7 +93,7 @@ cmd.argv( process.argv, async ( arg, opt ) => {
 
 	const startCommand = chalk.bold( getEnvironmentStartCommand( slug ) );
 
-	const environmentAlreadyExists = doesEnvironmentExist( getEnvironmentPath( slug ) );
+	const environmentAlreadyExists = await doesEnvironmentExist( getEnvironmentPath( slug ) );
 	if ( environmentAlreadyExists ) {
 		const messageToShow = `Environment already exists\n\n\nTo start the environment run:\n\n${ startCommand }\n\n` +
 			`To create another environment use ${ chalk.bold( '--slug' ) } option with a unique name.\n`;

--- a/src/bin/vip-dev-env-update.js
+++ b/src/bin/vip-dev-env-update.js
@@ -46,7 +46,7 @@ cmd.argv( process.argv, async ( arg, opt ) => {
 	await trackEvent( 'dev_env_update_command_execute', trackingInfo );
 
 	try {
-		const environmentAlreadyExists = doesEnvironmentExist( getEnvironmentPath( slug ) );
+		const environmentAlreadyExists = await doesEnvironmentExist( getEnvironmentPath( slug ) );
 		if ( ! environmentAlreadyExists ) {
 			throw new Error( DEV_ENVIRONMENT_NOT_FOUND );
 		}

--- a/src/lib/dev-environment/dev-environment-cli.js
+++ b/src/lib/dev-environment/dev-environment-cli.js
@@ -74,14 +74,14 @@ declare function promptForComponent( component: string, allowLocal: boolean, def
 
 export async function handleCLIException( exception: Error, trackKey?: string, trackBaseInfo?: any = {} ) {
 	const errorPrefix = chalk.red( 'Error:' );
-	if ( exception instanceof UserError && DEV_ENVIRONMENT_NOT_FOUND !== exception.message ) {
-		// User errors are handled in global error handler
-		throw exception;
-	} else if ( DEV_ENVIRONMENT_NOT_FOUND === exception.message ) {
+	if ( DEV_ENVIRONMENT_NOT_FOUND === exception.message ) {
 		const createCommand = chalk.bold( DEV_ENVIRONMENT_FULL_COMMAND + ' create' );
 
 		const message = `Environment doesn't exist.\n\n\nTo create a new environment run:\n\n${ createCommand }\n`;
 		console.error( errorPrefix, message );
+	} else if ( exception instanceof UserError ) {
+		// User errors are handled in global error handler
+		throw exception;
 	} else {
 		let message = exception.message;
 		// if the message has already ERROR prefix we should drop it as we are adding our own cool red Error-prefix

--- a/src/lib/dev-environment/dev-environment-cli.js
+++ b/src/lib/dev-environment/dev-environment-cli.js
@@ -74,7 +74,7 @@ declare function promptForComponent( component: string, allowLocal: boolean, def
 
 export async function handleCLIException( exception: Error, trackKey?: string, trackBaseInfo?: any = {} ) {
 	const errorPrefix = chalk.red( 'Error:' );
-	if ( exception instanceof UserError ) {
+	if ( exception instanceof UserError && DEV_ENVIRONMENT_NOT_FOUND !== exception.message ) {
 		// User errors are handled in global error handler
 		throw exception;
 	} else if ( DEV_ENVIRONMENT_NOT_FOUND === exception.message ) {

--- a/src/lib/dev-environment/dev-environment-core.js
+++ b/src/lib/dev-environment/dev-environment-core.js
@@ -212,8 +212,16 @@ export async function printAllEnvironmentsInfo( lando: Lando, options: PrintOpti
 
 	console.log( 'Found ' + chalk.bold( allEnvNames.length ) + ' environments' + ( allEnvNames.length ? ':' : '.' ) );
 	for ( const envName of allEnvNames ) {
-		console.log( '\n' );
-		await printEnvironmentInfo( lando, envName, options );
+		try {
+			console.log( '\n' );
+			await printEnvironmentInfo( lando, envName, options );
+		} catch ( error ) {
+			if ( error instanceof UserError ) {
+				console.warn( '\nWARNING: "%s" is not a valid environment\n', envName );
+			} else {
+				throw error;
+			}
+		}
 	}
 }
 
@@ -233,7 +241,7 @@ export async function printEnvironmentInfo( lando: Lando, slug: string, options:
 
 	const environmentExists = await doesEnvironmentExist( instancePath );
 	if ( ! environmentExists ) {
-		throw new Error( DEV_ENVIRONMENT_NOT_FOUND );
+		throw new UserError( DEV_ENVIRONMENT_NOT_FOUND );
 	}
 
 	const appInfo = await landoInfo( lando, instancePath );

--- a/src/lib/dev-environment/dev-environment-core.js
+++ b/src/lib/dev-environment/dev-environment-core.js
@@ -182,7 +182,7 @@ export async function destroyEnvironment( lando: Lando, slug: string, removeFile
 
 	debug( 'Instance path for', slug, 'is:', instancePath );
 
-	const environmentExists = doesEnvironmentExist( instancePath );
+	const environmentExists = await doesEnvironmentExist( instancePath );
 	if ( ! environmentExists ) {
 		throw new Error( DEV_ENVIRONMENT_NOT_FOUND );
 	}
@@ -231,7 +231,7 @@ export async function printEnvironmentInfo( lando: Lando, slug: string, options:
 
 	debug( 'Instance path for', slug, 'is:', instancePath );
 
-	const environmentExists = doesEnvironmentExist( instancePath );
+	const environmentExists = await doesEnvironmentExist( instancePath );
 	if ( ! environmentExists ) {
 		throw new Error( DEV_ENVIRONMENT_NOT_FOUND );
 	}
@@ -264,9 +264,15 @@ export async function exec( lando: Lando, slug: string, args: Array<string>, opt
 	await landoExec( lando, instancePath, command, commandArgs, options );
 }
 
-export function doesEnvironmentExist( instancePath: string ): boolean {
+export async function doesEnvironmentExist( instancePath: string ): Promise<boolean> {
 	debug( 'Will check for environment at', instancePath );
-	return fs.existsSync( instancePath );
+	const file = path.join( instancePath, instanceDataFileName );
+	try {
+		const stats = await fs.promises.stat( file );
+		return stats.isFile();
+	} catch ( err ) {
+		return false;
+	}
 }
 
 export function readEnvironmentData( slug: string ): InstanceData {
@@ -480,7 +486,7 @@ export async function importMediaPath( slug: string, filePath: string ) {
 	}
 
 	const environmentPath = getEnvironmentPath( slug );
-	if ( ! doesEnvironmentExist( environmentPath ) ) {
+	if ( ! await doesEnvironmentExist( environmentPath ) ) {
 		throw new Error( DEV_ENVIRONMENT_NOT_FOUND );
 	}
 

--- a/src/lib/dev-environment/dev-environment-lando.js
+++ b/src/lib/dev-environment/dev-environment-lando.js
@@ -121,7 +121,7 @@ async function getLandoApplication( lando: Lando, instancePath: string ): Promis
 		return Promise.resolve( appMap.get( instancePath ) );
 	}
 
-	if ( ! doesEnvironmentExist( instancePath ) ) {
+	if ( ! await doesEnvironmentExist( instancePath ) ) {
 		throw new Error( DEV_ENVIRONMENT_NOT_FOUND );
 	}
 


### PR DESCRIPTION
## Description

This PR makes the environment existence check more robust.

Previously, for an environment to exist, it was enough that a directory with the name matching the environment exists. It was enough to create an empty directory to crash the application.

Now we check that the `instance_data.json` file exists as well.

## Steps to Test

```
$ mkdir ~/.local/share/vip/dev-environment/xxx
$ vip dev-env list
...
WARN ==> could not find app in this dir or a reasonable amount of directories above it! 
Error: Cannot read properties of undefined (reading 'init')
```

```
$ npm run build
$ ./dist/bin/vip-dev-env-list.js
...
WARNING: "xxx" is not a valid environment
```
