### PR TITLE
[dev-env] Readds xdebug_config to vip dev-env update

### DIFF
--- a/src/lib/dev-environment/dev-environment-configuration-file.js
+++ b/src/lib/dev-environment/dev-environment-configuration-file.js
@@ -129,6 +129,7 @@ export function mergeConfigurationFileOptions( preselectedOptions: InstanceOptio
 		elasticsearch: configurationFileOptions.elasticsearch,
 		phpmyadmin: configurationFileOptions.phpmyadmin,
 		xdebug: configurationFileOptions.xdebug,
+		xdebugConfig: configurationFileOptions[ 'xdebug-config' ],
 		mailhog: configurationFileOptions.mailhog,
 	};
 

--- a/src/lib/dev-environment/types.js
+++ b/src/lib/dev-environment/types.js
@@ -65,6 +65,7 @@ export type ConfigurationFileOptions = {
 	elasticsearch?: boolean;
 	phpmyadmin?: boolean;
 	xdebug?: boolean;
+	'xdebug-config'?: string;
 	mailhog?: boolean;
 }
 


### PR DESCRIPTION
## Description

`xdebug_config` would not get to instance data due to it missing in the configFileMapping

## Steps to Test

1) npm run build && ./dist/bin/vip-dev-env-update.js --xdebug_config "client_host=6.tcp.ngrok.io client_port=18938" --slug test
2) Check `.lando.yml` for `XDEBUG_CONFIG: "client_host=6.tcp.ngrok.io client_port=18938"`
