### PR TITLE
Dev-env: Fix WordPress version inputs for major releases ending in .0

### DIFF
--- a/__tests__/lib/dev-environment/dev-environment-cli.js
+++ b/__tests__/lib/dev-environment/dev-environment-cli.js
@@ -22,6 +22,7 @@ import {
 	promptForComponent,
 	promptForArguments,
 	setIsTTY,
+	processVersionOption,
 } from '../../../src/lib/dev-environment/dev-environment-cli';
 import * as devEnvCore from '../../../src/lib/dev-environment/dev-environment-core';
 
@@ -466,6 +467,38 @@ describe( 'lib/dev-environment/dev-environment-cli', () => {
 			const expectedMaria = input.preselected.mariadb ? input.preselected.mariadb : input.default.mariadb;
 
 			expect( result.mariadb ).toStrictEqual( expectedMaria );
+		} );
+	} );
+	describe( 'processVersionOption', () => {
+		it.each( [
+			{
+				preselected: {
+					wp: 'trunk',
+				},
+				expected: {
+					wp: 'trunk',
+				},
+			},
+			{
+				preselected: {
+					wp: '6',
+				},
+				expected: {
+					wp: '6.0',
+				},
+			},
+			{
+				preselected: {
+					wp: '6.1',
+				},
+				expected: {
+					wp: '6.1',
+				},
+			},
+		] )( 'should process versions correctly', async input => {
+			const version = processVersionOption( input.preselected.wp );
+
+			expect( version ).toStrictEqual( input.expected.wp );
 		} );
 	} );
 } );

--- a/src/lib/dev-environment/dev-environment-cli.js
+++ b/src/lib/dev-environment/dev-environment-cli.js
@@ -359,8 +359,13 @@ async function processComponent( component: string, preselectedValue: string, de
 	const allowLocal = component !== 'wordpress';
 	const defaultObject = defaultValue ? processComponentOptionInput( defaultValue, allowLocal ) : null;
 	if ( preselectedValue ) {
+		if ( component === 'wordpress' && preselectedValue.indexOf( '.' ) === -1 && ! isNaN( parseFloat( preselectedValue ) ) ) {
+			preselectedValue = parseFloat( preselectedValue ).toFixed( 1 ); // Major releases ending in .0 aren't parsed correctly. This converts it back to a valid version.
+		}
 		result = processComponentOptionInput( preselectedValue, allowLocal );
-		console.log( `${ chalk.green( '✓' ) } Path to your local ${ componentDisplayNames[ component ] }: ${ preselectedValue }` );
+		if ( allowLocal ) {
+			console.log( `${ chalk.green( '✓' ) } Path to your local ${ componentDisplayNames[ component ] }: ${ preselectedValue }` );
+		}
 	} else {
 		result = await promptForComponent( component, allowLocal, defaultObject );
 	}

--- a/src/lib/dev-environment/dev-environment-cli.js
+++ b/src/lib/dev-environment/dev-environment-cli.js
@@ -626,22 +626,22 @@ export async function getTagChoices(): Promise<{ name: string, message: string, 
 	let versions = await getVersionList();
 	if ( versions.length < 1 ) {
 		versions = [ {
+			ref: '6.1.1',
+			tag: '6.1',
+			cacheable: true,
+			locked: true,
+			prerelease: false,
+		},
+		{
+			ref: '6.0.3',
+			tag: '6.0',
+			cacheable: true,
+			locked: true,
+			prerelease: false,
+		},
+		{
 			ref: '5.9.5',
 			tag: '5.9',
-			cacheable: true,
-			locked: true,
-			prerelease: false,
-		},
-		{
-			ref: '5.8.6',
-			tag: '5.8',
-			cacheable: true,
-			locked: true,
-			prerelease: false,
-		},
-		{
-			ref: '5.7.8',
-			tag: '5.7',
 			cacheable: true,
 			locked: true,
 			prerelease: false,

--- a/src/lib/dev-environment/dev-environment-cli.js
+++ b/src/lib/dev-environment/dev-environment-cli.js
@@ -134,6 +134,11 @@ const VALIDATION_STEPS = [
 	{ id: 'dns', name: 'Check DNS resolution' },
 ];
 
+const DEFAULT_OPTS = {
+	php: '8.0',
+	wp: 'trunk',
+};
+
 export const validateDependencies = async ( lando: Lando, slug: string, quiet?: boolean ) => {
 	const now = new Date();
 	const steps = slug ? VALIDATION_STEPS : VALIDATION_STEPS.filter( step => step.id !== 'dns' );
@@ -611,7 +616,7 @@ export function processVersionOption( value: string ): string {
 
 export function addDevEnvConfigurationOptions( command: Command ): any {
 	return command
-		.option( 'wordpress', 'Use a specific WordPress version', undefined, processVersionOption )
+		.option( 'wordpress', 'Use a specific WordPress version', DEFAULT_OPTS.wp, processVersionOption )
 		.option( [ 'u', 'mu-plugins' ], 'Use a specific mu-plugins changeset or local directory' )
 		.option( 'app-code', 'Use the application code from a local directory or use "demo" for VIP skeleton code' )
 		.option( 'phpmyadmin', 'Enable PHPMyAdmin component. By default it is disabled', undefined, processBooleanOption )
@@ -620,7 +625,7 @@ export function addDevEnvConfigurationOptions( command: Command ): any {
 		.option( 'elasticsearch', 'Enable Elasticsearch (needed by Enterprise Search)', undefined, processBooleanOption )
 		.option( 'mariadb', 'Explicitly choose MariaDB version to use' )
 		.option( [ 'r', 'media-redirect-domain' ], 'Domain to redirect for missing media files. This can be used to still have images without the need to import them locally.' )
-		.option( 'php', 'Explicitly choose PHP version to use', undefined, processVersionOption )
+		.option( 'php', 'Explicitly choose PHP version to use', DEFAULT_OPTS.php, processVersionOption )
 		.option( [ 'A', 'mailhog' ], 'Enable MailHog. By default it is disabled', undefined, processBooleanOption );
 }
 


### PR DESCRIPTION
## Description
When we pass in major versions ending in `.0`, it doesn't parse it correctly to the matching tag. It also logs it as `✓ Path to your local WordPress:`. This PR fixes that for `--wordpress` and `--php` parameters by adding `processVersionOption()`

Also updates `getTagChoices()` to use the latest WP Versions (if none found) since it was outdated.

## Steps to Test

0) Check out PR
1) `npm run build`
2) `./dist/bin/vip-dev-env-create.js --app-code ~/vipdev/vip-go-skeleton --mu-plugins ~/vipdev/vip-go-mu-plugins --elasticsearch true --mailhog=false --wordpress=6.0 --php=8.0 --xdebug false --phpmyadmin false --multisite false`
3) Observe no `✓ Path to your local WordPress: 6` in the output
4) `vip dev-env start` and ensure that it doesn't throw an error about the image not existing