### PR TITLE
fix(dev-env): Properly handle non-string arguments in resolvePhpVersion()

### DIFF
--- a/__tests__/lib/dev-environment/dev-environment-cli.js
+++ b/__tests__/lib/dev-environment/dev-environment-cli.js
@@ -1,7 +1,5 @@
 /* eslint-disable jest/no-conditional-expect */
-/**
- * @format
- */
+// @format
 
 /**
  * External dependencies
@@ -10,10 +8,10 @@ import chalk from 'chalk';
 import { prompt, selectRunMock, confirmRunMock } from 'enquirer';
 import nock from 'nock';
 import os from 'os';
+
 /**
  * Internal dependencies
  */
-
 import {
 	getEnvironmentName,
 	getEnvironmentStartCommand,
@@ -23,9 +21,11 @@ import {
 	promptForArguments,
 	setIsTTY,
 	processVersionOption,
+	resolvePhpVersion,
 } from '../../../src/lib/dev-environment/dev-environment-cli';
 import * as devEnvCore from '../../../src/lib/dev-environment/dev-environment-core';
 import * as devEnvConfiguration from '../../../src/lib/dev-environment/dev-environment-configuration-file';
+import { DEV_ENVIRONMENT_PHP_VERSIONS } from '../../../src/lib/constants/dev-environment';
 
 jest.mock( 'enquirer', () => {
 	const _selectRunMock = jest.fn();
@@ -538,4 +538,22 @@ describe( 'lib/dev-environment/dev-environment-cli', () => {
 			expect( version ).toStrictEqual( input.expected.wp );
 		} );
 	} );
+
+	describe( 'resolvePhpVersion', () => {
+		it.each( [
+			[ 7.4,   DEV_ENVIRONMENT_PHP_VERSIONS[ '7.4' ] ],
+			[ 8.0,   DEV_ENVIRONMENT_PHP_VERSIONS[ Object.keys( DEV_ENVIRONMENT_PHP_VERSIONS )[0] ] ],
+			[ 8.1,   DEV_ENVIRONMENT_PHP_VERSIONS[ '8.1' ] ],
+			[ 8.2,   DEV_ENVIRONMENT_PHP_VERSIONS[ '8.2' ] ],
+			[ 8,     DEV_ENVIRONMENT_PHP_VERSIONS[ Object.keys( DEV_ENVIRONMENT_PHP_VERSIONS )[0] ] ],
+			[ '7.4', DEV_ENVIRONMENT_PHP_VERSIONS[ '7.4' ] ],
+			[ '8.0', DEV_ENVIRONMENT_PHP_VERSIONS[ '8.0' ] ],
+			[ '8.1', DEV_ENVIRONMENT_PHP_VERSIONS[ '8.1' ] ],
+			[ '8.2', DEV_ENVIRONMENT_PHP_VERSIONS[ '8.2' ] ],
+			[ 'image:php:8.0', 'image:php:8.0' ]
+		] )( 'should process versions correctly', async ( input, expected ) => {
+			const actual = resolvePhpVersion( input );
+			expect( actual ).toStrictEqual( expected );
+		} );
+	} )
 } );

