### PR TITLE
Dev-env: Add command to view logs `vip dev-env logs`

### DIFF
--- a/__tests__/devenv-e2e/011-logs.spec.js
+++ b/__tests__/devenv-e2e/011-logs.spec.js
@@ -1,0 +1,97 @@
+/**
+ * External dependencies
+ */
+import { mkdtemp, rm } from 'node:fs/promises';
+import path from 'node:path';
+import os from 'node:os';
+import { describe, expect, it } from '@jest/globals';
+import xdgBaseDir from 'xdg-basedir';
+import Docker from 'dockerode';
+import nock from 'nock';
+
+/**
+ * Internal dependencies
+ */
+import { CliTest } from './helpers/cli-test';
+import { checkEnvExists, createAndStartEnvironment, destroyEnvironment, getProjectSlug, prepareEnvironment } from './helpers/utils';
+import { vipDevEnvLogs } from './helpers/commands';
+import { killProjectContainers } from './helpers/docker-utils';
+
+describe( 'vip dev-env logs', () => {
+	/** @type {CliTest} */
+	let cliTest;
+	/** @type {NodeJS.ProcessEnv} */
+	let env;
+	/** @type {string} */
+	let tmpPath;
+
+	beforeAll( async () => {
+		nock.cleanAll();
+		nock.enableNetConnect();
+
+		cliTest = new CliTest();
+
+		tmpPath = await mkdtemp( path.join( os.tmpdir(), 'vip-dev-env-' ) );
+		xdgBaseDir.data = tmpPath;
+
+		env = prepareEnvironment( tmpPath );
+	} );
+
+	afterAll( () => rm( tmpPath, { recursive: true, force: true } ) );
+	afterAll( () => nock.restore() );
+
+	describe( 'if the environment does not exist', () => {
+		it( 'should fail', async () => {
+			const slug = getProjectSlug();
+			expect( await checkEnvExists( slug ) ).toBe( false );
+
+			const result = await cliTest.spawn( [ process.argv[ 0 ], vipDevEnvLogs, '--slug', slug ], { env } );
+			expect( result.rc ).toBeGreaterThan( 0 );
+			expect( result.stderr ).toContain( 'Error: Environment doesn\'t exist.' );
+
+			return expect( checkEnvExists( slug ) ).resolves.toBe( false );
+		} );
+	} );
+
+	describe( 'if the environment exists', () => {
+		/** @type {Docker} */
+		let docker;
+		/** @type {string} */
+		let slug;
+
+		beforeAll( async () => {
+			docker = new Docker();
+
+			slug = getProjectSlug();
+			await createAndStartEnvironment( cliTest, slug, env );
+		} );
+
+		afterAll( async () => {
+			try {
+				await destroyEnvironment( cliTest, slug, env );
+			} finally {
+				await killProjectContainers( docker, slug );
+			}
+		} );
+
+		it( 'should display all the logs', async () => {
+			const result = await cliTest.spawn( [ process.argv[ 0 ], vipDevEnvLogs, '--slug', slug ], { env }, true );
+			expect( result.rc ).toBe( 0 );
+			expect( result.stdout ).toMatch( /database_1/ );
+			expect( result.stdout ).toMatch( /STARTING UP/ );
+		} );
+
+		it( 'should fail on unknown services', async () => {
+			const result = await cliTest.spawn( [ process.argv[ 0 ], vipDevEnvLogs, '--slug', slug, '--service', 'foobar' ], { env } );
+			expect( result.rc ).toBeGreaterThan( 0 );
+			console.log( result.stderr );
+			expect( result.stderr ).toContain( "Error:  Service 'foobar' not found. Please choose from one: devtools, nginx, php, database, memcached, wordpress, vip-mu-plugins, demo-app-code" );
+		} );
+
+		it( 'should display logs for a selected service', async () => {
+			const result = await cliTest.spawn( [ process.argv[ 0 ], vipDevEnvLogs, '--slug', slug, '--service', 'php' ], { env }, true );
+			expect( result.rc ).toBe( 0 );
+			expect( result.stdout ).toMatch( /php_1/ );
+		} );
+	} );
+} );

--- a/__tests__/devenv-e2e/helpers/commands.js
+++ b/__tests__/devenv-e2e/helpers/commands.js
@@ -15,3 +15,4 @@ export const vipDevEnvList = join( vipPath, 'vip-dev-env-list.js' );
 export const vipDevEnvStart = join( vipPath, 'vip-dev-env-start.js' );
 export const vipDevEnvStop = join( vipPath, 'vip-dev-env-stop.js' );
 export const vipDevEnvUpdate = join( vipPath, 'vip-dev-env-update.js' );
