### PR TITLE
ci: Set `DO_NOT_TRACK=1` for E2E tests

### DIFF
--- a/.github/workflows/devenv-e2e.yml
+++ b/.github/workflows/devenv-e2e.yml
@@ -7,6 +7,9 @@ on:
 permissions:
   contents: read
 
+env:
+  DO_NOT_TRACK: '1'
+
 jobs:
   test:
     name: Run E2E Tests, shard ${{ matrix.shard }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -4,6 +4,7 @@ on:
 
 env:
   NODE_OPTIONS: --unhandled-rejections=warn
+  DO_NOT_TRACK: '1'
 
 jobs:
   Run_windows_tests:


### PR DESCRIPTION
## Description

Our failing tests should not affect the stats so that we can get an objective picture.

## Steps to Test

CI should pass.
