### PR TITLE
fix(dev-env): Do not fail when lando_bridge_network does not exist

### DIFF
--- a/src/lib/dev-environment/dev-environment-lando.js
+++ b/src/lib/dev-environment/dev-environment-lando.js
@@ -270,7 +270,7 @@ export async function landoRebuild( lando: Lando, instancePath: string ): Promis
 async function getBridgeNetwork( lando: Lando ) {
 	const networkName = lando.config.networkBridge || 'lando_bridge_network';
 	try {
-		return lando.engine.getNetwork( networkName ).inspect();
+		return await lando.engine.getNetwork( networkName ).inspect();
 	} catch ( err ) {
 		debug( 'Error getting network %s: %s', networkName, err.message );
 		return null;


### PR DESCRIPTION
## Description

Because of the missing `await`, if `lando_bridge_network` does not exist, `vip dev-env destroy` might fail.

## Steps to Test

CI must pass.
