### PR TITLE
Revert "Remove use-database statement check"

### DIFF
--- a/__fixtures__/validations/bad-sql-dev-env.sql
+++ b/__fixtures__/validations/bad-sql-dev-env.sql
@@ -1,5 +1,6 @@
 CREATE DATABASE automatticians;
 
+-- for dev-env you should not switch database
 USE automatticians;
 
 INSERT INTO wp_options (option_name, option_value, autoload)

--- a/__tests__/lib/dev-environment/dev-environment-core.js
+++ b/__tests__/lib/dev-environment/dev-environment-core.js
@@ -22,7 +22,7 @@ import { getEnvironmentPath,
 	getApplicationInformation,
 	resolveImportPath,
 } from '../../../src/lib/dev-environment/dev-environment-core';
-import * as searchReplaceModule from '../../../src/lib/search-and-replace';
+import { searchAndReplace } from '../../../src/lib/search-and-replace';
 import { resolvePath } from '../../../src/lib/dev-environment/dev-environment-cli';
 import { DEV_ENVIRONMENT_NOT_FOUND } from '../../../src/lib/constants/dev-environment';
 import { bootstrapLando } from '../../../src/lib/dev-environment/dev-environment-lando';
@@ -31,8 +31,6 @@ jest.mock( 'xdg-basedir', () => ( {} ) );
 jest.mock( '../../../src/lib/api/app' );
 jest.mock( '../../../src/lib/search-and-replace' );
 jest.mock( '../../../src/lib/dev-environment/dev-environment-cli' );
