### PR TITLE
fix(dev-env): Fix "This app was built on a different version of Lando" warning

### DIFF
--- a/src/lib/dev-environment/dev-environment-lando.js
+++ b/src/lib/dev-environment/dev-environment-lando.js
@@ -110,6 +110,7 @@ async function getLandoConfig() {
 		userConfRoot: landoDir,
 		home: fakeHomeDir,
 		domain: 'lndo.site',
+		version: 'unknown',
 	};
 }
 


### PR DESCRIPTION
## Description

This PR fixes this meaningless and annoying warning.

It happened because we ded not pass the "version" key to Lando; it then tried to compare `"unknown"` to `undefined`, the result was `false`, Lando complained.

If we explicitly pass `unknown` as the `version`, everyting is OK.

## Steps to Test

Create and start a new environment and make sure this warning does not appear. It may appear for old environments because Lando caches meta data. It may take a couple of restarts to clear that warning.
