### PR TITLE
Fix the PassThrough class import

### DIFF
--- a/src/lib/client-file-uploader.js
+++ b/src/lib/client-file-uploader.js
@@ -13,7 +13,8 @@ import fetch from 'node-fetch';
 import chalk from 'chalk';
 import { createGunzip, createGzip } from 'zlib';
 import { createHash } from 'crypto';
-import { pipeline, PassThrough } from 'node:stream/promises';
+import { pipeline } from 'node:stream/promises';
+import { PassThrough } from 'stream';
 import { Parser as XmlParser } from 'xml2js';
 import debugLib from 'debug';
 


### PR DESCRIPTION
## Description

Fixing the `PassThrough` class import which is a regression introduced in  711f20e6c34b10706f0a7677be030599056dcf61

Here are the docs: https://nodejs.org/api/stream.html#class-streampassthrough

## Steps to Reproduce & Test

1. Check out the `develop` branch
1. Run `npm run build`
1. Run `./dist/bin/vip-import-sql.js @your_app.your_env <file-path>`
1. This should fail with ✕ Error:  TypeError: _promises.PassThrough is not a constructor
1. Check out this PR
1. Run `npm run build`
1. Run `./dist/bin/vip-import-sql.js @your_app.your_env <file-path>`
1. This should pass with `Status: Success ✓ imported data should be visible on your site .....`

