### PR TITLE
Dev-env: Fix WordPress version inputs for major releases ending in .0

### DIFF
--- a/__tests__/lib/dev-environment/dev-environment-cli.js
+++ b/__tests__/lib/dev-environment/dev-environment-cli.js
@@ -22,6 +22,7 @@ import {
 	promptForComponent,
 	promptForArguments,
 	setIsTTY,
+	processVersionOption,
 } from '../../../src/lib/dev-environment/dev-environment-cli';
 import * as devEnvCore from '../../../src/lib/dev-environment/dev-environment-core';
 
@@ -466,6 +467,38 @@ describe( 'lib/dev-environment/dev-environment-cli', () => {
 			const expectedMaria = input.preselected.mariadb ? input.preselected.mariadb : input.default.mariadb;
 
 			expect( result.mariadb ).toStrictEqual( expectedMaria );
+		} );
+	} );
+	describe( 'processVersionOption', () => {
+		it.each( [
+			{
+				preselected: {
+					wp: 'trunk',
+				},
+				expected: {
+					wp: 'trunk',
+				},
+			},
+			{
+				preselected: {
+					wp: '6',
+				},
+				expected: {
+					wp: '6.0',
+				},
+			},
+			{
+				preselected: {
+					wp: '6.1',
+				},
+				expected: {
+					wp: '6.1',
+				},
+			},
+		] )( 'should process versions correctly', async input => {
+			const version = processVersionOption( input.preselected.wp );
+
+			expect( version ).toStrictEqual( input.expected.wp );
 		} );
 	} );
 } );

