### PR TITLE
fix(dev-env): Do not run URL scan unless really need to

### DIFF
--- a/types/lando/lib/app.d.ts
+++ b/types/lando/lib/app.d.ts
@@ -9,7 +9,7 @@ export interface ServiceInfo {
 	healthy: boolean;
 }
 
-interface ScanResult {
+export interface ScanResult {
 	url: string;
 	status: boolean;
 	color: 'green' | 'yellow' | 'red';
@@ -71,6 +71,7 @@ declare class App {
 	metrics: any;
 	Promise: any;
 	events: import("lando/lib/events");
+	urls: ScanResult[] | undefined;
 	scanUrls: (urls: string[], options?: { max?: number, waitCodes?: number[] }) => Promise<ScanResult[]>;
 	/**
 	 * The apps configuration


### PR DESCRIPTION
## Description

When we start an environment, we scan URLs twice: first, Lando does that after bringing the containers up; second, we do when displaying the information about the started environment.

```
vip-local 13:56:26 VERBOSE ==> about to scan urls 
vip-local 13:56:26 DEBUG ==> scanning data urls=[http://vip-local.vipdev.lndo.site/, https://vip-local.vipdev.lndo.site/], max=16, waitCodes=[400, 502, 404]
vip-local 13:56:26 DEBUG ==> checking to see if http://vip-local.vipdev.lndo.site/ is ready. 
vip-local 13:56:26 DEBUG ==> checking to see if https://vip-local.vipdev.lndo.site/ is ready. 
vip-local 13:56:26 DEBUG ==> scan response https://vip-local.vipdev.lndo.site/ received status=200, cache-control=no-cache, must-revalidate, max-age=0, content-type=text/html; charset=UTF-8, date=Mon, 01 May 2023 10:56:26 GMT, expires=Wed, 11 Jan 1984 05:00:00 GMT, host-header=a9130478a60e5f9135f765b23f26593b, link=<https://vip-local.vipdev.lndo.site/wp-json/>; rel="https://api.w.org/", server=nginx/1.23.3, x-hacker=If you're reading this, you should visit wpvip.com/careers and apply to join the fun, mention this header., x-powered-by=WordPress VIP <https://wpvip.com>, x-robots-tag=noindex, nofollow, connection=close, transfer-encoding=chunked
vip-local 13:56:26 DEBUG ==> https://vip-local.vipdev.lndo.site/ is ready 
vip-local 13:56:26 DEBUG ==> scan response http://vip-local.vipdev.lndo.site/ received status=200, cache-control=no-cache, must-revalidate, max-age=0, content-type=text/html; charset=UTF-8, date=Mon, 01 May 2023 10:56:26 GMT, expires=Wed, 11 Jan 1984 05:00:00 GMT, host-header=a9130478a60e5f9135f765b23f26593b, link=<http://vip-local.vipdev.lndo.site/wp-json/>; rel="https://api.w.org/", server=nginx/1.23.3, x-hacker=If you're reading this, you should visit wpvip.com/careers and apply to join the fun, mention this header., x-powered-by=WordPress VIP <https://wpvip.com>, x-robots-tag=noindex, nofollow, connection=close, transfer-encoding=chunked
vip-local 13:56:26 DEBUG ==> http://vip-local.vipdev.lndo.site/ is ready 
vip-local 13:56:26 VERBOSE ==> scan completed. 
vip-local 13:56:26 DEBUG ==> scan results. url=http://vip-local.vipdev.lndo.site/, status=true, color=green, url=https://vip-local.vipdev.lndo.site/, status=true, color=green
vip-local 13:56:26 INFO ==> running build steps... 
...
  @automattic/vip:bin:dev-environment landoRebuild() took 12564 ms +10s
  @automattic/vip:bin:dev-environment Will get info for an environment vip-local +10s
  @automattic/vip:bin:dev-environment Instance path for vip-local is: /home/volodymyr/.local/share/vip/dev-environment/vip-local +0ms
  @automattic/vip:bin:dev-environment Will check for environment at /home/volodymyr/.local/share/vip/dev-environment/vip-local +0ms
  @automattic/vip:bin:dev-environment getLandoApplication() took 0 ms +0ms
  @automattic/vip:bin:dev-environment getLandoApplication() took 0 ms +0ms
vip-local 13:56:31 VERBOSE ==> about to scan urls 
vip-local 13:56:31 DEBUG ==> scanning data urls=[http://vip-local.vipdev.lndo.site/, https://vip-local.vipdev.lndo.site/], max=1, waitCodes=[400, 502, 404]
vip-local 13:56:31 DEBUG ==> checking to see if http://vip-local.vipdev.lndo.site/ is ready. 
vip-local 13:56:31 DEBUG ==> checking to see if https://vip-local.vipdev.lndo.site/ is ready. 
vip-local 13:56:31 DEBUG ==> scan response http://vip-local.vipdev.lndo.site/ received status=200, cache-control=no-cache, must-revalidate, max-age=0, content-type=text/html; charset=UTF-8, date=Mon, 01 May 2023 10:56:31 GMT, expires=Wed, 11 Jan 1984 05:00:00 GMT, host-header=a9130478a60e5f9135f765b23f26593b, link=<http://vip-local.vipdev.lndo.site/wp-json/>; rel="https://api.w.org/", server=nginx/1.23.3, x-hacker=If you're reading this, you should visit wpvip.com/careers and apply to join the fun, mention this header., x-powered-by=WordPress VIP <https://wpvip.com>, x-robots-tag=noindex, nofollow, connection=close, transfer-encoding=chunked
vip-local 13:56:31 DEBUG ==> http://vip-local.vipdev.lndo.site/ is ready 
vip-local 13:56:31 DEBUG ==> scan response https://vip-local.vipdev.lndo.site/ received status=200, cache-control=no-cache, must-revalidate, max-age=0, content-type=text/html; charset=UTF-8, date=Mon, 01 May 2023 10:56:31 GMT, expires=Wed, 11 Jan 1984 05:00:00 GMT, host-header=a9130478a60e5f9135f765b23f26593b, link=<https://vip-local.vipdev.lndo.site/wp-json/>; rel="https://api.w.org/", server=nginx/1.23.3, x-hacker=If you're reading this, you should visit wpvip.com/careers and apply to join the fun, mention this header., x-powered-by=WordPress VIP <https://wpvip.com>, x-robots-tag=noindex, nofollow, connection=close, transfer-encoding=chunked
vip-local 13:56:31 DEBUG ==> https://vip-local.vipdev.lndo.site/ is ready 
vip-local 13:56:31 VERBOSE ==> scan completed. 
vip-local 13:56:31 DEBUG ==> scan results. url=http://vip-local.vipdev.lndo.site/, status=true, color=green, url=https://vip-local.vipdev.lndo.site/, status=true, color=green
```

However, the second scan isn't really necessary because Lando caches the results of the scan. By reusing them, we can avoid the unnecessary scan and save some time.

## Steps to Test

1. Apply the patch, `npm run build; npm link`
2. Run `DEBUG=*,-modem vip dev-env start`
3. Observe that `VERBOSE ==> about to scan urls` occurs only once in the output
