### PR TITLE
fix(dev-env): Get more verbose logs from Lando in debug mode

### DIFF
--- a/src/lib/dev-environment/dev-environment-lando.js
+++ b/src/lib/dev-environment/dev-environment-lando.js
@@ -44,8 +44,8 @@ async function getLandoConfig() {
 
 	debug( `Getting lando config, using paths '${ landoPath }' and '${ atLandoPath }' for plugins` );
 
-	const isLandoDebugSelected = ( process.env.DEBUG || '' ).includes( DEBUG_KEY );
-	const isAllDebugSelected = process.env.DEBUG === '*';
+	const isLandoDebugSelected = debugLib.enabled( DEBUG_KEY );
+	const isAllDebugSelected = debugLib.enabled( '"*"' );
 	let logLevelConsole;
 	if ( isAllDebugSelected ) {
 		logLevelConsole = 'silly';

--- a/src/lib/dev-environment/dev-environment-lando.js
+++ b/src/lib/dev-environment/dev-environment-lando.js
@@ -46,7 +46,14 @@ async function getLandoConfig() {
 
 	const isLandoDebugSelected = ( process.env.DEBUG || '' ).includes( DEBUG_KEY );
 	const isAllDebugSelected = process.env.DEBUG === '*';
-	const logLevelConsole = ( isAllDebugSelected || isLandoDebugSelected ) ? 'debug' : 'warn';
+	let logLevelConsole;
+	if ( isAllDebugSelected ) {
+		logLevelConsole = 'silly';
+	} else if ( isLandoDebugSelected ) {
+		logLevelConsole = 'debug';
+	} else {
+		logLevelConsole = 'warn';
+	}
 
 	const vipDir = path.join( xdgBasedir.data || os.tmpdir(), 'vip' );
 	const landoDir = path.join( vipDir, 'lando' );


### PR DESCRIPTION
## Description

The current log level is not very useful when it comes to debugging issues with `docker`, `docker-compose` or Lando internals, because Lando does not display the most useful low level things.

This PR sets the log level to `silly`, which allows us to capture a lot of useful things.

The logic is:
  * `DEBUG=*`: log level is `silly`;
  * ` --debug @automattic/vip:bin:dev-environment`: log level is `debug`;
  * otherwise, log level is `warn`.

## Steps to Test

Run `DEBUG=* vip dev-env list` and observe `SILLY` in the output.
