### PR TITLE
Fix requiredArgs for other vip commands

### DIFF
--- a/src/bin/vip-cache.js
+++ b/src/bin/vip-cache.js
@@ -15,7 +15,7 @@
 import command from '../lib/cli/command';
 
 command( {
-	requiredArgs: 2,
+	requiredArgs: 1,
 } )
 	.command( 'purge-url', 'Purge page cache' )
 	.argv( process.argv );

--- a/src/bin/vip-config-envvar.js
+++ b/src/bin/vip-config-envvar.js
@@ -15,7 +15,7 @@
 import command from '../lib/cli/command';
 
 command( {
-	requiredArgs: 1,
+	requiredArgs: 0,
 } )
 	.command( 'delete', 'Permanently delete an environment variable' )
 	.command( 'get', 'Get the value of an environment variable' )

--- a/src/bin/vip-validate.js
+++ b/src/bin/vip-validate.js
@@ -11,7 +11,7 @@ import command from '../lib/cli/command';
 import { trackEvent } from '../lib/tracker';
 
 command( {
-	requiredArgs: 1,
+	requiredArgs: 0,
 } )
 	.command( 'preflight', 'Runs preflight tests to validate if your application is ready to be deployed' )
 	.argv( process.argv, async () => {


### PR DESCRIPTION
## Description

Similar to #1291, let's fix it for `cache`, `config` and `validate` when invalid subcommands are passed in, so it doesn't fail silently.

## Steps to Test

1. Run `npm run build`
2. `./dist/bin/vip-cache.js nonexistentcmd`
3. `./dist/bin/vip-config.js nonexistent cmd`
4. `./dist/bin/vip-config.js non existent cmd`