### PR TITLE
Prefix urls with // to fix the search-replace problem

### DIFF
--- a/__tests__/commands/dev-env-sync-sql.js
+++ b/__tests__/commands/dev-env-sync-sql.js
@@ -85,11 +85,11 @@ describe( 'commands/DevEnvSyncSQLCommand', () => {
 	describe( '.runSearchReplace', () => {
 		it( 'should run search-replace operation on the SQL file', async () => {
 			const cmd = new DevEnvSyncSQLCommand( app, env, 'test-slug' );
-			cmd.siteUrls = [ 'test.go-vip.com' ];
+			cmd.siteUrls = [ '//test.go-vip.com' ];
 			cmd.slug = 'test-slug';
 
 			await cmd.runSearchReplace();
-			expect( replace ).toHaveBeenCalledWith( mockReadStream, [ 'test.go-vip.com', 'test-slug.vipdev.lndo.site' ] );
+			expect( replace ).toHaveBeenCalledWith( mockReadStream, [ '//test.go-vip.com', '//test-slug.vipdev.lndo.site' ] );
 		} );
 	} );
 

--- a/src/commands/dev-env-sync-sql.js
+++ b/src/commands/dev-env-sync-sql.js
@@ -63,7 +63,7 @@ async function extractSiteUrls( sqlFile ) {
 		} );
 
 		readInterface.on( 'close', () => {
-			resolve( [ ...domains ] );
+			resolve( Array.from( domains ) );
 		} );
 
 		readInterface.on( 'error', reject );

--- a/src/commands/dev-env-sync-sql.js
+++ b/src/commands/dev-env-sync-sql.js
@@ -146,11 +146,10 @@ export class DevEnvSyncSQLCommand {
 	 */
 	async runImport() {
 		const importOptions = {
-			slug: this.slug,
 			inPlace: true,
 			skipValidate: true,
 		};
-		const importCommand = new DevEnvImportSQLCommand( this.sqlFile, importOptions );
+		const importCommand = new DevEnvImportSQLCommand( this.sqlFile, importOptions, this.slug );
 		await importCommand.run( true );
 	}
 


### PR DESCRIPTION
## Description

Imagine the following search-replace operations will run as a step of the vip-dev-env-sync command:
```
foo.com -> test.lndo.site
sub.foo.com -> test.lndo.site
```

Because of the ordering, we will end up with a domain `sub.test.lndo.site`.

In this PR, we are aiming to fix that by appending `//` to the domains.
We are also fixing two minor issues:
- Do not replace a non-url entry of home/siteUrl (i.e. if the entry is `inherit`, it shouldn't be replaced)
- Do not display the same occurrence multiple times.

## Steps to Test

1. If you are an automattician and using proxy, run `export VIP_PROXY=socks://localhost:8080`.
2. You need to have a local development instance of a site running in your computer. Run the following command if you don't have one:
`vip dev-env create --slug=srtest @<app>.<env> && vip dev-env start --slug=srtest`
3. Run the following to test this PR:
`rm -rf dist && npm link && node ./dist/bin/vip dev-env sync sql --slug=srtest @<app>.<env>`
