### PR TITLE
tests: Fix timing out tests on Windows

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -34,7 +34,7 @@ jobs:
 
       - name: Unit Tests
         working-directory: vip
-        run: npm run jest -- --testTimeout=45000
+        run: npm run jest
 
       - name: Test Command line
         working-directory: vip


### PR DESCRIPTION
## Description

This PR attempts to fix tests on Windows.

It turns out that sometimes, under high load, `child_process.exec()` takes too much time (or it takes much time to spawn docker and docker-compose). We try to fix this by providing a mock for `child_process.exec()`.

## Steps to Test

CI should pass.