### PR TITLE
fix(dev-env): Pull fresh images for new environments

### DIFF
--- a/src/lib/dev-environment/dev-environment-lando.js
+++ b/src/lib/dev-environment/dev-environment-lando.js
@@ -254,13 +254,14 @@ async function addHooks( app: App, lando: Lando ): Promise<void> {
 			registryResolvable = false;
 		}
 
-		data.opts.pull = registryResolvable && ( instanceData.pullAfter || 0 ) < Date.now();
-		if ( Array.isArray( data.opts.pullable ) && Array.isArray( data.opts.local ) && data.opts.local.length === 0 && ! data.opts.pull ) {
+		const pull = registryResolvable && ( instanceData.pullAfter || 0 ) < Date.now();
+		if ( Array.isArray( data.opts.pullable ) && Array.isArray( data.opts.local ) && data.opts.local.length === 0 && ! pull ) {
+			data.opts.pull = false;
 			data.opts.local = data.opts.pullable;
 			data.opts.pullable = [];
 		}
 
-		if ( data.opts.pull || ! instanceData.pullAfter ) {
+		if ( pull || ! instanceData.pullAfter ) {
 			instanceData.pullAfter = Date.now() + ( 7 * 24 * 60 * 60 * 1000 );
 			writeEnvironmentData( app._name, instanceData );
 		}

--- a/src/lib/dev-environment/dev-environment-lando.js
+++ b/src/lib/dev-environment/dev-environment-lando.js
@@ -254,7 +254,7 @@ async function addHooks( app: App, lando: Lando ): Promise<void> {
 			registryResolvable = false;
 		}
 
-		data.opts.pull = registryResolvable && instanceData.pullAfter < Date.now();
+		data.opts.pull = registryResolvable && ( instanceData.pullAfter || 0 ) < Date.now();
 		if ( Array.isArray( data.opts.pullable ) && Array.isArray( data.opts.local ) && data.opts.local.length === 0 && ! data.opts.pull ) {
 			data.opts.local = data.opts.pullable;
 			data.opts.pullable = [];

--- a/src/lib/dev-environment/dev-environment-lando.js
+++ b/src/lib/dev-environment/dev-environment-lando.js
@@ -254,9 +254,10 @@ async function addHooks( app: App, lando: Lando ): Promise<void> {
 			registryResolvable = false;
 		}
 
-		const pull = registryResolvable && ( instanceData.pullAfter || 0 ) < Date.now();
+		const pull = ( registryResolvable && ( instanceData.pullAfter || 0 ) < Date.now() );
 		if ( Array.isArray( data.opts.pullable ) && Array.isArray( data.opts.local ) && data.opts.local.length === 0 && ! pull ) {
-			data.opts.pull = false;
+			// Settigs `data.opts.pullable` to an empty array prevents Lando from pulling images with `docker pull`.
+			// Note that if some of the images are not available, they will still be pulled by `docker-compose`.
 			data.opts.local = data.opts.pullable;
 			data.opts.pullable = [];
 		}

--- a/src/lib/dev-environment/types.js
+++ b/src/lib/dev-environment/types.js
@@ -83,6 +83,7 @@ export interface InstanceData {
 	php: string;
 	elasticsearch?: string | boolean;
 	mailhog: boolean;
+	pullAfter?: number;
 
 	[index: string]: WordPressConfig | ComponentConfig | string | boolean;
 }


### PR DESCRIPTION
## Description

  * Fix comparison of `number` with `undefined` (`undefined < Date.now() === false`);
  * Fix Flow typings for `InstanceData`.

## Steps to Test

1. Apply the patch
2. Create a new environment
3. Provided that `ghcr.io` resolves, ensure that Lando will try to pull Docker images.
