### PR TITLE
fix(dev-env): Fix incorrect working directory when vip dev-env exec is run from a 8 level deep directory

### DIFF
--- a/src/lib/dev-environment/dev-environment-lando.js
+++ b/src/lib/dev-environment/dev-environment-lando.js
@@ -422,6 +422,7 @@ export async function landoExec( lando: Lando, instancePath: string, toolName: s
 
 		tool.app = app;
 		tool.name = toolName;
+		tool.dir = '/';
 
 		if ( options.stdio ) {
 			tool.stdio = options.stdio;


### PR DESCRIPTION
## Description

This PR provides the fix for the case when `vip dev-env exec` is run from a 8+ level deep directory.

## Steps to Test

```sh
mkdir -p ~/3/4/5/6/7/8
cd ~/3/4/5/6/7/8
vip dev-env exec --quiet -- wp option get home
```

Will fail without the patch, succeed with the patch.

