### PR TITLE
chore(deps): Replace socket.io-stream with @wearemothership/socket.io-stream

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -37,7 +37,7 @@
         "semver": "7.3.8",
         "single-line-log": "1.1.2",
         "socket.io-client": "^4.5.3",
-        "socket.io-stream": "0.9.1",
+        "socket.io-stream": "npm:@wearemothership/socket.io-stream@^0.9.1",
         "socks-proxy-agent": "^5.0.1",
         "update-notifier": "5.1.0",
         "uuid": "9.0.0",
@@ -16685,26 +16685,14 @@
       }
     },
     "node_modules/socket.io-stream": {
+      "name": "@wearemothership/socket.io-stream",
       "version": "0.9.1",
-      "resolved": "https://registry.npmjs.org/socket.io-stream/-/socket.io-stream-0.9.1.tgz",
-      "integrity": "sha512-yBSvp1RGwhLOP/XmgdlrCtf2rOMX1XvbPqceYuJd7tjxCI5p1dnPXS5p9zRPozUYa+/b2+sGHrqShY7Z5lVfwg==",
+      "resolved": "https://registry.npmjs.org/@wearemothership/socket.io-stream/-/socket.io-stream-0.9.1.tgz",
+      "integrity": "sha512-ZLoLvHpH9muTWWGlN2EBa4x5doeQuTD+zO5nMFmX3ndCJXw4Sy4XbfGtrgHsqspxaqqI+Hq1mOLT51pc583IIg==",
       "dependencies": {
         "component-bind": "~1.0.0",
-        "debug": "~2.2.0"
+        "debug": "~4.3.4"
       }
-    },
-    "node_modules/socket.io-stream/node_modules/debug": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
-      "integrity": "sha512-X0rGvJcskG1c3TgSCPqHJ0XJgwlcvOC7elJ5Y0hYuKBZoVqWpAMfLOeIh2UI/DCQ5ruodIjvsugZtjUYUw2pUw==",
-      "dependencies": {
-        "ms": "0.7.1"
-      }
-    },
-    "node_modules/socket.io-stream/node_modules/ms": {
-      "version": "0.7.1",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz",
-      "integrity": "sha512-lRLiIR9fSNpnP6TC4v8+4OU7oStC01esuNowdQ34L+Gk8e5Puoc88IqJ+XAY/B3Mn2ZKis8l8HX90oU8ivzUHg=="
     },
     "node_modules/socks": {
       "version": "2.6.2",
@@ -31420,27 +31408,12 @@
       }
     },
     "socket.io-stream": {
-      "version": "0.9.1",
-      "resolved": "https://registry.npmjs.org/socket.io-stream/-/socket.io-stream-0.9.1.tgz",
-      "integrity": "sha512-yBSvp1RGwhLOP/XmgdlrCtf2rOMX1XvbPqceYuJd7tjxCI5p1dnPXS5p9zRPozUYa+/b2+sGHrqShY7Z5lVfwg==",
+      "version": "npm:@wearemothership/socket.io-stream@0.9.1",
+      "resolved": "https://registry.npmjs.org/@wearemothership/socket.io-stream/-/socket.io-stream-0.9.1.tgz",
+      "integrity": "sha512-ZLoLvHpH9muTWWGlN2EBa4x5doeQuTD+zO5nMFmX3ndCJXw4Sy4XbfGtrgHsqspxaqqI+Hq1mOLT51pc583IIg==",
       "requires": {
         "component-bind": "~1.0.0",
-        "debug": "~2.2.0"
-      },
-      "dependencies": {
-        "debug": {
-          "version": "2.2.0",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
-          "integrity": "sha512-X0rGvJcskG1c3TgSCPqHJ0XJgwlcvOC7elJ5Y0hYuKBZoVqWpAMfLOeIh2UI/DCQ5ruodIjvsugZtjUYUw2pUw==",
-          "requires": {
-            "ms": "0.7.1"
-          }
-        },
-        "ms": {
-          "version": "0.7.1",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz",
-          "integrity": "sha512-lRLiIR9fSNpnP6TC4v8+4OU7oStC01esuNowdQ34L+Gk8e5Puoc88IqJ+XAY/B3Mn2ZKis8l8HX90oU8ivzUHg=="
-        }
+        "debug": "~4.3.4"
       }
     },
     "socks": {

--- a/package.json
+++ b/package.json
@@ -138,7 +138,7 @@
     "semver": "7.3.8",
     "single-line-log": "1.1.2",
     "socket.io-client": "^4.5.3",
-    "socket.io-stream": "0.9.1",
+    "socket.io-stream": "npm:@wearemothership/socket.io-stream@^0.9.1",
     "socks-proxy-agent": "^5.0.1",
     "update-notifier": "5.1.0",
     "uuid": "9.0.0",


### PR DESCRIPTION
## Description

`socket.io-stream` seems abandoned and has some security issues.

`@wearemothership/socket.io-stream` is a maintained fork of `socket.io-stream`. It has [no breaking changes](https://github.com/nkzawa/socket.io-stream/pull/128/files#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519).

This PR‌replaces the former with the latter and, as a bonus, fixes security issues caused by the outdated `debug` dependency.

## Steps to Test

1. Run `wp vip`
2. Run a valid WP‌ CLI command (e.g., `wp option get home`) and make sure it works.
