### PR TITLE
Skip requoting if the arg is a valid JSON Object

### DIFF
--- a/__tests__/lib/cli/format.js
+++ b/__tests__/lib/cli/format.js
@@ -1,0 +1,34 @@
+/**
+ * External dependencies
+ */
+
+/**
+ * Internal dependencies
+ */
+import { requoteArgs } from 'lib/cli/format';
+
+describe( 'utils/cli/format', () => {
+	describe( 'requoteArgs', () => {
+		it.each( [
+			{
+				input: [ 'text with spaces' ],
+				expected: [ '"text with spaces"' ],
+			},
+			{
+				input: [ 'textnospaces' ],
+				expected: [ 'textnospaces' ],
+			},
+			{
+				input: [ '{"json":"json with spaces"}' ],
+				expected: [ '{"json":"json with spaces"}' ],
+			},
+			{
+				input: [ '{"json":broken json with spaces}' ],
+				expected: [ '"{"json":broken json with spaces}"' ],
+			},
+		] )( 'should requote args when needed - %o', ( { input, expected } ) => {
+			const result = requoteArgs( input );
+			expect( result ).toStrictEqual( expected );
+		} );
+	} );
+} );

--- a/__tests__/lib/cli/format.js
+++ b/__tests__/lib/cli/format.js
@@ -23,12 +23,12 @@ describe( 'utils/cli/format', () => {
 				expected: [ '{"json":"json with spaces"}' ],
 			},
 			{
-				input: [ '{ "json" : "json with spaces outside strings" }' ],
-				expected: [ '{ "json" : "json with spaces outside strings" }' ],
+				input: [ '{ "json"     :    "json with spaces outside strings"     }' ],
+				expected: [ '{ "json"     :    "json with spaces outside strings"     }' ],
 			},
 			{
-				input: [ '{ "json" : "spaces-outside-strings-only" }' ],
-				expected: [ '{ "json" : "spaces-outside-strings-only" }' ],
+				input: [ '{ "json" : "spaces-outside-strings-only"      }' ],
+				expected: [ '{ "json" : "spaces-outside-strings-only"      }' ],
 			},
 			{
 				input: [ '{"json":broken json with spaces}' ],

--- a/__tests__/lib/cli/format.js
+++ b/__tests__/lib/cli/format.js
@@ -23,6 +23,14 @@ describe( 'utils/cli/format', () => {
 				expected: [ '{"json":"json with spaces"}' ],
 			},
 			{
+				input: [ '{ "json" : "json with spaces outside strings" }' ],
+				expected: [ '{ "json" : "json with spaces outside strings" }' ],
+			},
+			{
+				input: [ '{ "json" : "spaces-outside-strings-only" }' ],
+				expected: [ '{ "json" : "spaces-outside-strings-only" }' ],
+			},
+			{
 				input: [ '{"json":broken json with spaces}' ],
 				expected: [ '"{"json":broken json with spaces}"' ],
 			},

--- a/__tests__/lib/cli/format.js
+++ b/__tests__/lib/cli/format.js
@@ -27,6 +27,10 @@ describe( 'utils/cli/format', () => {
 				expected: [ '{ "json"     :    "json with spaces outside strings"     }' ],
 			},
 			{
+				input: [ '   { "json"     :    "json with spaces outside strings and outside the object"     }   ' ],
+				expected: [ '   { "json"     :    "json with spaces outside strings and outside the object"     }   ' ],
+			},
+			{
 				input: [ '{ "json" : "spaces-outside-strings-only"      }' ],
 				expected: [ '{ "json" : "spaces-outside-strings-only"      }' ],
 			},

--- a/__tests__/lib/cli/format.js
+++ b/__tests__/lib/cli/format.js
@@ -5,7 +5,7 @@
 /**
  * Internal dependencies
  */
-import { requoteArgs } from 'lib/cli/format';
+import { requoteArgs } from '../../../src/lib/cli/format';
 
 describe( 'utils/cli/format', () => {
 	describe( 'requoteArgs', () => {

--- a/src/lib/cli/format.js
+++ b/src/lib/cli/format.js
@@ -122,12 +122,25 @@ export function requoteArgs( args: Array<string> ): Array<string> {
 			return arg.replace( /^--(.*)=(.*)$/, '--$1="$2"' );
 		}
 
-		if ( arg.includes( ' ' ) ) {
+		if ( arg.includes( ' ' ) && ! isJsonObject( arg ) ) {
 			return `"${ arg }"`;
 		}
 
 		return arg;
 	} );
+}
+
+export function isJsonObject( str: string ): boolean {
+	return typeof str === 'string' && str.startsWith( '{' ) && isJson( str );
+}
+
+export function isJson( str: string ): boolean {
+	try {
+		JSON.parse( str );
+	} catch ( error ) {
+		return false;
+	}
+	return true;
 }
 
 export function capitalize( str: string ): string {

--- a/src/lib/cli/format.js
+++ b/src/lib/cli/format.js
@@ -131,7 +131,7 @@ export function requoteArgs( args: Array<string> ): Array<string> {
 }
 
 export function isJsonObject( str: string ): boolean {
-	return typeof str === 'string' && str.startsWith( '{' ) && isJson( str );
+	return typeof str === 'string' && str.trim().startsWith( '{' ) && isJson( str );
 }
 
 export function isJson( str: string ): boolean {


### PR DESCRIPTION
## Description

This PR improves how CLI handles commands that include JSON objects with spaces.

An example of this is this command
```
vip <environment> -- wp option update test '{"json":"json with spaces"}' --format=json
===================================
+ command: wp option update test "{"json":"json with spaces"}" --format=json
===================================
Error: Too many positional arguments: with spaces}
```

This PR introduces the same behaviour we have on [the cron runner](https://github.com/Automattic/cron-control-runner/blob/trunk/remote/remote.go#L436) by checking if the argument might be a JSON object, and only if it is a valid JSON object, it skips the quoting.

## Steps to Test

1. Check out PR.
1. Run `npm run build`
1. Run `node ./dist/bin/vip-wp <environment> -- option update test '{"json":"json with spaces"}' --format=json`
1. No error should be raised

