### PR TITLE
chore(dev-deps): Update dockerode to 3.3.5

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -6408,9 +6408,9 @@
       }
     },
     "node_modules/dockerode": {
-      "version": "3.3.4",
-      "resolved": "https://registry.npmjs.org/dockerode/-/dockerode-3.3.4.tgz",
-      "integrity": "sha512-3EUwuXnCU+RUlQEheDjmBE0B7q66PV9Rw5NiH1sXwINq0M9c5ERP9fxgkw36ZHOtzf4AGEEYySnkx/sACC9EgQ==",
+      "version": "3.3.5",
+      "resolved": "https://registry.npmjs.org/dockerode/-/dockerode-3.3.5.tgz",
+      "integrity": "sha512-/0YNa3ZDNeLr/tSckmD69+Gq+qVNhvKfAHNeZJBnp7EOP6RGKV8ORrJHkUn20So5wU+xxT7+1n5u8PjHbfjbSA==",
       "dev": true,
       "dependencies": {
         "@balena/dockerignore": "^1.0.2",
@@ -20819,9 +20819,9 @@
       }
     },
     "dockerode": {
-      "version": "3.3.4",
-      "resolved": "https://registry.npmjs.org/dockerode/-/dockerode-3.3.4.tgz",
-      "integrity": "sha512-3EUwuXnCU+RUlQEheDjmBE0B7q66PV9Rw5NiH1sXwINq0M9c5ERP9fxgkw36ZHOtzf4AGEEYySnkx/sACC9EgQ==",
+      "version": "3.3.5",
+      "resolved": "https://registry.npmjs.org/dockerode/-/dockerode-3.3.5.tgz",
+      "integrity": "sha512-/0YNa3ZDNeLr/tSckmD69+Gq+qVNhvKfAHNeZJBnp7EOP6RGKV8ORrJHkUn20So5wU+xxT7+1n5u8PjHbfjbSA==",
       "dev": true,
       "requires": {
         "@balena/dockerignore": "^1.0.2",


### PR DESCRIPTION
## Description

This PR‌ updates `dockerode` from 3.3.4 to 3.3.5 (adds support for node-current and fixes bugs).

## Steps to Test

E2E tests should pass.
