### PR TITLE
Config Software: fix small typo in "include" usage

### DIFF
--- a/src/bin/vip-config-software-get.js
+++ b/src/bin/vip-config-software-get.js
@@ -40,7 +40,7 @@ command( {
 	wildcardCommand: true,
 	format: true,
 	usage: 'vip @mysite.develop config software get <wordpress|php|nodejs|muplugins>',
-} ).option( 'include', `Extra information to be included. Valida values: ${ VALID_INCLUDES.join( ',' ) }` )
+} ).option( 'include', `Extra information to be included. Valid values: ${ VALID_INCLUDES.join( ',' ) }` )
 	.examples( examples ).argv( process.argv, async ( arg: string[], opt ) => {
 		const trackingInfo = {
 			environment_id: opt.env?.id,


### PR DESCRIPTION
## Description

Just a small fix in a usage example: `valida` to `valid`

## Steps to Test

1. Check out PR.
1. Run `npm run build`
1. Run `./dist/bin/vip-config-software-get.js @1234.envname --include blah`
1. Verify proper example is printed

