### PR TITLE
chore(dev-deps): Update @automattic/eslint-plugin-wpvip from 0.5.3 to 0.5.4

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -170,9 +170,9 @@
       }
     },
     "node_modules/@automattic/eslint-plugin-wpvip": {
-      "version": "0.5.3",
-      "resolved": "https://registry.npmjs.org/@automattic/eslint-plugin-wpvip/-/eslint-plugin-wpvip-0.5.3.tgz",
-      "integrity": "sha512-BPsuN6LqZMpShuuOyyiaxl7DLjlyk41XBs5wqhD1qeULNnWctGkTa8SiX9Ev88NRMtR/evApIAFIDMTQzxXV8Q==",
+      "version": "0.5.4",
+      "resolved": "https://registry.npmjs.org/@automattic/eslint-plugin-wpvip/-/eslint-plugin-wpvip-0.5.4.tgz",
+      "integrity": "sha512-piDZS4u25t4HWUMHAThcxCJONT2QxZuhAViC5yDP1DUknM58ZokX1oKffGk4XpUwI901he8snC+CGP7i4OqerA==",
       "dev": true,
       "dependencies": {
         "@babel/eslint-parser": "7.21.3",
@@ -15495,9 +15495,9 @@
       }
     },
     "@automattic/eslint-plugin-wpvip": {
-      "version": "0.5.3",
-      "resolved": "https://registry.npmjs.org/@automattic/eslint-plugin-wpvip/-/eslint-plugin-wpvip-0.5.3.tgz",
-      "integrity": "sha512-BPsuN6LqZMpShuuOyyiaxl7DLjlyk41XBs5wqhD1qeULNnWctGkTa8SiX9Ev88NRMtR/evApIAFIDMTQzxXV8Q==",
+      "version": "0.5.4",
+      "resolved": "https://registry.npmjs.org/@automattic/eslint-plugin-wpvip/-/eslint-plugin-wpvip-0.5.4.tgz",
+      "integrity": "sha512-piDZS4u25t4HWUMHAThcxCJONT2QxZuhAViC5yDP1DUknM58ZokX1oKffGk4XpUwI901he8snC+CGP7i4OqerA==",
       "dev": true,
       "requires": {
         "@babel/eslint-parser": "7.21.3",


### PR DESCRIPTION
## Description

This PR updates `@automattic/eslint-plugin-wpvip` to 0.5.4.

## Steps to Test

CI should pass.
