### PR TITLE
chore(deps): Update node-fetch from 2.6.9 to 2.6.11

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -11719,9 +11719,9 @@
       }
     },
     "node_modules/node-fetch": {
-      "version": "2.6.9",
-      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.9.tgz",
-      "integrity": "sha512-DJm/CJkZkRjKKj4Zi4BsKVZh3ValV5IR5s7LVZnW+6YMh0W1BfNA8XSs6DLMGYlId5F3KnA70uu2qepcR08Qqg==",
+      "version": "2.6.10",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.10.tgz",
+      "integrity": "sha512-5YytjUVbwzjE/BX4N62vnPPkGNxlJPwdA9/ArUc4pcM6cYS4Hinuv4VazzwjMGgnWuiQqcemOanib/5PpcsGug==",
       "dependencies": {
         "whatwg-url": "^5.0.0"
       },
@@ -24143,9 +24143,9 @@
       }
     },
     "node-fetch": {
-      "version": "2.6.9",
-      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.9.tgz",
-      "integrity": "sha512-DJm/CJkZkRjKKj4Zi4BsKVZh3ValV5IR5s7LVZnW+6YMh0W1BfNA8XSs6DLMGYlId5F3KnA70uu2qepcR08Qqg==",
+      "version": "2.6.10",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.10.tgz",
+      "integrity": "sha512-5YytjUVbwzjE/BX4N62vnPPkGNxlJPwdA9/ArUc4pcM6cYS4Hinuv4VazzwjMGgnWuiQqcemOanib/5PpcsGug==",
       "requires": {
         "whatwg-url": "^5.0.0"
       }

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -11719,9 +11719,9 @@
       }
     },
     "node_modules/node-fetch": {
-      "version": "2.6.10",
-      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.10.tgz",
-      "integrity": "sha512-5YytjUVbwzjE/BX4N62vnPPkGNxlJPwdA9/ArUc4pcM6cYS4Hinuv4VazzwjMGgnWuiQqcemOanib/5PpcsGug==",
+      "version": "2.6.11",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.11.tgz",
+      "integrity": "sha512-4I6pdBY1EthSqDmJkiNk3JIT8cswwR9nfeW/cPdUagJYEQG7R95WRH74wpz7ma8Gh/9dI9FP+OU+0E4FvtA55w==",
       "dependencies": {
         "whatwg-url": "^5.0.0"
       },
@@ -24143,9 +24143,9 @@
       }
     },
     "node-fetch": {
-      "version": "2.6.10",
-      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.10.tgz",
-      "integrity": "sha512-5YytjUVbwzjE/BX4N62vnPPkGNxlJPwdA9/ArUc4pcM6cYS4Hinuv4VazzwjMGgnWuiQqcemOanib/5PpcsGug==",
+      "version": "2.6.11",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.11.tgz",
+      "integrity": "sha512-4I6pdBY1EthSqDmJkiNk3JIT8cswwR9nfeW/cPdUagJYEQG7R95WRH74wpz7ma8Gh/9dI9FP+OU+0E4FvtA55w==",
       "requires": {
         "whatwg-url": "^5.0.0"
       }


### PR DESCRIPTION
## Description

This PR updates `node-fetch` from 2.6.9 to [2.6.11](https://github.com/node-fetch/node-fetch/releases/tag/v2.6.11) ~and includes a bug fix for handling BOM in text and JSON responses~.

## Steps to Test

CI should pass.
