### PR TITLE
chore(dev-deps): Update nock from 13.3.0 to 13.3.1

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -110,7 +110,7 @@
         "flow-bin": "^0.205.1",
         "jest": "^29.5.0",
         "jest-environment-jsdom": "^29.5.0",
-        "nock": "13.3.0",
+        "nock": "13.3.1",
         "prettier": "^2.0.5",
         "publish-please": "5.5.2",
         "rimraf": "3.0.2"
@@ -11646,9 +11646,9 @@
       "integrity": "sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ=="
     },
     "node_modules/nock": {
-      "version": "13.3.0",
-      "resolved": "https://registry.npmjs.org/nock/-/nock-13.3.0.tgz",
-      "integrity": "sha512-HHqYQ6mBeiMc+N038w8LkMpDCRquCHWeNmN3v6645P3NhN2+qXOBqvPqo7Rt1VyCMzKhJ733wZqw5B7cQVFNPg==",
+      "version": "13.3.1",
+      "resolved": "https://registry.npmjs.org/nock/-/nock-13.3.1.tgz",
+      "integrity": "sha512-vHnopocZuI93p2ccivFyGuUfzjq2fxNyNurp7816mlT5V5HF4SzXu8lvLrVzBbNqzs+ODooZ6OksuSUNM7Njkw==",
       "dev": true,
       "dependencies": {
         "debug": "^4.1.0",
@@ -24078,9 +24078,9 @@
       "integrity": "sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ=="
     },
     "nock": {
-      "version": "13.3.0",
-      "resolved": "https://registry.npmjs.org/nock/-/nock-13.3.0.tgz",
-      "integrity": "sha512-HHqYQ6mBeiMc+N038w8LkMpDCRquCHWeNmN3v6645P3NhN2+qXOBqvPqo7Rt1VyCMzKhJ733wZqw5B7cQVFNPg==",
+      "version": "13.3.1",
+      "resolved": "https://registry.npmjs.org/nock/-/nock-13.3.1.tgz",
+      "integrity": "sha512-vHnopocZuI93p2ccivFyGuUfzjq2fxNyNurp7816mlT5V5HF4SzXu8lvLrVzBbNqzs+ODooZ6OksuSUNM7Njkw==",
       "dev": true,
       "requires": {
         "debug": "^4.1.0",

--- a/package.json
+++ b/package.json
@@ -105,7 +105,7 @@
     "flow-bin": "^0.205.1",
     "jest": "^29.5.0",
     "jest-environment-jsdom": "^29.5.0",
-    "nock": "13.3.0",
+    "nock": "13.3.1",
     "prettier": "^2.0.5",
     "publish-please": "5.5.2",
     "rimraf": "3.0.2"


### PR DESCRIPTION
## Description

This PR updates `nock` from 13.3.0 to 13.3.1 to fix a compatibility issue with Node 18.

## Steps to Test

CI should pass.
