### PR TITLE
fix(dev-env): Force image pulling after recovering Landofile

### DIFF
--- a/src/lib/dev-environment/dev-environment-lando.js
+++ b/src/lib/dev-environment/dev-environment-lando.js
@@ -115,6 +115,7 @@ async function regenerateLandofile( instancePath: string ): Promise<void> {
 
 	const slug = path.basename( instancePath );
 	const currentInstanceData = readEnvironmentData( slug );
+	currentInstanceData.pullAfter = 0;
 	await updateEnvironment( currentInstanceData );
 }
 


### PR DESCRIPTION
## Description

When we recover a corrupt Landofile (or doing a migration :-) ), it makes sense to force pull fresh images to avoid unexpected errors.

## Steps to Test

CI should pass.
