### PR TITLE
feat(dev-env): Kill lando proxy when last env stops

### DIFF
--- a/src/lib/dev-environment/dev-environment-lando.js
+++ b/src/lib/dev-environment/dev-environment-lando.js
@@ -256,12 +256,38 @@ export async function landoRebuild( lando: Lando, instancePath: string ): Promis
 	}
 }
 
+/**
+ * @return {Promise<import('dockerode').NetworkInspectInfo | null>}
+ */
+async function getBridgeNetwork( lando: Lando ) {
+	const networkName = lando.config.networkBridge || 'lando_bridge_network';
+	try {
+		return lando.engine.getNetwork( networkName ).inspect();
+	} catch ( err ) {
+		debug( 'Error getting network %s: %s', networkName, err.message );
+		return null;
+	}
+}
+
+async function cleanUpLandoProxy( lando: Lando ): Promise<void> {
+	const network = await getBridgeNetwork( lando );
+	if ( network && network.Containers && ! Object.keys( network.Containers ).length ) {
+		const proxy = lando.engine.docker.getContainer( lando.config.proxyContainer );
+		try {
+			await proxy.remove( { force: true } );
+		} catch ( err ) {
+			debug( 'Error removing proxy container: %s', err.message );
+		}
+	}
+}
+
 export async function landoStop( lando: Lando, instancePath: string ): Promise<void> {
 	const started = new Date();
 	try {
 		debug( 'Will stop lando app on path:', instancePath );
 
 		const app = await getLandoApplication( lando, instancePath );
+		app.events.once( 'post-stop', () => cleanUpLandoProxy( lando ));
 		await app.stop();
 	} finally {
 		const duration = new Date().getTime() - started.getTime();
@@ -275,6 +301,7 @@ export async function landoDestroy( lando: Lando, instancePath: string ): Promis
 		debug( 'Will destroy lando app on path:', instancePath );
 
 		const app = await getLandoApplication( lando, instancePath );
+		app.events.once( 'post-stop', () => cleanUpLandoProxy( lando ));
 		await app.destroy();
 	} finally {
 		const duration = new Date().getTime() - started.getTime();


### PR DESCRIPTION
## Description

This PR adds functionality to stop and remove Lando proxy when the last environment exits. This makes ports 80 and 443 available to other applications.

Fixes: #1335

## Steps to Test

1. Create and start two environments.
2. Stop one of them. Make sure that the proxy container is running.
3. Stop the other. The proxy container should be removed now.

Without this patch, the proxy container will still be running.
