### PR TITLE
fix(dev-env): Suppress health warnings for new environments

### DIFF
--- a/src/bin/vip-dev-env-create.js
+++ b/src/bin/vip-dev-env-create.js
@@ -121,7 +121,7 @@ cmd.argv( process.argv, async ( arg, opt ) => {
 	try {
 		await createEnvironment( instanceData );
 
-		await printEnvironmentInfo( lando, slug, { extended: false } );
+		await printEnvironmentInfo( lando, slug, { extended: false, suppressWarnings: true } );
 
 		const message = '\n' + chalk.green( '✓' ) + ` environment created.\n\nTo start it please run:\n\n${ startCommand }\n`;
 		console.log( message );

--- a/src/bin/vip-dev-env-info.js
+++ b/src/bin/vip-dev-env-info.js
@@ -52,6 +52,7 @@ command()
 		try {
 			const options = {
 				extended: !! opt.extended,
+				suppressWarnings: true,
 			};
 			if ( opt.all ) {
 				await printAllEnvironmentsInfo( lando, options );

--- a/src/lib/dev-environment/dev-environment-core.js
+++ b/src/lib/dev-environment/dev-environment-core.js
@@ -216,7 +216,8 @@ export async function destroyEnvironment( lando: Lando, slug: string, removeFile
 }
 
 interface PrintOptions {
-	extended?: boolean
+	extended?: boolean;
+	suppressWarnings?: boolean;
 }
 
 export async function printAllEnvironmentsInfo( lando: Lando, options: PrintOptions ): Promise<void> {
@@ -259,7 +260,7 @@ export async function printEnvironmentInfo( lando: Lando, slug: string, options:
 		throw new UserError( DEV_ENVIRONMENT_NOT_FOUND );
 	}
 
-	const appInfo = await landoInfo( lando, instancePath );
+	const appInfo = await landoInfo( lando, instancePath, !! options.suppressWarnings );
 	if ( options.extended ) {
 		const environmentData = readEnvironmentData( slug );
 		appInfo.title = environmentData.wpTitle;

--- a/src/lib/dev-environment/dev-environment-lando.js
+++ b/src/lib/dev-environment/dev-environment-lando.js
@@ -310,7 +310,7 @@ export async function landoDestroy( lando: Lando, instancePath: string ) {
 	await app.destroy();
 }
 
-export async function landoInfo( lando: Lando, instancePath: string ) {
+export async function landoInfo( lando: Lando, instancePath: string, suppressWarnings: boolean ) {
 	const app = await getLandoApplication( lando, instancePath );
 
 	let appInfo = landoUtils.startTable( app );
@@ -351,7 +351,7 @@ export async function landoInfo( lando: Lando, instancePath: string ) {
 		appInfo[ 'Default password' ] = 'password';
 	}
 
-	if ( hasWarnings ) {
+	if ( ! suppressWarnings && hasWarnings ) {
 		let message = chalk.bold.yellow( 'The following services have failed health checks:\n' );
 		Object.keys( health ).forEach( service => {
 			if ( ! health[ service ] ) {

--- a/src/lib/dev-environment/dev-environment-lando.js
+++ b/src/lib/dev-environment/dev-environment-lando.js
@@ -355,7 +355,7 @@ export async function landoInfo( lando: Lando, instancePath: string, suppressWar
 		let message = chalk.bold.yellow( 'The following services have failed health checks:\n' );
 		Object.keys( health ).forEach( service => {
 			if ( ! health[ service ] ) {
-				message += `  ${ chalk.red( service ) }\n`;
+				message += `${ chalk.red( service ) }\n`;
 			}
 		} );
 		appInfo[ 'Health warnings' ] = message;


### PR DESCRIPTION
## Description

This PR suppresses health warnings for newly created environments.

## Steps to Test

Without the patch, `vip dev-env create` will say smth like:

```
 SLUG              vip-local                                                                           
 LOCATION          /home/volodymyr/.local/share/vip/dev-environment/vip-local                          
 SERVICES          devtools, nginx, php, database, memcached, wordpress, vip-mu-plugins, demo-app-code 
 NGINX URLS        http://vip-local.vipdev.lndo.site/                                                  
                   https://vip-local.vipdev.lndo.site/                                                 
 STATUS            DOWN                                                                                
 LOGIN URL         http://vip-local.vipdev.lndo.site/wp-admin/                                         
 DEFAULT USERNAME  vipgo                                                                               
 DEFAULT PASSWORD  password                                                                            
 HEALTH WARNINGS   The following services have failed health checks:                                   
                     nginx                                                                             
                                                                                                       
 DOCUMENTATION     https://docs.wpvip.com/technical-references/vip-local-development-environment/      

✓ environment created.
```

With this patch, there will be no "HEALTH WARNINGS" row in the output.
