### PR TITLE
fix(dev-env): Gracefully handle failures to fetch WP versions

### DIFF
--- a/src/lib/dev-environment/dev-environment-core.js
+++ b/src/lib/dev-environment/dev-environment-core.js
@@ -540,6 +540,10 @@ export async function importMediaPath( slug: string, filePath: string ) {
  */
 async function updateWordPressImage( slug: string ): Promise<boolean> {
 	const versions = await getVersionList();
+	if ( ! versions.length ) {
+		return false;
+	}
+
 	let message: string, envData, currentWordPressTag: string;
 
 	// Get the current environment configuration
@@ -627,9 +631,9 @@ async function updateWordPressImage( slug: string ): Promise<boolean> {
 /**
  * Makes a web call to raw.githubusercontent.com
  */
-export async function fetchVersionList(): Promise<string> {
+export async function fetchVersionList(): Promise<any> {
 	const url = `https://${ DEV_ENVIRONMENT_RAW_GITHUB_HOST }${ DEV_ENVIRONMENT_WORDPRESS_VERSIONS_URI }`;
-	return fetch( url ).then( res => res.text() );
+	return fetch( url ).then( res => res.json() );
 }
 
 /**
@@ -666,7 +670,7 @@ export async function getVersionList(): Promise<WordPressTag[]> {
 		// If the cache is expired, refresh it
 		if ( ! fs.existsSync( cacheFile ) || isVersionListExpired( cacheFile, DEV_ENVIRONMENT_WORDPRESS_VERSION_TTL ) ) {
 			res = await fetchVersionList();
-			await fs.promises.writeFile( cacheFile, res );
+			await fs.promises.writeFile( cacheFile, JSON.stringify( res ) );
 		}
 	} catch ( err ) {
 		// Soft error handling here, since it's still possible to use a previously cached file.


### PR DESCRIPTION
## Description

This PR does two things:
1. It adds the logic to handle the case when the list of WP versions is empty (e.g., due to a failure).
2. It makes sure that we don't store non-JSON responses from WP API as a version cache

## Steps to Test

1. Corrupt the `.local/share/vip/wordpress-versions.json` file
2. Try to start an environment

Without this path, it will fail with `Error: Cannot read properties of undefined (reading 'tag')`.

With the patch, it will skip this step:
```
The most recent WordPress version available is: 6.1
Environment WordPress version is: 6.1  ... 😎 nice! 
```

(Assuming that you corrupt the file right before starting the environment, VIP CLI will see the version file as fresh and won't try to refetch it. I have added a check to prevent corrupt data from being cached but, unfortunately, we can be in a situation when we already have a bad file).