+export const vipDevEnvLogs = join( vipPath, 'vip-dev-env-logs.js' );

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "vip-dev-env-list": "dist/bin/vip-dev-env-list.js",
     "vip-dev-env-start": "dist/bin/vip-dev-env-start.js",
     "vip-dev-env-stop": "dist/bin/vip-dev-env-stop.js",
+    "vip-dev-env-logs": "dist/bin/vip-dev-env-logs.js",
     "vip-import": "dist/bin/vip-import.js",
     "vip-import-media": "dist/bin/vip-import-media.js",
     "vip-import-media-abort": "dist/bin/vip-import-media-abort.js",

--- a/src/bin/vip-dev-env-logs.js
+++ b/src/bin/vip-dev-env-logs.js
@@ -1,9 +1,7 @@
 #!/usr/bin/env node
 
-/**
- * @flow
- * @format
- */
+// @flow
+// @format
 
 /**
  * External dependencies

--- a/src/bin/vip-dev-env-logs.js
+++ b/src/bin/vip-dev-env-logs.js
@@ -30,14 +30,14 @@ const examples = [
 		description: 'Return logs from the "elasticsearch" service from a local dev environment named "my_site"',
 	},
 	{
-		usage: `${ DEV_ENVIRONMENT_FULL_COMMAND } logs --slug=my_site --service=elasticsearch --follow`,
+		usage: `${ DEV_ENVIRONMENT_FULL_COMMAND } logs --slug=my_site --service=elasticsearch -f`,
 		description: 'Follow logs from the "elasticsearch" service from a local dev environment named "my_site"',
 	},
 ];
 
 command()
 	.option( 'slug', 'Custom name of the dev environment' )
-	.option( 'follow', 'Follow logs for a specific service in local dev environment' )
+	.option( [ 'f', 'follow' ], 'Follow logs for a specific service in local dev environment' )
 	.option( 'service', 'Show logs for a specific service in local dev environment. Defaults to all if none passed in.' )
 	.examples( examples )
 	.argv( process.argv, async ( arg, opt ) => {

--- a/src/bin/vip-dev-env-logs.js
+++ b/src/bin/vip-dev-env-logs.js
@@ -1,0 +1,77 @@
+#!/usr/bin/env node
+
+/**
+ * @flow
+ * @format
+ */
+
+/**
+ * External dependencies
+ */
+import debugLib from 'debug';
+
+/**
+ * Internal dependencies
+ */
+import { trackEvent } from '../lib/tracker';
+import command from '../lib/cli/command';
+import { showLogs } from '../lib/dev-environment/dev-environment-core';
+import { getEnvTrackingInfo, getEnvironmentName, handleCLIException, validateDependencies } from '../lib/dev-environment/dev-environment-cli';
+import { DEV_ENVIRONMENT_FULL_COMMAND } from '../lib/constants/dev-environment';
+import { bootstrapLando } from '../lib/dev-environment/dev-environment-lando';
+
+const debug = debugLib( '@automattic/vip:bin:dev-environment' );
+
+const examples = [
+	{
+		usage: `${ DEV_ENVIRONMENT_FULL_COMMAND } logs --slug=my_site`,
+		description: 'Return all logs from a local dev environment named "my_site"',
+	},
+	{
+		usage: `${ DEV_ENVIRONMENT_FULL_COMMAND } logs --slug=my_site --service=elasticsearch`,
+		description: 'Return logs from the "elasticsearch" service from a local dev environment named "my_site"',
+	},
+	{
+		usage: `${ DEV_ENVIRONMENT_FULL_COMMAND } logs --slug=my_site --service=elasticsearch --follow`,
+		description: 'Follow logs from the "elasticsearch" service from a local dev environment named "my_site"',
+	},
+];
+
+command()
+	.option( 'slug', 'Custom name of the dev environment' )
+	.option( 'follow', 'Follow logs for a specific service in local dev environment' )
+	.option( 'service', 'Show logs for a specific service in local dev environment. Defaults to all if none passed in.' )
+	.examples( examples )
+	.argv( process.argv, async ( arg, opt ) => {
+		const slug = getEnvironmentName( opt );
+
+		const lando = await bootstrapLando();
+		await validateDependencies( lando, slug );
+
+		const trackingInfo = getEnvTrackingInfo( slug );
+		await trackEvent( 'dev_env_logs_command_execute', trackingInfo );
+
+		debug( 'Args: ', arg, 'Options: ', opt );
+
+		if ( ! opt.follow ) {
+			opt.follow = false;
+		}
+
+		if ( ! opt.service ) {
+			opt.service = false;
+		}
+
+		const options = {
+			follow: opt.follow,
+			service: opt.service,
+			timestamps: true,
+		};
+
+		try {
+			await showLogs( lando, slug, options );
+			await trackEvent( 'dev_env_logs_command_success', trackingInfo );
+		} catch ( error ) {
+			await handleCLIException( error, 'dev_env_logs_command_error', trackingInfo );
+			process.exitCode = 1;
+		}
+	} );

