### PR TITLE
feat(dev-env)!: Replace MailHog with Mailpit

### DIFF
--- a/.github/workflows/devenv-e2e.yml
+++ b/.github/workflows/devenv-e2e.yml
@@ -40,7 +40,7 @@ jobs:
 
       - name: Preload Docker images
         run: |
-          vip dev-env create --app-code image --php 8.0 --mu-plugins image -e false -p true --mailhog true && \
+          vip dev-env create --app-code image --php 8.0 --mu-plugins image -e false -p true --mailpit true && \
           vip dev-env start -w && \
           vip dev-env destroy
 

--- a/__tests__/devenv-e2e/001-create.spec.js
+++ b/__tests__/devenv-e2e/001-create.spec.js
@@ -69,7 +69,7 @@ describe( 'vip dev-env create', () => {
 		const expectedElasticsearch = false;
 		const expectedPhpMyAdmin = false;
 		const expectedXDebug = false;
-		const expectedMailHog = false;
+		const expectedMailpit = false;
 
 		expect( await checkEnvExists( slug ) ).toBe( false );
 
@@ -91,7 +91,7 @@ describe( 'vip dev-env create', () => {
 			wordpress: expect.objectContaining( { mode: 'image', tag: expect.any( String ) } ),
 			phpmyadmin: expectedPhpMyAdmin,
 			xdebug: expectedXDebug,
-			mailhog: expectedMailHog,
+			mailpit: expectedMailpit,
 		} );
 	} );
 
@@ -104,7 +104,7 @@ describe( 'vip dev-env create', () => {
 		const expectedElasticsearch = true;
 		const expectedPhpMyAdmin = true;
 		const expectedXDebug = true;
-		const expectedMailHog = true;
+		const expectedMailpit = true;
 
 		expect( await checkEnvExists( slug ) ).toBe( false );
 
@@ -121,7 +121,7 @@ describe( 'vip dev-env create', () => {
 			'-e', `${ expectedElasticsearch }`,
 			'-p', `${ expectedPhpMyAdmin }`,
 			'-x', `${ expectedXDebug }`,
-			'--mailhog', `${ expectedMailHog }`,
+			'-A', `${ expectedMailpit }`,
 		], { env }, true );
 		expect( result.rc ).toBe( 0 );
 		expect( await checkEnvExists( slug ) ).toBe( true );
@@ -140,7 +140,7 @@ describe( 'vip dev-env create', () => {
 			wordpress: expect.objectContaining( { mode: 'image', tag: expectedWordPressVersion } ),
 			phpmyadmin: expectedPhpMyAdmin,
 			xdebug: expectedXDebug,
-			mailhog: expectedMailHog,
+			mailpit: expectedMailpit,
 		} );
 	} );
 } );

