### PR TITLE
chore(deps): Pin @apollo/client to 3.3.6

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -10,7 +10,7 @@
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
-        "@apollo/client": "^3.3.6",
+        "@apollo/client": "3.3.6",
         "@automattic/vip-go-preflight-checks": "^2.0.16",
         "@automattic/vip-search-replace": "^1.0.15",
         "args": "5.0.3",

--- a/package.json
+++ b/package.json
@@ -109,7 +109,7 @@
     "rimraf": "3.0.2"
   },
   "dependencies": {
-    "@apollo/client": "^3.3.6",
+    "@apollo/client": "3.3.6",
     "@automattic/vip-go-preflight-checks": "^2.0.16",
     "@automattic/vip-search-replace": "^1.0.15",
     "args": "5.0.3",


### PR DESCRIPTION
## Description

Ref: #1239 

This PR pins `@apollo/client` to 3.3.6 to avoid unintentional updates when npm processes other dependencies.

## Steps to Test

No changes to test.
