### PR TITLE
Dev-env: Fix silent failing when passing invalid subcommand

### DIFF
--- a/src/bin/vip-dev-env.js
+++ b/src/bin/vip-dev-env.js
@@ -15,7 +15,7 @@
 import command from '../lib/cli/command';
 
 command( {
-	requiredArgs: 1,
+	requiredArgs: 0,
 } )
 	.command( 'create', 'Create a new local dev environment' )
 	.command( 'update', 'Update an already created local dev environment' )


### PR DESCRIPTION
## Description
Running `vip dev-env nonexistentcmd` just fails silently. This PR fixes it to ensure that the correct error fires.

## Steps to Test

1. Run `npm run build`
1. Run `./dist/bin/vip-dev-env.js nonexistentcmd`
1. Expect to see:
```
Error:  `nonexistentsubcommand` is not a valid subcommand. See `vip --help`
```
1. Run `./dist/bin/vip-dev-env.js nonexistent cmd args`
1. Expect to see same error

