### PR TITLE
feat(dev-env): Add a concept of init-only containers

### DIFF
--- a/__tests__/devenv-e2e/003-start.spec.js
+++ b/__tests__/devenv-e2e/003-start.spec.js
@@ -75,16 +75,7 @@ describe( 'vip dev-env start', () => {
 		await createAndStartEnvironment( cliTest, slug, env );
 
 		const containersAfterStart = await getContainersForProject( docker, slug );
-		const expectedServices = [
-			'php',
-			'vip-mu-plugins',
-			'wordpress',
-			'database',
-			'memcached',
-			'demo-app-code',
-			'nginx',
-			'devtools',
-		];
+		const expectedServices = [ 'php', 'database', 'memcached', 'nginx' ];
 
 		expectedServices.forEach( service =>
 			expect(

--- a/assets/dev-env.lando.template.yml.ejs
+++ b/assets/dev-env.lando.template.yml.ejs
@@ -17,7 +17,7 @@ services:
     type: compose
     services:
       image: ghcr.io/automattic/vip-container-images/dev-tools:0.9
-      command: sleep infinity
+      command: exit 0
       volumes:
         - devtools:/dev-tools
         - scripts:/scripts
@@ -28,6 +28,7 @@ services:
     volumes:
       devtools: {}
       scripts:
+    initOnly: true
 
   nginx:
     type: compose
@@ -154,6 +155,7 @@ services:
     type: compose
     services:
       image: ghcr.io/automattic/vip-container-images/wordpress:<%= wordpress.tag %>
+#      command: /usr/local/bin/entrypoint.sh
       command: sh -c "rsync -a --chown=www-data:www-data /wp/ /shared/; sleep infinity"
       volumes:
         - ./wordpress:/shared
@@ -162,6 +164,10 @@ services:
           target: /scripts
           volume:
             nocopy: true
+#      environment:
+#        LANDO_NO_SCRIPTS: 1
+#        LANDO_NEEDS_EXEC: 1
+#    initOnly: true
 
 <% if ( muPlugins.mode == 'image' ) { %>
   vip-mu-plugins:
@@ -181,6 +187,7 @@ services:
         LANDO_NEEDS_EXEC: 1
     volumes:
       mu-plugins: {}
+    initOnly: true
 <% } %>
 
 <% if ( appCode.mode == 'image' ) { %>
@@ -188,7 +195,7 @@ services:
     type: compose
     services:
       image: ghcr.io/automattic/vip-container-images/skeleton:latest
-      command: sleep infinity
+      command: exit 0
       volumes:
         - clientcode_clientmuPlugins:/clientcode/client-mu-plugins
         - clientcode_images:/clientcode/images
@@ -205,6 +212,7 @@ services:
       clientcode_private: {}
       clientcode_themes: {}
       clientcode_vipconfig: {}
+    initOnly: true
 <% } %>
 
 <% if ( mailpit ) { %>

--- a/src/bin/vip-dev-env-shell.js
+++ b/src/bin/vip-dev-env-shell.js
@@ -26,14 +26,10 @@ import { bootstrapLando, landoShell } from '../lib/dev-environment/dev-environme
 const debug = debugLib( '@automattic/vip:bin:dev-environment' );
 
 const userMap = {
-	devtools: 'www-data',
 	nginx: 'www-data',
 	php: 'www-data',
 	database: 'mysql',
 	memcached: 'memcache',
-	wordpress: 'www-data',
-	'vip-mu-plugins': 'www-data',
-	'demo-app-code': 'www-data',
 	elasticsearch: 'elasticsearch',
 	phpmyadmin: 'www-data',
 	mailhog: 'mailhog',

--- a/src/lib/dev-environment/dev-environment-lando.ts
+++ b/src/lib/dev-environment/dev-environment-lando.ts
@@ -466,10 +466,11 @@ async function getExtraServicesConnections(
 		// eslint-disable-next-line no-await-in-loop
 		const containerScan = service.id ? await lando.engine.docker.scan( service.id ) : null;
 		if ( containerScan?.NetworkSettings.Ports ) {
+			type ExternalMapping = ( typeof containerScan.NetworkSettings.Ports )[ number ];
+
 			const mappings = Object.keys( containerScan.NetworkSettings.Ports )
 				.map( internalPort => containerScan.NetworkSettings.Ports[ internalPort ] )
-				// eslint-disable-next-line
-				.filter( externalMapping => externalMapping?.length );
+				.filter( ( externalMapping: ExternalMapping | undefined ) => externalMapping?.length );
 
 			if ( mappings.length ) {
 				const { HostIp: host, HostPort: port } = mappings[ 0 ][ 0 ];

--- a/src/lib/dev-environment/dev-environment-lando.ts
+++ b/src/lib/dev-environment/dev-environment-lando.ts
@@ -468,7 +468,8 @@ async function getExtraServicesConnections(
 		if ( containerScan?.NetworkSettings.Ports ) {
 			const mappings = Object.keys( containerScan.NetworkSettings.Ports )
 				.map( internalPort => containerScan.NetworkSettings.Ports[ internalPort ] )
-				.filter( externalMapping => externalMapping.length );
+				// eslint-disable-next-line
+				.filter( externalMapping => externalMapping?.length );
 
 			if ( mappings.length ) {
 				const { HostIp: host, HostPort: port } = mappings[ 0 ][ 0 ];

--- a/src/lib/dev-environment/dev-environment-lando.ts
+++ b/src/lib/dev-environment/dev-environment-lando.ts
@@ -93,6 +93,25 @@ async function getLandoConfig(): Promise< LandoConfig > {
 
 const appMap = new Map< string, App >();
 
+async function initLandoApplication( lando: Lando, instancePath: string ): Promise< App > {
+	const app = lando.getApp( instancePath );
+
+	app.events.on( 'post-init', 1, () => {
+		const initOnly: string[] = [];
+		Object.keys( app.config.services! ).forEach( serviceName => {
+			if ( app.config.services![ serviceName ].initOnly ) {
+				initOnly.push( serviceName );
+				app.config.services![ serviceName ].scanner = false;
+			}
+		} );
+
+		app.services = app.services.filter( service => ! initOnly.includes( service ) );
+	} );
+
+	await app.init();
+	return app;
+}
+
 async function regenerateLandofile( instancePath: string ): Promise< void > {
 	const landoFile = path.join( instancePath, '.lando.yml' );
 
@@ -128,9 +147,7 @@ async function landoRecovery( lando: Lando, instancePath: string, error: unknown
 
 	console.error( chalk.green( 'Recovery successful, trying to initialize again...' ) );
 	try {
-		const app = lando.getApp( instancePath );
-		await app.init();
-		return app;
+		return await initLandoApplication( lando, instancePath );
 	} catch ( initError ) {
 		console.error(
 			`${ chalk.bold.red(
@@ -155,8 +172,7 @@ async function getLandoApplication( lando: Lando, instancePath: string ): Promis
 		let app;
 
 		try {
-			app = lando.getApp( instancePath );
-			await app.init();
+			app = await initLandoApplication( lando, instancePath );
 		} catch ( error ) {
 			app = await landoRecovery( lando, instancePath, error );
 		}

--- a/types/lando/lib/app.d.ts
+++ b/types/lando/lib/app.d.ts
@@ -150,7 +150,7 @@ declare class App {
 	init(): Promise< void >;
 	composeData: any[];
 	envFiles: any;
-	services: any;
+	services: string[];
 	compose: any;
 	initialized: boolean;
 	/**

--- a/types/lando/lib/lando.d.ts
+++ b/types/lando/lib/lando.d.ts
@@ -4,6 +4,11 @@ type PluginDirEntry = string | {
     namespace: string;
 };
 
+export interface LandoService extends Record<string, unknown> {
+    initOnly?: boolean;
+    scanner?: boolean;
+}
+
 export interface LandoConfig extends Record<string, unknown> {
     composeBin: string;
     disablePlugins: string[];
@@ -35,6 +40,7 @@ export interface LandoConfig extends Record<string, unknown> {
     networkBridge?: string;
 
     tooling?: Record<string, Record<string, unknown>>;
+    services?: Record<string, LandoService>;
 }
 
 export interface LandoTask {


### PR DESCRIPTION
## Description

This PR adds a concept of "init-only" containers: they run some initialization code and the exit. This allows us to save some RAM and CPU cycles.

## Steps to Test

a. The CI should pass.
b. Apply the patch, create a new dev environment from scratch, play with it, stop it, restart it, destroy it - everything should work.
