### PR TITLE
Dev-env: Do not prompt to update WP version if trunk is used

### DIFF
--- a/src/lib/dev-environment/dev-environment-core.js
+++ b/src/lib/dev-environment/dev-environment-core.js
@@ -535,7 +535,7 @@ export async function importMediaPath( slug: string, filePath: string ) {
  *   - If there is a newer version of the WordPress version currently used
  *   - A choice to use a different image
  *
- * @param {Object=} slug slug
+ * @param {string} slug slug
  * @return {boolean} boolean
  */
 async function updateWordPressImage( slug: string ): Promise<boolean> {

--- a/src/lib/dev-environment/dev-environment-core.js
+++ b/src/lib/dev-environment/dev-environment-core.js
@@ -550,6 +550,9 @@ async function updateWordPressImage( slug: string ): Promise<boolean> {
 	try {
 		envData = readEnvironmentData( slug );
 		currentWordPressTag = envData.wordpress.tag;
+		if ( currentWordPressTag === 'trunk' ) {
+			return false;
+		}
 	} catch ( error ) {
 		// This can throw an exception if the env is build with older vip version
 		if ( 'ENOENT' === error.code ) {


### PR DESCRIPTION
## Description

It doesn't make sense to prompt the user to update if they pass in `trunk` as their WP version.

## Steps to Test

1) `npm run build`
2) `vip dev-env create  --app-code=~/vipdev/vip-go-skeleton --mu-plugins=~/vipdev/vip-go-mu-plugins --elasticsearch=true --mailhog=false --wordpress=trunk --php=8.0 --xdebug=false --phpmyadmin=false --multisite=false --debug --slug=test`
3) `./dist/bin/vip-dev-env-start.js --slug=test`
4) Expect no prompt from step 3)