### PR TITLE
feat(dev-env): Implement upgrade path for changes affecting .lando.yml

### DIFF
--- a/__tests__/devenv-e2e/001-create.spec.js
+++ b/__tests__/devenv-e2e/001-create.spec.js
@@ -67,6 +67,8 @@ describe( 'vip dev-env create', () => {
 		const expectedMultisite = false;
 		const expectedPhpVersion = '8.0';
 		const expectedElasticsearch = false;
+		const expectedPhpMyAdmin = false;
+		const expectedXDebug = false;
 		const expectedMailHog = false;
 
 		expect( await checkEnvExists( slug ) ).toBe( false );
@@ -88,12 +90,10 @@ describe( 'vip dev-env create', () => {
 			muPlugins: { mode: 'image' },
 			appCode: { mode: 'image' },
 			wordpress: expect.objectContaining( { mode: 'image', tag: expect.any( String ) } ),
+			phpmyadmin: expectedPhpMyAdmin,
+			xdebug: expectedXDebug,
 			mailhog: expectedMailHog,
 		} );
-
-		// Our bugs :-)
-		expect( data ).not.toHaveProperty( 'phpmyadmin' );
-		expect( data ).not.toHaveProperty( 'xdebug' );
 	} );
 
 	it( 'should be configurable via command line', async () => {

--- a/__tests__/devenv-e2e/005-update.spec.js
+++ b/__tests__/devenv-e2e/005-update.spec.js
@@ -80,12 +80,10 @@ describe( 'vip dev-env update', () => {
 		expect( dataBefore ).toMatchObject( {
 			siteSlug: slug,
 			elasticsearch: expectedElasticsearch,
+			phpmyadmin: expectedPhpMyAdmin,
+			xdebug: expectedXDebug,
 			mailhog: expectedMailHog,
 		} );
-
-		// Our bugs :-)
-		expect( dataBefore ).not.toHaveProperty( 'phpmyadmin' );
-		expect( dataBefore ).not.toHaveProperty( 'xdebug' );
 
 		result = await cliTest.spawn( [
 			process.argv[ 0 ], vipDevEnvUpdate,

--- a/__tests__/devenv-e2e/006-list.spec.js
+++ b/__tests__/devenv-e2e/006-list.spec.js
@@ -99,6 +99,7 @@ describe( 'vip dev-env list', () => {
 		expect( result2.stdout ).toContain( 'could not find app in this dir' );
 		expect( result2.stderr ).toContain( 'There was an error initializing Lando, trying to recover' );
 		expect( result2.stderr ).toContain( 'Recovery successful, trying to initialize again' );
+		expect( result2.stderr ).not.toContain( 'Backed up' );
 	} );
 
 	it( 'should be able to handle corrupt .lando.yml', async () => {
@@ -125,6 +126,7 @@ describe( 'vip dev-env list', () => {
 		expect( result2.stdout ).toContain( 'composer is not a supported service type' );
 		expect( result2.stderr ).toContain( 'There was an error initializing Lando, trying to recover' );
 		expect( result2.stderr ).toContain( 'Recovery successful, trying to initialize again' );
+		expect( result2.stderr ).toContain( 'Backed up' );
 	} );
 
 	describe( 'for started environments', () => {

--- a/src/lib/dev-environment/dev-environment-core.js
+++ b/src/lib/dev-environment/dev-environment-core.js
@@ -168,6 +168,14 @@ function preProcessInstanceData( instanceData: InstanceData ): InstanceData {
 		newInstanceData.xdebugConfig = '';
 	}
 
+	if ( ! newInstanceData.xdebug ) {
+		newInstanceData.xdebug = false;
+	}
+
+	if ( ! newInstanceData.phpmyadmin ) {
+		newInstanceData.phpmyadmin = false;
+	}
+
 	// Mailhog migration
 	if ( ! newInstanceData.mailhog ) {
 		newInstanceData.mailhog = false;

--- a/src/lib/dev-environment/dev-environment-lando.js
+++ b/src/lib/dev-environment/dev-environment-lando.js
@@ -120,6 +120,45 @@ async function getLandoConfig() {
 
 const appMap: Map<string, App> = new Map();
 
+async function regenerateLandofile( instancePath: string ): Promise<void> {
+	const landoFile = path.join( instancePath, '.lando.yml' );
+
+	try {
+		const now = new Date().toISOString().replace( /[^\d]/g, '' ).slice( 0, -3 );
+		const backup = `${ landoFile }.${ now }`;
+		await fs.promises.rename( landoFile, backup );
+		console.warn( chalk.yellow( 'Backed up %s to %s' ), landoFile, backup );
+	} catch ( err ) {
+		// Rename failed - possible the file does not exist. Silently ignoring.
+	}
+
+	const slug = path.basename( instancePath );
+	const currentInstanceData = readEnvironmentData( slug );
+	await updateEnvironment( currentInstanceData );
+}
+
+async function landoRecovery( lando: Lando, instancePath: string, error: Error ): Promise<App> {
+	debug( 'Error initializing Lando app', error );
+	console.warn( chalk.yellow( 'There was an error initializing Lando, trying to recover...' ) );
+	try {
+		await regenerateLandofile( instancePath );
+	} catch ( err ) {
+		console.error( `${ chalk.bold.red( 'Recovery failed, aborting.' ) } Please recreate the environment or contact support.` );
+		throw err;
+	}
+
+	console.error( chalk.green( 'Recovery successful, trying to initialize again...' ) );
+	try {
+		const app = lando.getApp( instancePath );
+		addHooks( app, lando );
+		await app.init();
+		return app;
+	} catch ( initError ) {
+		console.error( `${ chalk.bold.red( 'Initialization failed, aborting.' ) } Please recreate the environment or contact support.` );
+		throw initError;
+	}
+}
+
 async function getLandoApplication( lando: Lando, instancePath: string ): Promise<App> {
 	if ( appMap.has( instancePath ) ) {
 		return Promise.resolve( appMap.get( instancePath ) );
@@ -136,26 +175,7 @@ async function getLandoApplication( lando: Lando, instancePath: string ): Promis
 		addHooks( app, lando );
 		await app.init();
 	} catch ( error ) {
-		debug( 'Error initializing Lando app', error );
-		console.warn( chalk.yellow( 'There was an error initializing Lando, trying to recover...' ) );
-		try {
-			const slug = path.basename( instancePath );
-			const currentInstanceData = readEnvironmentData( slug );
-			await updateEnvironment( currentInstanceData );
-		} catch ( err ) {
-			console.error( `${ chalk.bold.red( 'Recovery failed, aborting.' ) } Please recreate the environment or contact support.` );
-			throw err;
-		}
-
-		console.error( chalk.green( 'Recovery successful, trying to initialize again...' ) );
-		try {
-			app = lando.getApp( instancePath );
-			addHooks( app, lando );
-			await app.init();
-		} catch ( initError ) {
-			console.error( `${ chalk.bold.red( 'Initialization failed, aborting.' ) } Please recreate the environment or contact support.` );
-			throw initError;
-		}
+		app = await landoRecovery( lando, instancePath, error );
 	}
 
 	appMap.set( instancePath, app );


### PR DESCRIPTION
## Description

Ref: #1245, #1248

This PR implements recovery logic in case Lando has troubles reading its `.lando.yml` file. We simply recreate it using the instance data.

## Steps to Test

Create a dev environment and corrupt its `.lando.yml`, for example, like this:

```diff
 services:
 
   devtools:
-    type: compose
+    type: composer
     services:
```

Don't limit your creativity; the only condition is that Lando should fail when reading the file (you can use `vip dev-env list` to verify that Lando crashes).

The error you see may look like this:
```
WARN ==> composer is not a supported service type. 
TypeError: Cannot read properties of undefined (reading 'builder')
```

Apply the patch. Try `vip dev-env list` again. You should see something like this:
```
WARN ==> composer is not a supported service type. 
There was an error initializing Lando, trying to recover...
Recovery successful, trying to initialize again...
 SLUG           vip-local                                                                           
 LOCATION       /home/volodymyr/.local/share/vip/dev-environment/vip-local                          
 SERVICES       devtools, nginx, php, database, memcached, wordpress, vip-mu-plugins, demo-app-code 
 STATUS         DOWN                                                                                
 DOCUMENTATION  https://docs.wpvip.com/technical-references/vip-local-development-environment/      
```

UPD: another scenario is to remove `.lando.yml` and ensure that the system regenerates it.