### PR TITLE
Fix preselected options on update

### DIFF
--- a/src/bin/vip-dev-env-update.js
+++ b/src/bin/vip-dev-env-update.js
@@ -61,12 +61,12 @@ cmd.argv( process.argv, async ( arg, opt ) => {
 		const preselectedOptions: InstanceOptions = {
 			title: currentInstanceData.wpTitle,
 			multisite: currentInstanceData.multisite,
-			...opt
-		}
+			...opt,
+		};
 
 		const configurationFileOptions = await getConfigurationFileOptions();
 		const thereAreOptionsFromConfigFile = Object.keys( configurationFileOptions ).length > 0;
-		const finalPreselectedOptions = mergeConfigurationFileOptions( preselectedOptions, configurationFileOptions )
+		const finalPreselectedOptions = mergeConfigurationFileOptions( preselectedOptions, configurationFileOptions );
 
 		const defaultOptions: InstanceOptions = {
 			appCode: currentInstanceData.appCode.dir || currentInstanceData.appCode.tag || 'latest',


### PR DESCRIPTION
## Description

Introduction of config file broke the enforced multisite and title on update.
https://github.com/Automattic/vip-cli/pull/1173

The code used to set `selectedOptions` which were then ignored. This change simplifies the code and makes it that the title and multisite is in fact preselected.

## Steps to Test

1) Create a site as multisite
2) Run update
3) You shoul NOT be prompted for multisite or title

