### PR TITLE
fix(dev-env): ElasticSearch => Elasticsearch

### DIFF
--- a/__tests__/devenv-e2e/001-create.spec.js
+++ b/__tests__/devenv-e2e/001-create.spec.js
@@ -66,7 +66,7 @@ describe( 'vip dev-env create', () => {
 		const slug = getProjectSlug();
 		const expectedMultisite = false;
 		const expectedPhpVersion = '8.0';
-		const expectedElasticSearch = false;
+		const expectedElasticsearch = false;
 		const expectedMailHog = false;
 
 		expect( await checkEnvExists( slug ) ).toBe( false );
@@ -82,7 +82,7 @@ describe( 'vip dev-env create', () => {
 			multisite: expectedMultisite,
 			mariadb: '10.3',
 			mediaRedirectDomain: '',
-			elasticsearch: expectedElasticSearch,
+			elasticsearch: expectedElasticsearch,
 			xdebugConfig: '',
 			php: expect.stringContaining( `:${ expectedPhpVersion }` ),
 			muPlugins: { mode: 'image' },
@@ -102,7 +102,7 @@ describe( 'vip dev-env create', () => {
 		const expectedMultisite = true;
 		const expectedPhpVersion = '8.0';
 		const expectedWordPressVersion = '6.1';
-		const expectedElasticSearch = true;
+		const expectedElasticsearch = true;
 		const expectedPhpMyAdmin = true;
 		const expectedXDebug = true;
 		const expectedMailHog = true;
@@ -119,7 +119,7 @@ describe( 'vip dev-env create', () => {
 			'--php', expectedPhpVersion,
 			'--wordpress', expectedWordPressVersion,
 			'--mu-plugins', 'image',
-			'-e', `${ expectedElasticSearch }`,
+			'-e', `${ expectedElasticsearch }`,
 			'-p', `${ expectedPhpMyAdmin }`,
 			'-x', `${ expectedXDebug }`,
 			'--mailhog', `${ expectedMailHog }`,
@@ -134,7 +134,7 @@ describe( 'vip dev-env create', () => {
 			multisite: expectedMultisite,
 			mariadb: '10.3',
 			mediaRedirectDomain: '',
-			elasticsearch: expectedElasticSearch,
+			elasticsearch: expectedElasticsearch,
 			xdebugConfig: '',
 			php: expect.stringContaining( `:${ expectedPhpVersion }` ),
 			muPlugins: expect.objectContaining( { mode: 'image' } ), // BUG: our code adds `{ tag: 'image' }`

--- a/__tests__/devenv-e2e/005-update.spec.js
+++ b/__tests__/devenv-e2e/005-update.spec.js
@@ -65,7 +65,7 @@ describe( 'vip dev-env update', () => {
 
 	it( 'should update the environment', async () => {
 		const slug = getProjectSlug();
-		const expectedElasticSearch = false;
+		const expectedElasticsearch = false;
 		const expectedPhpMyAdmin = false;
 		const expectedXDebug = false;
 		const expectedMailHog = false;
@@ -79,7 +79,7 @@ describe( 'vip dev-env update', () => {
 		const dataBefore = readEnvironmentData( slug );
 		expect( dataBefore ).toMatchObject( {
 			siteSlug: slug,
-			elasticsearch: expectedElasticSearch,
+			elasticsearch: expectedElasticsearch,
 			mailhog: expectedMailHog,
 		} );
 
@@ -90,7 +90,7 @@ describe( 'vip dev-env update', () => {
 		result = await cliTest.spawn( [
 			process.argv[ 0 ], vipDevEnvUpdate,
 			'--slug', slug,
-			'-e', `${ ! expectedElasticSearch }`,
+			'-e', `${ ! expectedElasticsearch }`,
 			'-p', `${ ! expectedPhpMyAdmin }`,
 			'-x', `${ ! expectedXDebug }`,
 			'--mailhog', `${ ! expectedMailHog }`,
@@ -101,7 +101,7 @@ describe( 'vip dev-env update', () => {
 		const dataAfter = readEnvironmentData( slug );
 		expect( dataAfter ).toMatchObject( {
 			siteSlug: slug,
-			elasticsearch: ! expectedElasticSearch,
+			elasticsearch: ! expectedElasticsearch,
 			phpmyadmin: ! expectedPhpMyAdmin,
 			xdebug: ! expectedXDebug,
 			mailhog: ! expectedMailHog,

--- a/src/bin/vip-dev-env-import-sql.js
+++ b/src/bin/vip-dev-env-import-sql.js
@@ -105,7 +105,7 @@ command( {
 
 			try {
 				await exec( lando, slug, [ 'wp', 'cli', 'has-command', 'vip-search' ] );
-				const doIndex = await promptForBoolean( 'Do you want to index data in Elasticsearch (used by enterprise search)?', true );
+				const doIndex = await promptForBoolean( 'Do you want to index data in Elasticsearch (used by Enterprise Search)?', true );
 				if ( doIndex ) {
 					await exec( lando, slug, [ 'wp', 'vip-search', 'index', '--setup', '--network-wide', '--skip-confirm' ] );
 				}

--- a/src/bin/vip-dev-env-import-sql.js
+++ b/src/bin/vip-dev-env-import-sql.js
@@ -105,7 +105,7 @@ command( {
 
 			try {
 				await exec( lando, slug, [ 'wp', 'cli', 'has-command', 'vip-search' ] );
-				const doIndex = await promptForBoolean( 'Do you want to index data in ElasticSearch (used by enterprise search)?', true );
+				const doIndex = await promptForBoolean( 'Do you want to index data in Elasticsearch (used by enterprise search)?', true );
 				if ( doIndex ) {
 					await exec( lando, slug, [ 'wp', 'vip-search', 'index', '--setup', '--network-wide', '--skip-confirm' ] );
 				}


### PR DESCRIPTION
## Description

This PR fixes a typo.

## Steps to Test

`vip dev-env import sql` on ES-enabled environment should ask

```
Do you want to index data in Elasticsearch (used by enterprise search)?
```

instead of 

```
Do you want to index data in ElasticSearch (used by Enterprise Search)?
```