--- a/src/bin/vip-dev-env-update.js
+++ b/src/bin/vip-dev-env-update.js
@@ -64,7 +64,7 @@ cmd.argv( process.argv, async ( arg, opt ) => {
 		const defaultOptions: InstanceOptions = {
 			appCode: currentInstanceData.appCode.dir || currentInstanceData.appCode.tag || 'latest',
 			muPlugins: currentInstanceData.muPlugins.dir || currentInstanceData.muPlugins.tag || 'latest',
-			wordpress: currentInstanceData.wordpress.tag,
+			wordpress: currentInstanceData.wordpress.tag || 'trunk',
 			elasticsearch: currentInstanceData.elasticsearch,
 			php: currentInstanceData.php || DEV_ENVIRONMENT_PHP_VERSIONS.default,
 			mariadb: currentInstanceData.mariadb,

--- a/src/lib/dev-environment/dev-environment-cli.js
+++ b/src/lib/dev-environment/dev-environment-cli.js
@@ -360,7 +360,9 @@ async function processComponent( component: string, preselectedValue: string, de
 	const defaultObject = defaultValue ? processComponentOptionInput( defaultValue, allowLocal ) : null;
 	if ( preselectedValue ) {
 		result = processComponentOptionInput( preselectedValue, allowLocal );
-		console.log( `${ chalk.green( '✓' ) } Path to your local ${ componentDisplayNames[ component ] }: ${ preselectedValue }` );
+		if ( allowLocal ) {
+			console.log( `${ chalk.green( '✓' ) } Path to your local ${ componentDisplayNames[ component ] }: ${ preselectedValue }` );
+		}
 	} else {
 		result = await promptForComponent( component, allowLocal, defaultObject );
 	}
@@ -481,8 +483,7 @@ function resolvePhpVersion( version: string ): string {
 	const versions = Object.keys( DEV_ENVIRONMENT_PHP_VERSIONS );
 	const images = ( ( Object.values( DEV_ENVIRONMENT_PHP_VERSIONS ): any[] ): string[] );
 
-	// eslint-disable-next-line eqeqeq -- use loose comparison because commander resolves '8.0' to '8'
-	const index = versions.findIndex( value => value == version );
+	const index = versions.findIndex( value => value === version );
 	if ( index === -1 ) {
 		const image = images.find( value => value === version );
 		return image ?? images[ 0 ];
@@ -599,9 +600,18 @@ export function processBooleanOption( value: string ): boolean {
 	return ! ( FALSE_OPTIONS.includes( value.toLowerCase?.() ) );
 }
 
+export function processVersionOption( value: string ): string {
+	if ( ! isNaN( value ) && value % 1 === 0 ) {
+		// If it's an Integer passed in, let's ensure that it has a decimal in it to match the version tags e.g. 6 => 6.0
+		return parseFloat( value ).toFixed( 1 );
+	}
+
+	return value;
+}
+
 export function addDevEnvConfigurationOptions( command: Command ): any {
 	return command
-		.option( 'wordpress', 'Use a specific WordPress version' )
+		.option( 'wordpress', 'Use a specific WordPress version', undefined, processVersionOption )
 		.option( [ 'u', 'mu-plugins' ], 'Use a specific mu-plugins changeset or local directory' )
 		.option( 'app-code', 'Use the application code from a local directory or use "demo" for VIP skeleton code' )
 		.option( 'phpmyadmin', 'Enable PHPMyAdmin component. By default it is disabled', undefined, processBooleanOption )
@@ -610,7 +620,7 @@ export function addDevEnvConfigurationOptions( command: Command ): any {
 		.option( 'elasticsearch', 'Enable Elasticsearch (needed by Enterprise Search)', undefined, processBooleanOption )
 		.option( 'mariadb', 'Explicitly choose MariaDB version to use' )
 		.option( [ 'r', 'media-redirect-domain' ], 'Domain to redirect for missing media files. This can be used to still have images without the need to import them locally.' )
-		.option( 'php', 'Explicitly choose PHP version to use' )
+		.option( 'php', 'Explicitly choose PHP version to use', undefined, processVersionOption )
 		.option( [ 'A', 'mailhog' ], 'Enable MailHog. By default it is disabled', undefined, processBooleanOption );
 }
 
@@ -621,22 +631,22 @@ export async function getTagChoices(): Promise<{ name: string, message: string, 
 	let versions = await getVersionList();
 	if ( versions.length < 1 ) {
 		versions = [ {
+			ref: '6.1.1',
+			tag: '6.1',
+			cacheable: true,
+			locked: true,
+			prerelease: false,
+		},
+		{
+			ref: '6.0.3',
+			tag: '6.0',
+			cacheable: true,
+			locked: true,
+			prerelease: false,
+		},
+		{
 			ref: '5.9.5',
 			tag: '5.9',
-			cacheable: true,
-			locked: true,
-			prerelease: false,
-		},
-		{
-			ref: '5.8.6',
-			tag: '5.8',
-			cacheable: true,
-			locked: true,
-			prerelease: false,
-		},
-		{
-			ref: '5.7.8',
-			tag: '5.7',
 			cacheable: true,
 			locked: true,
 			prerelease: false,

--- a/src/lib/dev-environment/dev-environment-cli.js
+++ b/src/lib/dev-environment/dev-environment-cli.js
@@ -610,6 +610,7 @@ export function processVersionOption( value: string ): string {
 }
 
 export function addDevEnvConfigurationOptions( command: Command ): any {
+	// We leave the third parameter to undefined on some because the defaults are handled in preProcessInstanceData()
 	return command
 		.option( 'wordpress', 'Use a specific WordPress version', undefined, processVersionOption )
 		.option( [ 'u', 'mu-plugins' ], 'Use a specific mu-plugins changeset or local directory' )

--- a/src/lib/dev-environment/dev-environment-core.js
+++ b/src/lib/dev-environment/dev-environment-core.js
@@ -164,6 +164,10 @@ function preProcessInstanceData( instanceData: InstanceData ): InstanceData {
 		newInstanceData.php = newInstanceData.php.slice( 'image:'.length );
 	}
 
+	if ( isNaN( newInstanceData.wordpress.tag ) ) {
+		newInstanceData.wordpress.tag = 'trunk';
+	}
+
 	if ( ! newInstanceData.xdebugConfig ) {
 		newInstanceData.xdebugConfig = '';
 	}

--- a/src/lib/dev-environment/dev-environment-core.js
+++ b/src/lib/dev-environment/dev-environment-core.js
@@ -111,7 +111,7 @@ export async function stopEnvironment( lando: Lando, slug: string ): Promise<voi
 
 export async function createEnvironment( instanceData: InstanceData ): Promise<void> {
 	const slug = instanceData.siteSlug;
-	debug( 'Will create an environment', slug, 'with instanceData: ', instanceData );
+	debug( 'Will process an environment', slug, 'with instanceData for creation: ', instanceData );
 
 	const instancePath = getEnvironmentPath( slug );
 
@@ -124,13 +124,14 @@ export async function createEnvironment( instanceData: InstanceData ): Promise<v
 	}
 
 	const preProcessedInstanceData = preProcessInstanceData( instanceData );
+	debug( 'Will create an environment', slug, 'with instanceData: ', preProcessedInstanceData );
 
 	await prepareLandoEnv( preProcessedInstanceData, instancePath );
 }
 
 export async function updateEnvironment( instanceData: InstanceData ): Promise<void> {
 	const slug = instanceData.siteSlug;
-	debug( 'Will update an environment', slug, 'with instanceData: ', instanceData );
+	debug( 'Will process an environment', slug, 'with instanceData for updating: ', instanceData );
 
 	const instancePath = getEnvironmentPath( slug );
 
@@ -143,6 +144,7 @@ export async function updateEnvironment( instanceData: InstanceData ): Promise<v
 	}
 
 	const preProcessedInstanceData = preProcessInstanceData( instanceData );
+	debug( 'Will create an environment', slug, 'with instanceData: ', preProcessedInstanceData );
 
 	await prepareLandoEnv( preProcessedInstanceData, instancePath );
 }
@@ -164,7 +166,7 @@ function preProcessInstanceData( instanceData: InstanceData ): InstanceData {
 		newInstanceData.php = newInstanceData.php.slice( 'image:'.length );
 	}
 
-	if ( isNaN( newInstanceData.wordpress.tag ) ) {
+	if ( isNaN( instanceData.wordpress.tag ) ) {
 		newInstanceData.wordpress.tag = 'trunk';
 	}
 


### PR DESCRIPTION
## Description

Let's try this again. Previously committed in #1262 and reverted in #1265

We need to leave the third option to be `undefined` in `addDevEnvConfigurationOptions()` because the defaults are processed in `preProcessInstanceData()`. I also moved the `debug()` statements to reflect the afterwards of `preProcessInstanceData()` for better accuracy debugging