### PR TITLE
fix(ci): Do not prompt for WP update

### DIFF
--- a/.github/workflows/devenv-e2e.yml
+++ b/.github/workflows/devenv-e2e.yml
@@ -38,7 +38,7 @@ jobs:
       - name: Preload Docker images
         run: |
           vip dev-env create --app-code image --php 8.0 --mu-plugins image -e false -p true --mailhog true && \
-          vip dev-env start && \
+          vip dev-env start -w && \
           vip dev-env destroy
 
       - name: Run tests

--- a/__tests__/devenv-e2e/003-start.spec.js
+++ b/__tests__/devenv-e2e/003-start.spec.js
@@ -54,7 +54,7 @@ describe( 'vip dev-env start', () => {
 		slug = getProjectSlug();
 		expect( await checkEnvExists( slug ) ).toBe( false );
 
-		const result = await cliTest.spawn( [ process.argv[ 0 ], vipDevEnvStart, '--slug', slug ], { env } );
+		const result = await cliTest.spawn( [ process.argv[ 0 ], vipDevEnvStart, '--slug', slug, '-w' ], { env } );
 		expect( result.rc ).toBeGreaterThan( 0 );
 		expect( result.stderr ).toContain( 'Error: Environment doesn\'t exist.' );
 

--- a/__tests__/devenv-e2e/helpers/utils.js
+++ b/__tests__/devenv-e2e/helpers/utils.js
@@ -68,7 +68,7 @@ export async function createAndStartEnvironment( cliTest, slug, env, options = [
 	expect( result.stdout ).toContain( `vip dev-env start --slug ${ slug }` );
 	expect( await checkEnvExists( slug ) ).toBe( true );
 
-	result = await cliTest.spawn( [ process.argv[ 0 ], vipDevEnvStart, '--slug', slug ], { env }, true );
+	result = await cliTest.spawn( [ process.argv[ 0 ], vipDevEnvStart, '--slug', slug, '-w' ], { env }, true );
 	expect( result.rc ).toBe( 0 );
 	expect( result.stdout ).toMatch( /STATUS\s+UP/u );
 }


### PR DESCRIPTION
## Description

A new WP version puts `vip dev-env` into interactive mode, and it is not supported in CI.

Ref: https://github.com/Automattic/vip-cli/actions/runs/4428897717/jobs/7768622045#step:6:57

## Steps to Test

The CI should pass.