--- a/__tests__/lib/dev-environment/dev-environment-cli.js
+++ b/__tests__/lib/dev-environment/dev-environment-cli.js
@@ -550,7 +550,8 @@ describe( 'lib/dev-environment/dev-environment-cli', () => {
 			[ '8.0', DEV_ENVIRONMENT_PHP_VERSIONS[ '8.0' ] ],
 			[ '8.1', DEV_ENVIRONMENT_PHP_VERSIONS[ '8.1' ] ],
 			[ '8.2', DEV_ENVIRONMENT_PHP_VERSIONS[ '8.2' ] ],
-			[ 'image:php:8.0', 'image:php:8.0' ]
+			[ 'image:php:8.0', 'image:php:8.0' ],
+			[ 'ghcr.io/automattic/vip-container-images/php-fpm-ubuntu:8.0', 'ghcr.io/automattic/vip-container-images/php-fpm-ubuntu:8.0' ]
 		] )( 'should process versions correctly', async ( input, expected ) => {
 			const actual = resolvePhpVersion( input );
 			expect( actual ).toStrictEqual( expected );

--- a/__tests__/lib/dev-environment/dev-environment-cli.js
+++ b/__tests__/lib/dev-environment/dev-environment-cli.js
@@ -370,6 +370,7 @@ describe( 'lib/dev-environment/dev-environment-cli', () => {
 			},
 		] )( 'should handle title', async input => {
 			prompt.mockResolvedValue( { input: input.default.title } );
+			selectRunMock.mockResolvedValue( '' );
 
 			const result = await promptForArguments( input.preselected, input.default );
 
@@ -428,6 +429,7 @@ describe( 'lib/dev-environment/dev-environment-cli', () => {
 			},
 		] )( 'should handle multisite', async input => {
 			confirmRunMock.mockResolvedValue( input.default.multisite );
+			selectRunMock.mockResolvedValue( '' );
 
 			const result = await promptForArguments( input.preselected, input.default );
 
@@ -465,6 +467,7 @@ describe( 'lib/dev-environment/dev-environment-cli', () => {
 			},
 		] )( 'should handle media redirect query', async input => {
 			confirmRunMock.mockResolvedValue( input.default.mediaRedirectDomain );
+			selectRunMock.mockResolvedValue( '' );
 
 			const result = await promptForArguments( input.preselected, input.default );
 
@@ -499,6 +502,8 @@ describe( 'lib/dev-environment/dev-environment-cli', () => {
 				},
 			},
 		] )( 'should handle mariadb', async input => {
+			selectRunMock.mockResolvedValue( '' );
+
 			const result = await promptForArguments( input.preselected, input.default );
 
 			const expectedMaria = input.preselected.mariadb ? input.preselected.mariadb : input.default.mariadb;
@@ -541,11 +546,6 @@ describe( 'lib/dev-environment/dev-environment-cli', () => {
 
 	describe( 'resolvePhpVersion', () => {
 		it.each( [
-			[ 7.4,   DEV_ENVIRONMENT_PHP_VERSIONS[ '7.4' ] ],
-			[ 8.0,   DEV_ENVIRONMENT_PHP_VERSIONS[ Object.keys( DEV_ENVIRONMENT_PHP_VERSIONS )[0] ] ],
-			[ 8.1,   DEV_ENVIRONMENT_PHP_VERSIONS[ '8.1' ] ],
-			[ 8.2,   DEV_ENVIRONMENT_PHP_VERSIONS[ '8.2' ] ],
-			[ 8,     DEV_ENVIRONMENT_PHP_VERSIONS[ Object.keys( DEV_ENVIRONMENT_PHP_VERSIONS )[0] ] ],
 			[ '7.4', DEV_ENVIRONMENT_PHP_VERSIONS[ '7.4' ] ],
 			[ '8.0', DEV_ENVIRONMENT_PHP_VERSIONS[ '8.0' ] ],
 			[ '8.1', DEV_ENVIRONMENT_PHP_VERSIONS[ '8.1' ] ],

--- a/src/lib/dev-environment/dev-environment-cli.js
+++ b/src/lib/dev-environment/dev-environment-cli.js
@@ -494,11 +494,7 @@ export function promptForBoolean( message: string, initial: boolean ): Promise<b
 	return Promise.resolve( initial );
 }
 
-export function resolvePhpVersion( version: string | number ): string {
-	if ( typeof version !== 'string' ) {
-		version = version?.toString() || '';
-	}
-
+export function resolvePhpVersion( version: string ): string {
 	debug( `Resolving PHP version %j`, version );
 
 	if ( version.startsWith( 'image:' ) ) {
@@ -535,7 +531,11 @@ export async function promptForPhpVersion( initialValue: string ): Promise<strin
 	if ( isStdinTTY ) {
 		const choices = Object.keys( DEV_ENVIRONMENT_PHP_VERSIONS );
 		const images = Object.values( DEV_ENVIRONMENT_PHP_VERSIONS );
-		const initial = images.findIndex( version => version === initialValue );
+		let initial = images.findIndex( version => version === initialValue );
+		if (initial === -1) {
+			choices.push(initialValue);
+			initial = choices.length - 1;
+		}
 
 		const select = new Select( {
 			message: 'PHP version to use',
@@ -642,7 +642,7 @@ export function processVersionOption( value: string ): string {
 		return parseFloat( value ).toFixed( 1 );
 	}
 
-	return value;
+	return value + '';
 }
 
 export function addDevEnvConfigurationOptions( command: Command ): any {

--- a/src/lib/dev-environment/dev-environment-cli.js
+++ b/src/lib/dev-environment/dev-environment-cli.js
@@ -494,23 +494,28 @@ export function promptForBoolean( message: string, initial: boolean ): Promise<b
 	return Promise.resolve( initial );
 }
 
-function resolvePhpVersion( version: string ): string {
-	debug( `Resolving PHP version '${ version }'` );
+export function resolvePhpVersion( version: string | number ): string {
+	if ( typeof version !== 'string' ) {
+		version = version?.toString() || '';
+	}
 
-	if ( typeof version === 'string' && version.startsWith( 'image:' ) ) {
+	debug( `Resolving PHP version %j`, version );
+
+	if ( version.startsWith( 'image:' ) ) {
 		return version;
 	}
 
-	const versions = Object.keys( DEV_ENVIRONMENT_PHP_VERSIONS );
-	const images = ( ( Object.values( DEV_ENVIRONMENT_PHP_VERSIONS ): any[] ): string[] );
-
-	const index = versions.findIndex( value => value === version );
-	if ( index === -1 ) {
+	let result: string;
+	if ( DEV_ENVIRONMENT_PHP_VERSIONS[ version ] === undefined ) {
+		const images: string[] = Object.values( DEV_ENVIRONMENT_PHP_VERSIONS );
 		const image = images.find( value => value === version );
-		return image ?? images[ 0 ];
+		result = image ?? images[ 0 ];
+	} else {
+		result = DEV_ENVIRONMENT_PHP_VERSIONS[ version ];
 	}
 
-	return images[ index ];
+	debug( 'Resolved PHP image: %j', result );
+	return result;
 }
 
 export async function promptForPhpVersion( initialValue: string ): Promise<string> {

--- a/src/lib/dev-environment/dev-environment-cli.js
+++ b/src/lib/dev-environment/dev-environment-cli.js
@@ -509,7 +509,17 @@ export function resolvePhpVersion( version: string | number ): string {
 	if ( DEV_ENVIRONMENT_PHP_VERSIONS[ version ] === undefined ) {
 		const images: string[] = Object.values( DEV_ENVIRONMENT_PHP_VERSIONS );
 		const image = images.find( value => value === version );
-		result = image ?? images[ 0 ];
+		if ( image ) {
+			result = image;
+		} else if ( version.indexOf( '/' ) !== -1 ) {
+			// Assuming this is a Docker image
+			// This can happen when we first called `vip dev-env update -P image:ghcr.io/...`
+			// and then called `vip dev-env update` again. The custom image won't match our images
+			// but we still want to use it.
+			result = version;
+		} else {
+			result = images[ 0 ];
+		}
 	} else {
 		result = DEV_ENVIRONMENT_PHP_VERSIONS[ version ];
 	}


### PR DESCRIPTION
## Description

Due to the way `args` parses command-line arguments, `resolvePhpVersion()` could get a number as its argument instead of a string. This caused the strict comparison to fail; as a result, PHP 8.2 was chosen in those cases.

You can use

```
vip dev-env update -P 8.1 --debug @automattic/vip:bin:dev-environment
```

to confirm.

This PR ensures that the argument is always a string. It also adds some tests.

## Steps to Test

See above + CI should pass (we have test cases now).
