### PR TITLE
fix(dev-env): Provide Flow typings for `landoLogs()`

### DIFF
--- a/src/lib/dev-environment/dev-environment-core.js
+++ b/src/lib/dev-environment/dev-environment-core.js
@@ -21,7 +21,7 @@ import type Lando from 'lando';
 /**
  * Internal dependencies
  */
-import { landoDestroy, landoInfo, landoExec, landoStart, landoStop, landoRebuild, landoLogs } from './dev-environment-lando';
+import { type LandoLogsOptions, landoDestroy, landoInfo, landoExec, landoStart, landoStop, landoRebuild, landoLogs } from './dev-environment-lando';
 import { searchAndReplace } from '../search-and-replace';
 import { handleCLIException, printTable, promptForComponent, resolvePath } from './dev-environment-cli';
 import app from '../api/app';
@@ -267,7 +267,7 @@ export async function showLogs( lando: Lando, slug: string, options: any = {} ):
 		}
 	}
 
-	return landoLogs( lando, instancePath, options );
+	return landoLogs( lando, instancePath, ( options: LandoLogsOptions ) );
 }
 
 export async function printEnvironmentInfo( lando: Lando, slug: string, options: PrintOptions ): Promise<void> {

--- a/src/lib/dev-environment/dev-environment-lando.js
+++ b/src/lib/dev-environment/dev-environment-lando.js
@@ -207,7 +207,13 @@ export async function landoStart( lando: Lando, instancePath: string ) {
 	await app.start();
 }
 
-export async function landoLogs( lando: Lando, instancePath: string, options: {} ) {
+export interface LandoLogsOptions {
+	follow: boolean;
+	service: string;
+	timestamps: boolean;
+}
+
+export async function landoLogs( lando: Lando, instancePath: string, options: LandoLogsOptions ) {
 	debug( 'Will show lando logs on path:', instancePath, ' with options: ', options );
 
 	const app = await getLandoApplication( lando, instancePath );


### PR DESCRIPTION
## Description

Flow generates several `Flow(prop-missing)` errors because `landoLogs()` uses `{}` as a type for `options`.

This PR provides the correct type definition.

## Steps to Test

1. The CI should pass.
2. Opening `src/lib/dev-environment/dev-environment-lando.js` should not produce Flow errors for `landoLogs()` (except for "Cannot use `Lando` as a type because it is an `any`-typed value").