--- a/src/bin/vip-dev-env.js
+++ b/src/bin/vip-dev-env.js
@@ -26,4 +26,5 @@ command( {
 	.command( 'list', 'Provides basic info about all local dev environments' )
 	.command( 'exec', 'Execute an operation on a dev environment' )
 	.command( 'import', 'Import data into a local WordPress environment' )
+	.command( 'logs', 'View logs from a local WordPress environment' )
 	.argv( process.argv );

--- a/src/lib/dev-environment/dev-environment-core.js
+++ b/src/lib/dev-environment/dev-environment-core.js
@@ -21,7 +21,7 @@ import type Lando from 'lando';
 /**
  * Internal dependencies
  */
-import { landoDestroy, landoInfo, landoExec, landoStart, landoStop, landoRebuild } from './dev-environment-lando';
+import { landoDestroy, landoInfo, landoExec, landoStart, landoStop, landoRebuild, landoLogs } from './dev-environment-lando';
 import { searchAndReplace } from '../search-and-replace';
 import { handleCLIException, printTable, promptForComponent, resolvePath } from './dev-environment-cli';
 import app from '../api/app';
@@ -251,6 +251,23 @@ function parseComponentForInfo( component: ComponentConfig | WordPressConfig ): 
 		return component.dir || '';
 	}
 	return component.tag || '[demo-image]';
+}
+
+export async function showLogs( lando: Lando, slug: string, options: any = {} ): Promise<*> {
+	debug( 'Will display logs command on env', slug, 'with options', options );
+
+	const instancePath = getEnvironmentPath( slug );
+
+	debug( 'Instance path for', slug, 'is:', instancePath );
+
+	if ( options.service ) {
+		const appInfo = await landoInfo( lando, instancePath );
+		if ( ! appInfo.services.includes( options.service ) ) {
+			throw new UserError( `Invalid service '${ options.service }'. Please choose from one: ${ appInfo.services }` );
+		}
+	}
+
+	return landoLogs( lando, instancePath, options );
 }
 
 export async function printEnvironmentInfo( lando: Lando, slug: string, options: PrintOptions ): Promise<void> {

--- a/src/lib/dev-environment/dev-environment-core.js
+++ b/src/lib/dev-environment/dev-environment-core.js
@@ -263,7 +263,7 @@ export async function showLogs( lando: Lando, slug: string, options: any = {} ):
 	if ( options.service ) {
 		const appInfo = await landoInfo( lando, instancePath );
 		if ( ! appInfo.services.includes( options.service ) ) {
-			throw new UserError( `Invalid service '${ options.service }'. Please choose from one: ${ appInfo.services }` );
+			throw new UserError( `Service '${ options.service }' not found. Please choose from one: ${ appInfo.services }` );
 		}
 	}
 

--- a/src/lib/dev-environment/dev-environment-lando.js
+++ b/src/lib/dev-environment/dev-environment-lando.js
@@ -207,6 +207,20 @@ export async function landoStart( lando: Lando, instancePath: string ) {
 	await app.start();
 }
 
+export async function landoLogs( lando: Lando, instancePath: string, options: {} ) {
+	debug( 'Will show lando logs on path:', instancePath, ' with options: ', options );
+
+	const app = await getLandoApplication( lando, instancePath );
+	const logTask = lando.tasks.find( task => task.command === 'logs' );
+
+	await logTask.run( {
+		follow: options.follow,
+		service: options.service,
+		timestamps: options.timestamps,
+		_app: app,
+	} );
+}
+
 export async function landoRebuild( lando: Lando, instancePath: string ) {
 	debug( 'Will rebuild lando app on path:', instancePath );
 


### PR DESCRIPTION
## Description

Adds an easier step to view logs rather than having to do `docker ps` > `docker logs container`.

Usage as follows:

`vip dev-env logs` 
`vip dev-env logs --service=<service-name> [--follow]` for a specific container

## Steps to Test

1) Create an environment 
2) `npm run build`
3) ` ./dist/bin/vip-dev-env-logs.js --service=php` and have it display logs from the PHP container
4) Choose a service that doesn't exist for environment created and pass it into the service flag: ` ./dist/bin/vip-dev-env-logs.js --service=elasticsearch`
5) Test follow option: ` ./dist/bin/vip-dev-env-logs.js --service=php --follow`