### PR TITLE
tests(e2e): Force Jest to exit after all tests have completed running

### DIFF
--- a/__tests__/devenv-e2e/jest/jest.config.js
+++ b/__tests__/devenv-e2e/jest/jest.config.js
@@ -16,6 +16,7 @@ const config = {
 	testTimeout: 120000,
 	maxWorkers: process.env.CI ? 1 : 2,
 	testSequencer: path.join( __dirname, 'sequencer.js' ),
+	forceExit: true,
 };
 
 module.exports = config;


### PR DESCRIPTION
## Description

Force Jest to exit after all tests have completed running. This is useful when we (or Lando) fail to clean up after Docker.

Ref: https://github.com/Automattic/vip-cli/actions/runs/4629598563/jobs/8190056000?pr=1325#step:7:412

Docs: https://jestjs.io/docs/cli#--forceexit

## Steps to Test

CI should pass.
