### PR TITLE
test: Do not mock `localStorage` if `global.localStorage` is defined

### DIFF
--- a/__tests__/lib/keychain.js
+++ b/__tests__/lib/keychain.js
@@ -80,19 +80,21 @@ describe( 'token tests (insecure)', () => {
 } );
 
 describe( 'token tests (browser)', () => {
-	// mock localStorage
-	global.localStorage = {
-		data: {},
-		getItem( key ) {
-			return this.data[ key ];
-		},
-		setItem( key, value ) {
-			this.data[ key ] = value;
-		},
-		removeItem( key ) {
-			delete this.data[ key ];
-		},
-	};
+	if ( 'undefined' === typeof global.localStorage ) {
+		// mock localStorage
+		global.localStorage = {
+			data: {},
+			getItem( key ) {
+				return this.data[ key ];
+			},
+			setItem( key, value ) {
+				this.data[ key ] = value;
+			},
+			removeItem( key ) {
+				delete this.data[ key ];
+			},
+		};
+	}
 
 	keychain = new Browser();
 


### PR DESCRIPTION
## Description

Ref: https://github.com/Automattic/vip-cli/actions/runs/4256882873/jobs/7406330215#step:5:289

Something has changed in Node 19.7.0, and it is now impossible to override `global.localStorage`.

## Steps to Test

The CI should pass.
