### PR TITLE
refactor(dev-env): Do not use Lando's memcached plugin

### DIFF
--- a/assets/dev-env.lando.template.yml.ejs
+++ b/assets/dev-env.lando.template.yml.ejs
@@ -77,10 +77,14 @@ services:
       database_data:
 
   memcached:
-    type: memcached:custom
-    overrides:
+    type: compose
+    services:
       image: memcached:1.6-alpine3.16
-      command: docker-entrypoint.sh memcached
+      command: memcached -m 64
+      environment:
+        LANDO_NO_USER_PERMS: 1
+        LANDO_NO_SCRIPTS: 1
+        LANDO_NEEDS_EXEC: 1
 
 <% if ( phpmyadmin ) { %>
   phpmyadmin:

--- a/src/lib/dev-environment/dev-environment-lando.js
+++ b/src/lib/dev-environment/dev-environment-lando.js
@@ -71,7 +71,6 @@ function getLandoConfig() {
 			// Plugins we need:
 			// '@lando/compose',
 			// '@lando/mailhog',
-			// '@lando/memcached',
 			// '@lando/phpmyadmin',
 			// The rest we don't need
 			'@lando/acquia',
@@ -89,6 +88,7 @@ function getLandoConfig() {
 			'@lando/lemp',
 			'@lando/mariadb',
 			'@lando/mean',
+			'@lando/memcached',
 			'@lando/mongo',
 			'@lando/mssql',
 			'@lando/mysql',


### PR DESCRIPTION
## Description

This PR removes Lando's memcached plugin (`@lando/memcached`) and uses the `compose` service to provide the removed functionality.

As a result, we have minus one dependency and a bit faster startup.

## Steps to Test

The change is covered by E2E tests.
