### PR TITLE
chore(deps): Update semver from 7.3.8 to 7.5.0

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -34,7 +34,7 @@
         "opn": "5.5.0",
         "proxy-from-env": "^1.1.0",
         "rollbar": "2.22.0",
-        "semver": "7.3.8",
+        "semver": "7.5.0",
         "shelljs": "^0.8.5",
         "single-line-log": "1.1.2",
         "socket.io-client": "^4.5.3",
@@ -13274,9 +13274,9 @@
       }
     },
     "node_modules/semver": {
-      "version": "7.3.8",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.8.tgz",
-      "integrity": "sha512-NB1ctGL5rlHrPJtFDVIVzTyQylMLu9N9VICA6HSFJo8MCGVTMW6gfpicwKmmK/dAjTOrqu5l63JJOpDSrAis3A==",
+      "version": "7.5.0",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.0.tgz",
+      "integrity": "sha512-+XC0AD/R7Q2mPSRuy2Id0+CGTZ98+8f+KvwirxOKIEyid+XSx6HbC63p+O4IndTHuX5Z+JxQ0TghCkO5Cg/2HA==",
       "dependencies": {
         "lru-cache": "^6.0.0"
       },
@@ -25271,9 +25271,9 @@
       }
     },
     "semver": {
-      "version": "7.3.8",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.8.tgz",
-      "integrity": "sha512-NB1ctGL5rlHrPJtFDVIVzTyQylMLu9N9VICA6HSFJo8MCGVTMW6gfpicwKmmK/dAjTOrqu5l63JJOpDSrAis3A==",
+      "version": "7.5.0",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.0.tgz",
+      "integrity": "sha512-+XC0AD/R7Q2mPSRuy2Id0+CGTZ98+8f+KvwirxOKIEyid+XSx6HbC63p+O4IndTHuX5Z+JxQ0TghCkO5Cg/2HA==",
       "requires": {
         "lru-cache": "^6.0.0"
       },

--- a/package.json
+++ b/package.json
@@ -135,7 +135,7 @@
     "opn": "5.5.0",
     "proxy-from-env": "^1.1.0",
     "rollbar": "2.22.0",
-    "semver": "7.3.8",
+    "semver": "7.5.0",
     "shelljs": "^0.8.5",
     "single-line-log": "1.1.2",
     "socket.io-client": "^4.5.3",


### PR DESCRIPTION
## Description

This PR umps `semver` from 7.3.8 to 7.5.0.

Changes:
* [7.5.0](https://github.com/npm/node-semver/releases/tag/v7.5.0)
* [7.4.0](https://github.com/npm/node-semver/releases/tag/v7.4.0)

[Diff](https://github.com/npm/node-semver/compare/v7.3.8...v7.5.0)

## Steps to Test

CI should pass.