--- a/__tests__/devenv-e2e/005-update.spec.js
+++ b/__tests__/devenv-e2e/005-update.spec.js
@@ -68,7 +68,7 @@ describe( 'vip dev-env update', () => {
 		const expectedElasticsearch = false;
 		const expectedPhpMyAdmin = false;
 		const expectedXDebug = false;
-		const expectedMailHog = false;
+		const expectedMailpit = false;
 
 		expect( await checkEnvExists( slug ) ).toBe( false );
 
@@ -82,7 +82,7 @@ describe( 'vip dev-env update', () => {
 			elasticsearch: expectedElasticsearch,
 			phpmyadmin: expectedPhpMyAdmin,
 			xdebug: expectedXDebug,
-			mailhog: expectedMailHog,
+			mailpit: expectedMailpit,
 		} );
 
 		result = await cliTest.spawn( [
@@ -91,7 +91,7 @@ describe( 'vip dev-env update', () => {
 			'-e', `${ ! expectedElasticsearch }`,
 			'-p', `${ ! expectedPhpMyAdmin }`,
 			'-x', `${ ! expectedXDebug }`,
-			'--mailhog', `${ ! expectedMailHog }`,
+			'-A', `${ ! expectedMailpit }`,
 		], { env }, true );
 		expect( result.rc ).toBe( 0 );
 		expect( await checkEnvExists( slug ) ).toBe( true );
@@ -102,7 +102,7 @@ describe( 'vip dev-env update', () => {
 			elasticsearch: ! expectedElasticsearch,
 			phpmyadmin: ! expectedPhpMyAdmin,
 			xdebug: ! expectedXDebug,
-			mailhog: ! expectedMailHog,
+			mailpit: ! expectedMailpit,
 		} );
 	} );
 
@@ -166,19 +166,19 @@ describe( 'vip dev-env update', () => {
 		const result = await cliTest.spawn( [
 			process.argv[ 0 ], vipDevEnvUpdate,
 			'--slug', slug,
-			'--mailhog', 'true',
+			'--mailpit', 'true',
 		], { env }, true );
 		expect( result.rc ).toBe( 0 );
 
 		const dataAfter = readEnvironmentData( slug );
 		expect( dataAfter ).toMatchObject( {
 			mariadb: expect.any( String ),
-			mailhog: true,
+			mailpit: true,
 		} );
 
 		const landofile = await readFile( dst[ 1 ], 'utf8' );
 		expect( landofile ).not.toContain( 'image: mysql:' );
 		expect( landofile ).toContain( 'image: mariadb:' );
-		expect( landofile ).toContain( 'mailhog:' );
+		expect( landofile ).toContain( 'mailpit:' );
 	} );
 } );

--- a/__tests__/devenv-e2e/011-configuration-file.spec.js
+++ b/__tests__/devenv-e2e/011-configuration-file.spec.js
@@ -109,7 +109,7 @@ describe( 'vip dev-env configuration file', () => {
 		const expectedElasticsearch = true;
 		const expectedPhpMyAdmin = true;
 		const expectedXDebug = true;
-		const expectedMailHog = true;
+		const expectedMailpit = true;
 
 		expect( await checkEnvExists( expectedSlug ) ).toBe( false );
 
@@ -123,7 +123,7 @@ describe( 'vip dev-env configuration file', () => {
 			elasticsearch: expectedElasticsearch,
 			phpmyadmin: expectedPhpMyAdmin,
 			xdebug: expectedXDebug,
-			mailhog: expectedMailHog,
+			mailpit: expectedMailpit,
 			'mu-plugins': 'image',
 			'app-code': 'image',
 		} );
@@ -152,7 +152,7 @@ describe( 'vip dev-env configuration file', () => {
 			wordpress: expect.objectContaining( { mode: 'image', tag: expectedWordPressVersion } ),
 			phpmyadmin: expectedPhpMyAdmin,
 			xdebug: expectedXDebug,
-			mailhog: expectedMailHog,
+			mailpit: expectedMailpit,
 		} );
 
 		return expect( checkEnvExists( expectedSlug ) ).resolves.toBe( true );
@@ -163,7 +163,7 @@ describe( 'vip dev-env configuration file', () => {
 		const expectedElasticsearch = false;
 		const expectedPhpMyAdmin = false;
 		const expectedXDebug = false;
-		const expectedMailHog = false;
+		const expectedMailpit = false;
 
 		expect( await checkEnvExists( slug ) ).toBe( false );
 
@@ -174,7 +174,7 @@ describe( 'vip dev-env configuration file', () => {
 			elasticsearch: expectedElasticsearch,
 			phpmyadmin: expectedPhpMyAdmin,
 			xdebug: expectedXDebug,
-			mailhog: expectedMailHog,
+			mailpit: expectedMailpit,
 		} );
 
 		const spawnOptions = {
@@ -192,7 +192,7 @@ describe( 'vip dev-env configuration file', () => {
 			elasticsearch: expectedElasticsearch,
 			phpmyadmin: expectedPhpMyAdmin,
 			xdebug: expectedXDebug,
-			mailhog: expectedMailHog,
+			mailpit: expectedMailpit,
 		} );
 
 		// Update environment from changed configuration file
@@ -202,7 +202,7 @@ describe( 'vip dev-env configuration file', () => {
 			elasticsearch: ! expectedElasticsearch,
 			phpmyadmin: ! expectedPhpMyAdmin,
 			xdebug: ! expectedXDebug,
-			mailhog: ! expectedMailHog,
+			mailpit: ! expectedMailpit,
 		} );
 
 		result = await cliTest.spawn( [ process.argv[ 0 ], vipDevEnvUpdate ], spawnOptions, true );
@@ -215,7 +215,7 @@ describe( 'vip dev-env configuration file', () => {
 			elasticsearch: ! expectedElasticsearch,
 			phpmyadmin: ! expectedPhpMyAdmin,
 			xdebug: ! expectedXDebug,
-			mailhog: ! expectedMailHog,
+			mailpit: ! expectedMailpit,
 		} );
 	} );
 } );

--- a/__tests__/e2e_test.bat
+++ b/__tests__/e2e_test.bat
@@ -14,7 +14,7 @@ rem dev-env tests
 
 echo "== Creating dev-env"
 
-call vip dev-env create --app-code image --title Test --multisite false --php 8.0 --wordpress 6.0 --mu-plugins image -e false -p false -x false --mailhog false
+call vip dev-env create --app-code image --title Test --multisite false --php 8.0 --wordpress 6.0 --mu-plugins image -e false -p false -x false --mailpit false
 
 if NOT %errorlevel% == 0 (
     echo "== Failed to create dev-env"

--- a/assets/dev-env.lando.template.yml.ejs
+++ b/assets/dev-env.lando.template.yml.ejs
@@ -9,6 +9,8 @@ proxy:
 <% } %>
   phpmyadmin:
     - <%= siteSlug %>-pma.vipdev.lndo.site
+  mailpit:
+    - <%= siteSlug %>-mailpit.vipdev.lndo.site:8025
 
 services:
   devtools:
@@ -197,9 +199,19 @@ services:
       clientcode_vipconfig: {}
 <% } %>
 
