### PR TITLE
feature(dev-env): Add dev-env-sync-sql command

### DIFF
--- a/__tests__/commands/dev-env-sync-sql.js
+++ b/__tests__/commands/dev-env-sync-sql.js
@@ -85,11 +85,11 @@ describe( 'commands/DevEnvSyncSQLCommand', () => {
 	describe( '.runSearchReplace', () => {
 		it( 'should run search-replace operation on the SQL file', async () => {
 			const cmd = new DevEnvSyncSQLCommand( app, env, 'test-slug' );
-			cmd.siteUrls = [ 'test.go-vip.com' ];
+			cmd.siteUrls = [ '//test.go-vip.com' ];
 			cmd.slug = 'test-slug';
 
 			await cmd.runSearchReplace();
-			expect( replace ).toHaveBeenCalledWith( mockReadStream, [ 'test.go-vip.com', 'test-slug.vipdev.lndo.site' ] );
+			expect( replace ).toHaveBeenCalledWith( mockReadStream, [ '//test.go-vip.com', '//test-slug.vipdev.lndo.site' ] );
 		} );
 	} );
 

--- a/__tests__/commands/dev-env-sync-sql.js
+++ b/__tests__/commands/dev-env-sync-sql.js
@@ -44,6 +44,7 @@ const mockWriteStream = getMockStream( [ { name: 'finish' } ], 20 );
 
 jest.spyOn( fs, 'createReadStream' ).mockReturnValue( mockReadStream );
 jest.spyOn( fs, 'createWriteStream' ).mockReturnValue( mockWriteStream );
+jest.spyOn( fs, 'renameSync' ).mockImplementation( () => {} );
 jest.mock( '@automattic/vip-search-replace', () => {
 	return {
 		replace: jest.fn(),

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -73,6 +73,8 @@
         "vip-dev-env-shell": "dist/bin/vip-dev-env-shell.js",
         "vip-dev-env-start": "dist/bin/vip-dev-env-start.js",
         "vip-dev-env-stop": "dist/bin/vip-dev-env-stop.js",
+        "vip-dev-env-sync": "dist/bin/vip-dev-env-sync.js",
+        "vip-dev-env-sync-sql": "dist/bin/vip-dev-env-sync-sql.js",
         "vip-dev-env-update": "dist/bin/vip-dev-env-update.js",
         "vip-export": "dist/bin/vip-export.js",
         "vip-export-sql": "dist/bin/vip-export-sql.js",

--- a/package.json
+++ b/package.json
@@ -35,6 +35,8 @@
     "vip-dev-env-logs": "dist/bin/vip-dev-env-logs.js",
     "vip-export": "dist/bin/vip-export.js",
     "vip-export-sql": "dist/bin/vip-export-sql.js",
+    "vip-dev-env-sync": "dist/bin/vip-dev-env-sync.js",
+    "vip-dev-env-sync-sql": "dist/bin/vip-dev-env-sync-sql.js",
     "vip-import": "dist/bin/vip-import.js",
     "vip-import-media": "dist/bin/vip-import-media.js",
     "vip-import-media-abort": "dist/bin/vip-import-media-abort.js",

--- a/src/bin/vip-dev-env-sync-sql.js
+++ b/src/bin/vip-dev-env-sync-sql.js
@@ -1,0 +1,62 @@
+#!/usr/bin/env node
+
+/**
+ * @flow
+ * @format
+ */
+
+/**
+ * External dependencies
+ */
+
+/**
+ * Internal dependencies
+ */
+import command from '../lib/cli/command';
+import { getEnvironmentPath } from '../lib/dev-environment/dev-environment-core';
+import { bootstrapLando, isEnvUp } from '../lib/dev-environment/dev-environment-lando';
+import UserError from '../lib/user-error';
+import { DevEnvSyncSQLCommand } from '../lib/dev-environment/dev-environment-sync-sql';
+import { DEV_ENVIRONMENT_FULL_COMMAND } from '../lib/constants/dev-environment';
+
+const examples = [
+	{
+		usage: `${ DEV_ENVIRONMENT_FULL_COMMAND } sync sql @my-test.develop --slug=my_site`,
+		description: 'Syncs with the `my-test` site\'s `develop` environment database into `my_site`',
+	},
+];
+
+const appQuery = `
+	id,
+	name,
+	type,
+	organization { id, name },
+	environments{
+		id
+		appId
+		type
+		name
+		primaryDomain { name }
+	}
+`;
+
+command( {
+	appContext: true,
+	appQuery,
+	envContext: true,
+	requiredArgs: 0,
+	module: 'dev-env-sync-sql',
+} )
+	.option( 'slug', 'Custom name of the dev environment' )
+	.examples( examples )
+	.argv( process.argv, async ( arg: string[], { app, env, slug } ) => {
+		const lando = await bootstrapLando();
+		const envPath = getEnvironmentPath( slug );
+
+		if ( ! await isEnvUp( lando, envPath ) ) {
+			throw new UserError( 'Environment needs to be started first' );
+		}
+
+		const cmd = new DevEnvSyncSQLCommand( app, env, slug );
+		await cmd.run();
+	} );

--- a/src/bin/vip-dev-env-sync-sql.js
+++ b/src/bin/vip-dev-env-sync-sql.js
@@ -8,6 +8,7 @@
 /**
  * External dependencies
  */
+import chalk from 'chalk';
 
 /**
  * Internal dependencies
@@ -39,6 +40,7 @@ const appQuery = `
 		name
 		primaryDomain { name }
 		uniqueLabel
+		isMultisite
 	}
 `;
 
@@ -54,6 +56,20 @@ command( {
 	.argv( process.argv, async ( arg: string[], { app, env, slug } ) => {
 		const trackerFn = makeCommandTracker( 'dev_env_sync_sql', { app: app.id, env: env.uniqueLabel, slug } );
 		await trackerFn( 'execute' );
+
+		if ( env.isMultisite ) {
+			console.log( chalk.yellow( 'You seem to be trying to sync a SQL database for a network site.' ) );
+			console.log( chalk.yellow( 'Unfortunately, the current version of our tool does not yet support syncing network sites.\n' ) );
+			console.log( chalk.yellow( 'However, you can manually export the database using the following command:' ) );
+			console.log( chalk.yellow( chalk.bold( `vip export sql @${ app.id }.${ env.uniqueLabel } --output=${ app.id }-${ env.uniqueLabel }-exported.sql.gz\n` ) ) );
+			console.log( chalk.yellow( 'After exporting the database, you\'ll need to perform the necessary search and replace operations on the exported file to update any relevant data or configurations.' ) );
+			console.log( chalk.yellow( 'See: https://docs.wpvip.com/how-tos/dev-env-add-content/#h-3-import-the-sql-file\n' ) );
+			console.log( chalk.yellow( 'Once you\'ve made the required changes, you can import the modified SQL file into your development environment using the following command:' ) );
+			console.log( chalk.yellow( chalk.bold( `vip dev-env import sql ${ app.id }-${ env.uniqueLabel }-exported.sql.gz --slug=${ slug }` ) ) );
+
+			await trackerFn( 'aborted', { error_type: 'multisite_not_supported' } );
+			process.exit( 0 );
+		}
 
 		const lando = await bootstrapLando();
 		const envPath = getEnvironmentPath( slug );

--- a/src/bin/vip-dev-env-sync-sql.js
+++ b/src/bin/vip-dev-env-sync-sql.js
@@ -59,7 +59,7 @@ command( {
 		const envPath = getEnvironmentPath( slug );
 
 		if ( ! await isEnvUp( lando, envPath ) ) {
-			await trackerFn( 'error', { errorMessage: 'Environment was not running' } );
+			await trackerFn( 'env_not_running_error', { errorMessage: 'Environment was not running' } );
 			throw new UserError( 'Environment needs to be started first' );
 		}
 

--- a/src/bin/vip-dev-env-sync-sql.js
+++ b/src/bin/vip-dev-env-sync-sql.js
@@ -16,7 +16,7 @@ import command from '../lib/cli/command';
 import { getEnvironmentPath } from '../lib/dev-environment/dev-environment-core';
 import { bootstrapLando, isEnvUp } from '../lib/dev-environment/dev-environment-lando';
 import UserError from '../lib/user-error';
-import { DevEnvSyncSQLCommand } from '../lib/dev-environment/dev-environment-sync-sql';
+import { DevEnvSyncSQLCommand } from '../commands/dev-env-sync-sql';
 import { DEV_ENVIRONMENT_FULL_COMMAND } from '../lib/constants/dev-environment';
 
 const examples = [

--- a/src/bin/vip-dev-env-sync-sql.js
+++ b/src/bin/vip-dev-env-sync-sql.js
@@ -37,6 +37,7 @@ const appQuery = `
 		type
 		name
 		primaryDomain { name }
+		uniqueLabel
 	}
 `;
 

--- a/src/bin/vip-dev-env-sync.js
+++ b/src/bin/vip-dev-env-sync.js
@@ -1,0 +1,21 @@
+#!/usr/bin/env node
+
+/**
+ * @flow
+ * @format
+ */
+
+/**
+ * External dependencies
+ */
+
+/**
+ * Internal dependencies
+ */
+import command from '../lib/cli/command';
+
+command( {
+	requiredArgs: 1,
+} )
+	.command( 'sql', 'Sync local database with a production environment' )
+	.argv( process.argv );

--- a/src/bin/vip-dev-env-sync.js
+++ b/src/bin/vip-dev-env-sync.js
@@ -13,9 +13,12 @@
  * Internal dependencies
  */
 import command from '../lib/cli/command';
+import { trackEvent } from '../lib/tracker';
 
 command( {
 	requiredArgs: 1,
 } )
 	.command( 'sql', 'Sync local database with a production environment' )
-	.argv( process.argv );
+	.argv( process.argv, async () => {
+		await trackEvent( 'dev_env_sync_command_execute' );
+	} );

--- a/src/bin/vip-dev-env-sync.js
+++ b/src/bin/vip-dev-env-sync.js
@@ -13,12 +13,9 @@
  * Internal dependencies
  */
 import command from '../lib/cli/command';
-import { trackEvent } from '../lib/tracker';
 
 command( {
 	requiredArgs: 1,
 } )
 	.command( 'sql', 'Sync local database with a production environment' )
-	.argv( process.argv, async () => {
-		await trackEvent( 'dev_env_sync_command_execute' );
-	} );
+	.argv( process.argv );

--- a/src/bin/vip-dev-env.js
+++ b/src/bin/vip-dev-env.js
@@ -28,5 +28,5 @@ command( {
 	.command( 'import', 'Import data into a local WordPress environment' )
 	.command( 'shell', 'Spawns a shell in a dev environment' )
 	.command( 'logs', 'View logs from a local WordPress environment' )
-	.command( 'sync', 'Sync a local development environment with a production environment' )
+	.command( 'sync', 'Pull data from production to local development environment' )
 	.argv( process.argv );

--- a/src/bin/vip-dev-env.js
+++ b/src/bin/vip-dev-env.js
@@ -28,4 +28,5 @@ command( {
 	.command( 'import', 'Import data into a local WordPress environment' )
 	.command( 'shell', 'Spawns a shell in a dev environment' )
 	.command( 'logs', 'View logs from a local WordPress environment' )
+	.command( 'sync', 'Sync a local development environment with a production environment' )
 	.argv( process.argv );

--- a/src/commands/dev-env-sync-sql.js
+++ b/src/commands/dev-env-sync-sql.js
@@ -124,10 +124,15 @@ export class DevEnvSyncSQLCommand {
 		const replacements = this.siteUrls.reduce( ( acc, url ) => [ ...acc, url, this.landoDomain ], [] );
 		const readStream = fs.createReadStream( this.sqlFile );
 		const replacedStream = await replace( readStream, replacements );
-		replacedStream.pipe( fs.createWriteStream( this.sqlFile ) );
+
+		const outputFile = `${ this.tmpDir }/sql-export-sr.sql`;
+		replacedStream.pipe( fs.createWriteStream( outputFile ) );
 
 		return new Promise( ( resolve, reject ) => {
-			replacedStream.on( 'finish', resolve );
+			replacedStream.on( 'finish', () => {
+				fs.renameSync( outputFile, this.sqlFile );
+				resolve();
+			} );
 			replacedStream.on( 'error', reject );
 		} );
 	}

--- a/src/commands/dev-env-sync-sql.js
+++ b/src/commands/dev-env-sync-sql.js
@@ -63,7 +63,7 @@ async function extractSiteUrls( sqlFile ) {
 		} );
 
 		readInterface.on( 'close', () => {
-			resolve( [ ...domains ] );
+			resolve( Array.from( domains ) );
 		} );
 
 		readInterface.on( 'error', reject );

--- a/src/commands/dev-env-sync-sql.js
+++ b/src/commands/dev-env-sync-sql.js
@@ -146,11 +146,10 @@ export class DevEnvSyncSQLCommand {
 	 */
 	async runImport() {
 		const importOptions = {
-			slug: this.slug,
 			inPlace: true,
 			skipValidate: true,
 		};
-		const importCommand = new DevEnvImportSQLCommand( this.sqlFile, importOptions );
+		const importCommand = new DevEnvImportSQLCommand( this.sqlFile, importOptions, this.slug );
 		await importCommand.run( true );
 	}
 

--- a/src/commands/dev-env-sync-sql.js
+++ b/src/commands/dev-env-sync-sql.js
@@ -174,7 +174,7 @@ export class DevEnvSyncSQLCommand {
 			await unzipFile( this.gzFile, this.sqlFile );
 			console.log( `${ chalk.green( '✓' ) } Extracted to ${ this.sqlFile }` );
 		} catch ( err ) {
-			await this.track( 'error', { errorMessage: 'Could not extract the exported SQL file' } );
+			await this.track( 'archive_extraction_error', { errorMessage: err?.message } );
 			exit.withError( `Error extracting the SQL export: ${ err?.message }` );
 		}
 
@@ -193,7 +193,7 @@ export class DevEnvSyncSQLCommand {
 			await this.runSearchReplace();
 			console.log( `${ chalk.green( '✓' ) } Search-replace operation is complete` );
 		} catch ( err ) {
-			await this.track( 'error', { errorMessage: 'Could not run the search-replace operation' } );
+			await this.track( 'search_replace_error', { errorMessage: err?.message } );
 			exit.withError( `Error replacing domains: ${ err?.message }` );
 		}
 
@@ -202,7 +202,7 @@ export class DevEnvSyncSQLCommand {
 			await this.runImport();
 			console.log( `${ chalk.green( '✓' ) } SQL file imported` );
 		} catch ( err ) {
-			await this.track( 'error', { errorMessage: 'Failed when importing the SQL file after search-replace operation' } );
+			await this.track( 'sql_import_error', { errorMessage: err?.message } );
 			exit.withError( `Error importing SQL file: ${ err?.message }` );
 		}
 	}

--- a/src/commands/dev-env-sync-sql.js
+++ b/src/commands/dev-env-sync-sql.js
@@ -202,7 +202,7 @@ export class DevEnvSyncSQLCommand {
 			await this.runImport();
 			console.log( `${ chalk.green( '✓' ) } SQL file imported` );
 		} catch ( err ) {
-			await this.track( 'sql_import_error', { errorMessage: err?.message } );
+			await this.track( 'import_error', { errorMessage: err?.message } );
 			exit.withError( `Error importing SQL file: ${ err?.message }` );
 		}
 	}


### PR DESCRIPTION
## Description

In this PR, we are adding a new command which synchronizes a local development environment into the latest SQL backup of a production site.

```bash
vip dev-env sync sql --slug=my-site @test-site.develop
```

The above is an example command which does the following:
- Checks if `my-site` exists and the containers are running in user's computer. If not, the command will exit.
- Generate and download the export of the latest backup 
- Extracts site-urls from the downloaded SQL export.
- Runs a search-replace operation to replace the site-urls with the lando domain.
- Imports the curated SQL file to the local database.

The implementation has assumed the following limitations, which will be addressed in subsequent work:

- Doesn't check for permission (and rely on the API to fail if the user does not have sufficient permission)
- Doesn't allow user to select network-sites

## Steps to Test

1. If you are an automattician and using proxy, run `VIP_PROXY=socks://localhost:8080`.
1. You need to have a local development instance of a site running in your computer. Run the following command if you don't have one:
`vip dev-env create --slug=<your-site> @<app>.<env> && vip dev-env start --slug=<your-site>` 
1. Run the following to test this PR:
`rm -rf dist && npm link && node ./dist/bin/vip dev-env sync sql --slug=<your-site> @<app>.<env>`.