### PR TITLE
chore(deps): Update xml2js to 0.5.0

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -42,7 +42,7 @@
         "update-notifier": "5.1.0",
         "uuid": "9.0.0",
         "xdg-basedir": "^4.0.0",
-        "xml2js": "^0.4.23"
+        "xml2js": "^0.5.0"
       },
       "bin": {
         "vip": "dist/bin/vip.js",
@@ -15234,9 +15234,9 @@
       }
     },
     "node_modules/xml2js": {
-      "version": "0.4.23",
-      "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.4.23.tgz",
-      "integrity": "sha512-ySPiMjM0+pLDftHgXY4By0uswI3SPKLDw/i3UXbnO8M/p28zqexCUoPmQFrYD+/1BzhGJSs2i1ERWKJAtiLrug==",
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.5.0.tgz",
+      "integrity": "sha512-drPFnkQJik/O+uPKpqSgr22mpuFHqKdbS835iAQrUC73L2F5WkboIRd63ai/2Yg6I1jzifPFKH2NTK+cfglkIA==",
       "dependencies": {
         "sax": ">=0.6.0",
         "xmlbuilder": "~11.0.0"
@@ -26793,9 +26793,9 @@
       "dev": true
     },
     "xml2js": {
-      "version": "0.4.23",
-      "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.4.23.tgz",
-      "integrity": "sha512-ySPiMjM0+pLDftHgXY4By0uswI3SPKLDw/i3UXbnO8M/p28zqexCUoPmQFrYD+/1BzhGJSs2i1ERWKJAtiLrug==",
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.5.0.tgz",
+      "integrity": "sha512-drPFnkQJik/O+uPKpqSgr22mpuFHqKdbS835iAQrUC73L2F5WkboIRd63ai/2Yg6I1jzifPFKH2NTK+cfglkIA==",
       "requires": {
         "sax": ">=0.6.0",
         "xmlbuilder": "~11.0.0"

--- a/package.json
+++ b/package.json
@@ -143,7 +143,7 @@
     "update-notifier": "5.1.0",
     "uuid": "9.0.0",
     "xdg-basedir": "^4.0.0",
-    "xml2js": "^0.4.23"
+    "xml2js": "^0.5.0"
   },
   "optionalDependencies": {
     "keytar": "7.7.0"


### PR DESCRIPTION
## Description

This fixes [CVE-2023-0842](https://nvd.nist.gov/vuln/detail/CVE-2023-0842), which is of high severity

Ref: [GHSA-776f-qx25-q3cc](https://github.com/advisories/GHSA-776f-qx25-q3cc)

It seems like [there are no breaking changes in the code](https://github.com/Leonidas-from-XIV/node-xml2js/compare/0.4.22...0.5.0).

## Steps to Test

1. Export the database from your test site.
2. Apply the patch. Don't forget to run `npm ci`.
3. Run `vip @<env> import SQL <file>`
4. Make sure everything works.