-
-const { searchAndReplace } = searchReplaceModule;
 
 describe( 'lib/dev-environment/dev-environment-core', () => {
 	const cleanup = () => fs.rmSync( path.join( os.tmpdir(), 'lando' ), { recursive: true, force: true } );
@@ -306,9 +304,8 @@ describe( 'lib/dev-environment/dev-environment-core', () => {
 		it( 'should resolve the path', () => {
 			jest.spyOn( fs, 'existsSync' ).mockReturnValue( true );
 			jest.spyOn( fs, 'lstatSync' ).mockReturnValue( { isDirectory: () => false } );
-			jest.spyOn( searchReplaceModule, 'copyToTempFile' ).mockReturnValue( '/tmp/abcd/testfile.sql' );
 
-			const resolvedPath = '/tmp/abcd/testfile.sql';
+			const resolvedPath = `${ os.homedir() }/testfile.sql`;
 			resolvePath.mockReturnValue( resolvedPath );
 
 			const promise = resolveImportPath( 'foo', 'testfile.sql', null, false );

--- a/__tests__/lib/validations/sql.js
+++ b/__tests__/lib/validations/sql.js
@@ -107,8 +107,8 @@ describe( 'lib/validations/sql', () => {
 			}
 			debug( 'output', output );
 		} );
-		it( 'use statement should be ok', () => {
-			expect( output ).not.toContain( 'USE <DATABASE_NAME> statement on' );
+		it( 'use statement', () => {
+			expect( output ).toContain( 'USE <DATABASE_NAME> statement on' );
 		} );
 		it( 'not correct siteUrl', () => {
 			expect( output ).toContain( 'Siteurl/home options not pointing to lando domain' );

--- a/src/bin/vip-dev-env-import-sql.js
+++ b/src/bin/vip-dev-env-import-sql.js
@@ -10,7 +10,6 @@
  */
 import fs from 'fs';
 import chalk from 'chalk';
-import ChildProcess from 'child_process';
 
 /**
  * Internal dependencies
@@ -65,12 +64,6 @@ command( {
 		try {
 			const resolvedPath = await resolveImportPath( slug, fileName, searchReplace, inPlace );
 
-			// Remove the `USE` and `CREATE DATABASE` statements from the SQL file.
-			ChildProcess.execFileSync(
-				'sed',
-				[ '--in-place', '-E', '/^(USE|CREATE DATABASE)/Id', resolvedPath ],
-			);
-
 			if ( ! opt.skipValidate ) {
 				if ( ! isEnvUp( lando, getEnvironmentPath( slug ) ) ) {
 					throw new UserError( 'Environment needs to be started first' );
@@ -103,7 +96,7 @@ command( {
 				process.stdin.isTTY = origIsTTY;
 			}
 
-			if ( ! inPlace ) {
+			if ( searchReplace && searchReplace.length && ! inPlace ) {
 				fs.unlinkSync( resolvedPath );
 			}
 

--- a/src/lib/dev-environment/dev-environment-core.js
+++ b/src/lib/dev-environment/dev-environment-core.js
@@ -22,7 +22,7 @@ import type Lando from 'lando';
  * Internal dependencies
  */
 import { landoDestroy, landoInfo, landoExec, landoStart, landoStop, landoRebuild } from './dev-environment-lando';
-import { copyToTempFile, searchAndReplace } from '../search-and-replace';
+import { searchAndReplace } from '../search-and-replace';
 import { handleCLIException, printTable, promptForComponent, resolvePath } from './dev-environment-cli';
 import app from '../api/app';
 import {
@@ -491,11 +491,6 @@ export async function resolveImportPath( slug: string, fileName: string, searchR
 		}
 
 		resolvedPath = outputFileName;
-	} else if ( ! inPlace ) {
-		// Adding this for consistency:
-		// If the --in-place flag was false, we need to create a temporary file
-		// Irrespectively of whether the --search-replace flag was provided or not
-		resolvedPath = copyToTempFile( resolvedPath );
 	}
 
 	return resolvedPath;

--- a/src/lib/search-and-replace.js
+++ b/src/lib/search-and-replace.js
@@ -48,15 +48,6 @@ function makeTempDir() {
 	return tmpDir;
 }
 
-export function copyToTempFile( fileName ) {
-	const midputFileName = path.join( makeTempDir(), path.basename( fileName ) );
-	fs.copyFileSync( fileName, midputFileName );
-
-	debug( `Copied input file to ${ midputFileName }` );
-
-	return midputFileName;
-}
-
 export function getReadAndWriteStreams( {
 	fileName,
 	inPlace,
@@ -67,7 +58,10 @@ export function getReadAndWriteStreams( {
 	let outputFileName;
 
 	if ( inPlace ) {
-		const midputFileName = copyToTempFile( fileName );
+		const midputFileName = path.join( makeTempDir(), path.basename( fileName ) );
+		fs.copyFileSync( fileName, midputFileName );
+
+		debug( `Copied input file to ${ midputFileName }` );
 
 		debug( `Set output to the original file path ${ fileName }` );
 

--- a/src/lib/validations/sql.js
+++ b/src/lib/validations/sql.js
@@ -228,6 +228,15 @@ const checks: Checks = {
 		excerpt: "'DROP DATABASE' should not be present (case-insensitive)",
 		recommendation: 'Remove these lines',
 	},
+	useStatement: {
+		matcher: /^USE /i,
+		matchHandler: lineNumber => ( { lineNumber } ),
+		outputFormatter: lineNumberCheckFormatter,
+		results: [],
+		message: 'USE <DATABASE_NAME> statement',
+		excerpt: "'USE <DATABASE_NAME>' should not be present (case-insensitive)",
+		recommendation: 'Remove these lines',
+	},
 	alterUser: {
 		matcher: /^(ALTER USER|SET PASSWORD)/i,
 		matchHandler: lineNumber => ( { lineNumber } ),
@@ -316,7 +325,7 @@ const checks: Checks = {
 			"We suggest you search for all 'ENGINE=X' entries and replace them with 'ENGINE=InnoDB'!",
 	},
 };
-const DEV_ENV_SPECIFIC_CHECKS = [ 'siteHomeUrlLando' ];
+const DEV_ENV_SPECIFIC_CHECKS = [ 'useStatement', 'siteHomeUrlLando' ];
 
 function findDuplicates( arr: Array<*>, where: Set<*> ) {
 	const filtered = arr.filter( item => {


### PR DESCRIPTION
Reverts Automattic/vip-cli#1253

The use of `sed` is not x-platform friendly and the PR is mostly redundant due to https://lobby.vip.wordpress.com/2023/01/11/notice-stripping-use-create-statements-from-database-exports/