### PR TITLE
fix(dev-env): Handle `--media-redirect-domain` in `vip dev-env update`

### DIFF
--- a/src/lib/dev-environment/dev-environment-configuration-file.js
+++ b/src/lib/dev-environment/dev-environment-configuration-file.js
@@ -71,7 +71,9 @@ async function sanitizeConfiguration( configuration: Object ): Promise<Configura
 
 	if ( Array.isArray( configuration ) || typeof configuration !== 'object' ) {
 		throw new Error( genericConfigurationError );
-	} else if ( configuration[ 'configuration-version' ] === undefined || configuration.slug === undefined ) {
+	}
+
+	if ( configuration[ 'configuration-version' ] === undefined || configuration.slug === undefined ) {
 		throw new Error( genericConfigurationError );
 	}
 
@@ -106,6 +108,7 @@ async function sanitizeConfiguration( configuration: Object ): Promise<Configura
 		phpmyadmin: stringToBooleanIfDefined( configuration.phpmyadmin ),
 		xdebug: stringToBooleanIfDefined( configuration.xdebug ),
 		mailpit: stringToBooleanIfDefined( configuration.mailpit ?? configuration.mailhog ),
+		'media-redirect-domain': configuration[ 'media-redirect-domain' ],
 	};
 
 	// Remove undefined values
@@ -131,6 +134,7 @@ export function mergeConfigurationFileOptions( preselectedOptions: InstanceOptio
 		xdebug: configurationFileOptions.xdebug,
 		xdebugConfig: configurationFileOptions[ 'xdebug-config' ],
 		mailpit: configurationFileOptions.mailpit ?? configurationFileOptions.mailhog,
+		mediaRedirectDomain: configurationFileOptions[ 'media-redirect-domain' ],
 	};
 
 	const mergedOptions: InstanceOptions = {};

--- a/src/lib/dev-environment/types.js
+++ b/src/lib/dev-environment/types.js
@@ -69,6 +69,7 @@ export type ConfigurationFileOptions = {
 	'xdebug-config'?: string;
 	mailhog?: boolean; // Legacy
 	mailpit?: boolean;
+	'media-redirect-domain'?: string;
 }
 
 export interface InstanceData {


### PR DESCRIPTION
## Description

This PR fixes the bug that prevents setting/updating `mediaRedirectDomain` in `vip dev-env update`.

Fixes: #1355 

## Steps to Test

1. `vip dev-env create < /dev/null`
2. `vip dev-env update -r https://example.com`
3. Verify that `.lando.yml` does not mention `https://example.com`.
4. Apply the patch, `npm run build`
5. `vip dev-env update -r https://example.com`
6. Verify that `.lando.yml` does mention `https://example.com`.
