### PR TITLE
chore(deps): Update Lando

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -29,7 +29,7 @@
         "js-yaml": "^4.1.0",
         "json2csv": "5.0.7",
         "jwt-decode": "2.2.0",
-        "lando": "github:automattic/lando-cli.git#d75a4e8",
+        "lando": "github:automattic/lando-cli.git#d58d9b3",
         "node-fetch": "^2.6.1",
         "opn": "5.5.0",
         "proxy-from-env": "^1.1.0",
@@ -10912,7 +10912,7 @@
     "node_modules/lando": {
       "name": "@lando/cli",
       "version": "3.6.5",
-      "resolved": "git+ssh://git@github.com/automattic/lando-cli.git#d75a4e8f16d03ef3f07a5958f1ae91d68f613528",
+      "resolved": "git+ssh://git@github.com/automattic/lando-cli.git#d58d9b35eda082b3f9e8fbabb5b4ffb7569b940c",
       "license": "GPL-3.0",
       "dependencies": {
         "@lando/compose": "^0.5.0",
@@ -23449,8 +23449,8 @@
       "dev": true
     },
     "lando": {
-      "version": "git+ssh://git@github.com/automattic/lando-cli.git#d75a4e8f16d03ef3f07a5958f1ae91d68f613528",
-      "from": "lando@github:automattic/lando-cli.git#d75a4e8",
+      "version": "git+ssh://git@github.com/automattic/lando-cli.git#d58d9b35eda082b3f9e8fbabb5b4ffb7569b940c",
+      "from": "lando@github:automattic/lando-cli.git#d58d9b3",
       "requires": {
         "@lando/compose": "^0.5.0",
         "@lando/mailhog": "^0.5.0",

--- a/package.json
+++ b/package.json
@@ -130,7 +130,7 @@
     "js-yaml": "^4.1.0",
     "json2csv": "5.0.7",
     "jwt-decode": "2.2.0",
-    "lando": "github:automattic/lando-cli.git#d75a4e8",
+    "lando": "github:automattic/lando-cli.git#d58d9b3",
     "node-fetch": "^2.6.1",
     "opn": "5.5.0",
     "proxy-from-env": "^1.1.0",


### PR DESCRIPTION
## Description

This PR updates Lando to include these fixes:
* [fix: Compatibility with docker-compose v2](https://github.com/Automattic/lando-cli/pull/35)
* [fix: network.external.name is deprecated in favor of network.name](https://github.com/Automattic/lando-cli/pull/37)

## Steps to Test

CI should pass.
