### PR TITLE
chore(dev-deps): Update nock to 13.3.0

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -109,7 +109,7 @@
         "flow-bin": "0.201.0",
         "jest": "^29.5.0",
         "jest-environment-jsdom": "^29.5.0",
-        "nock": "13.2.9",
+        "nock": "13.3.0",
         "prettier": "^2.0.5",
         "publish-please": "5.5.2",
         "rimraf": "3.0.2"
@@ -12187,9 +12187,9 @@
       "dev": true
     },
     "node_modules/nock": {
-      "version": "13.2.9",
-      "resolved": "https://registry.npmjs.org/nock/-/nock-13.2.9.tgz",
-      "integrity": "sha512-1+XfJNYF1cjGB+TKMWi29eZ0b82QOvQs2YoLNzbpWGqFMtRQHTa57osqdGj4FrFPgkO4D4AZinzUJR9VvW3QUA==",
+      "version": "13.3.0",
+      "resolved": "https://registry.npmjs.org/nock/-/nock-13.3.0.tgz",
+      "integrity": "sha512-HHqYQ6mBeiMc+N038w8LkMpDCRquCHWeNmN3v6645P3NhN2+qXOBqvPqo7Rt1VyCMzKhJ733wZqw5B7cQVFNPg==",
       "dev": true,
       "dependencies": {
         "debug": "^4.1.0",
@@ -25240,9 +25240,9 @@
       }
     },
     "nock": {
-      "version": "13.2.9",
-      "resolved": "https://registry.npmjs.org/nock/-/nock-13.2.9.tgz",
-      "integrity": "sha512-1+XfJNYF1cjGB+TKMWi29eZ0b82QOvQs2YoLNzbpWGqFMtRQHTa57osqdGj4FrFPgkO4D4AZinzUJR9VvW3QUA==",
+      "version": "13.3.0",
+      "resolved": "https://registry.npmjs.org/nock/-/nock-13.3.0.tgz",
+      "integrity": "sha512-HHqYQ6mBeiMc+N038w8LkMpDCRquCHWeNmN3v6645P3NhN2+qXOBqvPqo7Rt1VyCMzKhJ733wZqw5B7cQVFNPg==",
       "dev": true,
       "requires": {
         "debug": "^4.1.0",

--- a/package.json
+++ b/package.json
@@ -105,7 +105,7 @@
     "flow-bin": "0.201.0",
     "jest": "^29.5.0",
     "jest-environment-jsdom": "^29.5.0",
-    "nock": "13.2.9",
+    "nock": "13.3.0",
     "prettier": "^2.0.5",
     "publish-please": "5.5.2",
     "rimraf": "3.0.2"


### PR DESCRIPTION
## Description

This PR updates `nock` from 12.2.9 to [13.3.0](https://github.com/nock/nock/releases/tag/v13.3.0). There are no breaking changes.

## Steps to Test

CI should pass.