### PR TITLE
Fail with a msg if an export job with a different backup is running

### DIFF
--- a/src/bin/vip-dev-env-sync-sql.js
+++ b/src/bin/vip-dev-env-sync-sql.js
@@ -37,6 +37,7 @@ const appQuery = `
 		type
 		name
 		primaryDomain { name }
+		uniqueLabel
 	}
 `;
 


### PR DESCRIPTION
## Description

Presently, VIP does not allow running more than one export job for each site. In this PR, we are handling the case where a user initiates the `vip dev-env sync sql` command but discovers that another export job is already running on an older backup. In that scenario, we inform the user that there is an export job already running, and we cannot run another export until that finishes.

## Steps to Test

1. Check out PR.
2. Run `export VIP_PROXY=socks://localhost:8080` if you are using a8c proxy.
3. Go to https://dashboard.wpvip.com/apps/6721/production/data/database/backups and initiate an export job on any backup other than the latest one.
1. Run `rm -rf dist && npm link && node ./dist/bin/vip dev-env sync sql @6721.production --slug=wpvip`
1. Verify that it has failed with this message:
```
Error:  There is an export job already running for this site: https://dashboard.wpvip.com/apps/6721/wasif-test/data/database/backups
Currently, we allow only one export job per site. Please try again later.
```