-<% if ( mailhog ) { %>
-  mailhog:
-    type: mailhog
+<% if ( mailpit ) { %>
+  mailpit:
+    type: compose
+    services:
+      image: axllent/mailpit:latest
+      command: /mailpit
+      ports:
+        - ":1025"
+        - ":8025"
+      environment:
+        LANDO_NO_USER_PERMS: 1
+        LANDO_NO_SCRIPTS: 1
+        LANDO_NEEDS_EXEC: 1
 <% } %>
 
 tooling:

--- a/src/bin/vip-dev-env-create.js
+++ b/src/bin/vip-dev-env-create.js
@@ -28,6 +28,7 @@ import {
 	handleCLIException,
 	processBooleanOption,
 	validateDependencies,
+	handleDeprecatedOptions,
 } from '../lib/dev-environment/dev-environment-cli';
 import {
 	DEV_ENVIRONMENT_FULL_COMMAND,
@@ -95,6 +96,8 @@ cmd.argv( process.argv, async ( arg, opt ) => {
 	await validateDependencies( lando, slug );
 
 	debug( 'Args: ', arg, 'Options: ', opt );
+
+	handleDeprecatedOptions( opt );
 
 	const trackingInfo = {
 		slug,

--- a/src/bin/vip-dev-env-shell.js
+++ b/src/bin/vip-dev-env-shell.js
@@ -32,6 +32,7 @@ const userMap = {
 	elasticsearch: 'elasticsearch',
 	phpmyadmin: 'www-data',
 	mailhog: 'mailhog',
+	mailpit: 'root',
 };
 
 const examples = [

--- a/src/bin/vip-dev-env-update.js
+++ b/src/bin/vip-dev-env-update.js
@@ -77,7 +77,7 @@ cmd.argv( process.argv, async ( arg, opt ) => {
 			mariadb: currentInstanceData.mariadb,
 			phpmyadmin: currentInstanceData.phpmyadmin,
 			xdebug: currentInstanceData.xdebug,
-			mailhog: currentInstanceData.mailhog,
+			mailpit: currentInstanceData.mailpit ?? currentInstanceData.mailhog,
 			mediaRedirectDomain: currentInstanceData.mediaRedirectDomain,
 			multisite: false,
 			title: '',

--- a/src/bin/vip-dev-env-update.js
+++ b/src/bin/vip-dev-env-update.js
@@ -17,7 +17,15 @@ import chalk from 'chalk';
 import { trackEvent } from '../lib/tracker';
 import command from '../lib/cli/command';
 import { DEV_ENVIRONMENT_FULL_COMMAND, DEV_ENVIRONMENT_NOT_FOUND, DEV_ENVIRONMENT_PHP_VERSIONS } from '../lib/constants/dev-environment';
-import { addDevEnvConfigurationOptions, getEnvTrackingInfo, getEnvironmentName, handleCLIException, promptForArguments, validateDependencies } from '../lib/dev-environment/dev-environment-cli';
+import {
+	addDevEnvConfigurationOptions,
+	getEnvTrackingInfo,
+	getEnvironmentName,
+	handleCLIException,
+	handleDeprecatedOptions,
+	promptForArguments,
+	validateDependencies,
+} from '../lib/dev-environment/dev-environment-cli';
 import type { InstanceOptions } from '../lib/dev-environment/types';
 import { doesEnvironmentExist, getEnvironmentPath, readEnvironmentData, updateEnvironment } from '../lib/dev-environment/dev-environment-core';
 import { bootstrapLando } from '../lib/dev-environment/dev-environment-lando';
@@ -41,6 +49,8 @@ addDevEnvConfigurationOptions( cmd );
 cmd.examples( examples );
 cmd.argv( process.argv, async ( arg, opt ) => {
 	const slug = await getEnvironmentName( opt );
+
+	handleDeprecatedOptions( opt );
 
 	const lando = await bootstrapLando();
 	await validateDependencies( lando, slug );

--- a/src/lib/dev-environment/dev-environment-cli.js
+++ b/src/lib/dev-environment/dev-environment-cli.js
@@ -639,6 +639,7 @@ export function addDevEnvConfigurationOptions( command: Command ): any {
 		.option( 'elasticsearch', 'Enable Elasticsearch (needed by Enterprise Search)', undefined, processBooleanOption )
 		.option( [ 'r', 'media-redirect-domain' ], 'Domain to redirect for missing media files. This can be used to still have images without the need to import them locally.' )
 		.option( 'php', 'Explicitly choose PHP version to use', undefined, processVersionOption )
+		.option( [ 'G', 'mailhog' ], 'Enable Mailpit. By default it is disabled (deprecated option, please use --mailpit instead)', undefined, processBooleanOption )
 		.option( [ 'A', 'mailpit' ], 'Enable Mailpit. By default it is disabled', undefined, processBooleanOption );
 }
 
@@ -709,5 +710,16 @@ export function getEnvTrackingInfo( slug: string ): any {
 		return {
 			slug,
 		};
+	}
+}
+
+export function handleDeprecatedOptions( opts: any ): void {
+	if ( opts.mailhog ) {
+		console.warn( chalk.yellow( 'Warning: --mailhog is deprecated and will be removed in a future release. Please use --mailpit instead.' ) );
+		if ( opts.mailpit === undefined ) {
+			opts.mailpit = opts.mailhog;
+		}
+
+		delete opts.mailhog;
 	}
 }

--- a/src/lib/dev-environment/dev-environment-cli.js
+++ b/src/lib/dev-environment/dev-environment-cli.js
@@ -317,13 +317,13 @@ export async function promptForArguments( preselectedOptions: InstanceOptions, d
 		xdebug: false,
 		xdebugConfig: preselectedOptions.xdebugConfig,
 		siteSlug: '',
-		mailhog: false,
+		mailpit: false,
 	};
 
 	const promptLabels = {
 		xdebug: 'XDebug',
 		phpmyadmin: 'phpMyAdmin',
-		mailhog: 'MailHog',
+		mailpit: 'Mailpit',
 	};
 
 	if ( ! instanceData.mediaRedirectDomain && defaultOptions.mediaRedirectDomain ) {
@@ -354,7 +354,7 @@ export async function promptForArguments( preselectedOptions: InstanceOptions, d
 		instanceData.elasticsearch = await promptForBoolean( 'Enable Elasticsearch (needed by Enterprise Search)?', !! defaultOptions.elasticsearch );
 	}
 
-	for ( const service of [ 'phpmyadmin', 'xdebug', 'mailhog' ] ) {
+	for ( const service of [ 'phpmyadmin', 'xdebug', 'mailpit' ] ) {
 		if ( service in instanceData ) {
 			if ( service in preselectedOptions ) {
 				instanceData[ service ] = preselectedOptions[ service ];
@@ -639,7 +639,7 @@ export function addDevEnvConfigurationOptions( command: Command ): any {
 		.option( 'elasticsearch', 'Enable Elasticsearch (needed by Enterprise Search)', undefined, processBooleanOption )
 		.option( [ 'r', 'media-redirect-domain' ], 'Domain to redirect for missing media files. This can be used to still have images without the need to import them locally.' )
 		.option( 'php', 'Explicitly choose PHP version to use', undefined, processVersionOption )
-		.option( [ 'A', 'mailhog' ], 'Enable MailHog. By default it is disabled', undefined, processBooleanOption );
+		.option( [ 'A', 'mailpit' ], 'Enable Mailpit. By default it is disabled', undefined, processBooleanOption );
 }
 
 /**

--- a/src/lib/dev-environment/dev-environment-configuration-file.js
+++ b/src/lib/dev-environment/dev-environment-configuration-file.js
@@ -105,7 +105,7 @@ async function sanitizeConfiguration( configuration: Object ): Promise<Configura
 		elasticsearch: stringToBooleanIfDefined( configuration.elasticsearch ),
 		phpmyadmin: stringToBooleanIfDefined( configuration.phpmyadmin ),
 		xdebug: stringToBooleanIfDefined( configuration.xdebug ),
-		mailhog: stringToBooleanIfDefined( configuration.mailhog ),
+		mailpit: stringToBooleanIfDefined( configuration.mailpit ?? configuration.mailhog ),
 	};
 
 	// Remove undefined values
@@ -130,7 +130,7 @@ export function mergeConfigurationFileOptions( preselectedOptions: InstanceOptio
 		phpmyadmin: configurationFileOptions.phpmyadmin,
 		xdebug: configurationFileOptions.xdebug,
 		xdebugConfig: configurationFileOptions[ 'xdebug-config' ],
-		mailhog: configurationFileOptions.mailhog,
+		mailpit: configurationFileOptions.mailpit ?? configurationFileOptions.mailhog,
 	};
 
 	const mergedOptions: InstanceOptions = {};

--- a/src/lib/dev-environment/dev-environment-core.js
+++ b/src/lib/dev-environment/dev-environment-core.js
@@ -352,6 +352,7 @@ export function readEnvironmentData( slug: string ): InstanceData {
 
 	if ( instanceData.mailhog ) {
 		instanceData.mailpit = instanceData.mailhog;
+		delete instanceData.mailhog;
 	}
 
 	return instanceData;

--- a/src/lib/dev-environment/dev-environment-core.js
+++ b/src/lib/dev-environment/dev-environment-core.js
@@ -182,9 +182,9 @@ function preProcessInstanceData( instanceData: InstanceData ): InstanceData {
 		newInstanceData.phpmyadmin = false;
 	}
 
-	// Mailhog migration
-	if ( ! newInstanceData.mailhog ) {
-		newInstanceData.mailhog = false;
+	// Mailpit migration
+	if ( ! newInstanceData.mailpit ) {
+		newInstanceData.mailpit = newInstanceData.mailhog ?? false;
 	}
 
 	// MariaDB migration
@@ -261,7 +261,7 @@ export async function showLogs( lando: Lando, slug: string, options: any = {} ):
 	debug( 'Instance path for', slug, 'is:', instancePath );
 
 	if ( options.service ) {
-		const appInfo = await landoInfo( lando, instancePath );
+		const appInfo = await landoInfo( lando, instancePath, false );
 		if ( ! appInfo.services.includes( options.service ) ) {
 			throw new UserError( `Service '${ options.service }' not found. Please choose from one: ${ appInfo.services }` );
 		}
@@ -348,6 +348,10 @@ export function readEnvironmentData( slug: string ): InstanceData {
 	if ( instanceData.clientCode ) {
 		// clientCode was renamed to appCode
 		instanceData.appCode = instanceData.clientCode;
+	}
+
+	if ( instanceData.mailhog ) {
+		instanceData.mailpit = instanceData.mailhog;
 	}
 
 	return instanceData;

--- a/src/lib/dev-environment/dev-environment-lando.js
+++ b/src/lib/dev-environment/dev-environment-lando.js
@@ -86,6 +86,7 @@ async function getLandoConfig() {
 		],
 		disablePlugins: [
 			'@lando/argv',
+			'@lando/mailhog',
 		],
 		proxyName: 'vip-dev-env-proxy',
 		userConfRoot: landoDir,
@@ -358,6 +359,10 @@ const extraServiceDisplayConfiguration = [
 	},
 	{
 		name: 'mailhog',
+		skip: true,
+	},
+	{
+		name: 'mailpit',
 		skip: true,
 	},
 ];

--- a/src/lib/dev-environment/types.js
+++ b/src/lib/dev-environment/types.js
@@ -6,13 +6,14 @@ export interface InstanceOptions {
 	muPlugins?: string;
 	appCode?: string;
 	elasticsearch?: boolean;
-	mariadb?: string;
+	mariadb?: string; // Legacy
 	php?: string;
 	mediaRedirectDomain?: string;
 	phpmyadmin?: boolean;
 	xdebug?: boolean;
 	xdebugConfig?: string;
-	mailhog?: boolean;
+	mailhog?: boolean; // Legacy
+	mailpit?: boolean;
 
 	[index: string]: string | boolean;
 }
@@ -66,7 +67,8 @@ export type ConfigurationFileOptions = {
 	phpmyadmin?: boolean;
 	xdebug?: boolean;
 	'xdebug-config'?: string;
-	mailhog?: boolean;
+	mailhog?: boolean; // Legacy
+	mailpit?: boolean;
 }
 
 export interface InstanceData {
@@ -80,10 +82,11 @@ export interface InstanceData {
 	phpmyadmin: boolean;
 	xdebug: boolean;
 	xdebugConfig?: string;
-	mariadb?: string;
+	mariadb?: string; // Legacy
 	php: string;
 	elasticsearch?: string | boolean;
-	mailhog: boolean;
+	mailhog?: boolean; // Legacy
+	mailpit: boolean;
 	pullAfter?: number;
 
 	[index: string]: WordPressConfig | ComponentConfig | string | boolean;


### PR DESCRIPTION
## Description

[Mailhog is not maintained anymore](https://github.com/mailhog/MailHog/issues/442#issuecomment-1493415258). Moreover, it has serious bugs that make it inconvenient to use:

![mailhog-1](https://user-images.githubusercontent.com/7810770/230808536-e5c3e76b-666d-4c12-849f-4e9e70367c1b.png)
![mailhog-2](https://user-images.githubusercontent.com/7810770/230808533-fa66441c-ef6d-4967-84c0-6f370cbeea0c.png)

[Mailpit](https://github.com/axllent/mailpit) is a faster alternative to MailHog; it is recommended, for example, by [Laravel](https://laravel.com/docs/10.x/sail#previewing-emails).

This PR replaces MailHog with Mailpit, retaining backward compatibility. As a side effect, there is now one more Lando plugin that we can drop: `@lando/mailhog`.

### Backward Compatibility

1. `.lando.yml` is rebuilt automatically (because we removed `@lando/mailhog`).
2. In `instance_data.json`, `mailhog` is treated as a synonym to `mailpit`.
3. `--mailhog` command line switch is aliased to `--mailpit` (and triggers a deprecation warning).

## Steps to Test

E2E tests should pass.
