### PR TITLE
[dev-env] Update the wording for Docker connection check

### DIFF
--- a/src/lib/dev-environment/dev-environment-cli.js
+++ b/src/lib/dev-environment/dev-environment-cli.js
@@ -129,9 +129,9 @@ const verifyDNSResolution = async ( slug: string ): Promise<void> => {
 };
 
 const VALIDATION_STEPS = [
-	{ id: 'docker', name: 'Check for docker installation' },
+	{ id: 'docker', name: 'Check for Docker installation' },
 	{ id: 'compose', name: 'Check for docker-compose installation' },
-	{ id: 'access', name: 'Check access to docker for current user' },
+	{ id: 'access', name: 'Check Docker connectivity' },
 	{ id: 'dns', name: 'Check DNS resolution' },
 ];
 

--- a/src/lib/dev-environment/dev-environment-lando.js
+++ b/src/lib/dev-environment/dev-environment-lando.js
@@ -554,10 +554,10 @@ export async function validateDockerInstalled( lando: Lando ) {
 
 export async function validateDockerAccess( lando: Lando ) {
 	const docker = lando.engine.docker;
-	lando.log.verbose( 'Fetching docker info to verify user is in docker group' );
+	lando.log.verbose( 'Fetching docker info to verify Docker connection' );
 	try {
 		await docker.info();
 	} catch ( error ) {
-		throw Error( 'Failed to connect to docker. Please verify that the current user is part of docker group and has access to docker commands.' );
+		throw Error( 'Failed to connect to Docker. Please verify that Docker engine (service) is running and follow the troubleshooting instructions for your platform.' );
 	}
 }


### PR DESCRIPTION
## Description

Current wording is misleading, we don't really check for the user, we're fetching checking docker.info() which provides some info about the docker engine (if it's running and we're able to connect to it). User not being added to group is just one edge case out of many.

## Steps to Test

Outline the steps to test and verify the PR here.

Example:

1. Check out PR.
1. Run `npm run build`
1. Run `node ./dist/bin/vip dev-env start`
1. Verify the new wording

