### PR TITLE
[dev-env] add vscode flag to event tracking for start

### DIFF
--- a/src/bin/vip-dev-env-start.js
+++ b/src/bin/vip-dev-env-start.js
@@ -48,6 +48,7 @@ command()
 		const startProcessing = new Date();
 
 		const trackingInfo = getEnvTrackingInfo( slug );
+		trackingInfo.vscode = !! opt.vscode;
 		await trackEvent( 'dev_env_start_command_execute', trackingInfo );
 
 		debug( 'Args: ', arg, 'Options: ', opt );


### PR DESCRIPTION
## Description

This adds `vscode: true/false` for `vip dev-env start` tracking events to show if users use the new `--vscode` feature or not.

## Steps to Test

```
npm run build && ./dist/bin/vip-dev-env-start.js --slug vip_local  --debug @automattic/vip:analytics:clients:pendo
...
 @automattic/vip:analytics:clients:pendo send() {
...
  event: 'vip_cli_dev_dev_env_start_command_execute',
  properties: {
    cli_version: '2.28.2',
    os_name: 'linux',
    os_version: '5.19.0-41-generic',
    node_version: 'v16.17.0',
    slug: 'vip_local',
    vscode: false
  },
...
} +1ms
...
```


