### PR TITLE
feature(dev-env): Add vip export sql command

### DIFF
--- a/__tests__/lib/cli/format.js
+++ b/__tests__/lib/cli/format.js
@@ -5,7 +5,7 @@
 /**
  * Internal dependencies
  */
-import { requoteArgs } from '../../../src/lib/cli/format';
+import { formatBytes, requoteArgs } from '../../../src/lib/cli/format';
 
 describe( 'utils/cli/format', () => {
 	describe( 'requoteArgs', () => {
@@ -41,6 +41,15 @@ describe( 'utils/cli/format', () => {
 		] )( 'should requote args when needed - %o', ( { input, expected } ) => {
 			const result = requoteArgs( input );
 			expect( result ).toStrictEqual( expected );
+		} );
+	} );
+
+	describe( 'formatBytes', () => {
+		it( 'should format bytes', () => {
+			expect( formatBytes( 1000 ) ).toStrictEqual( '1000 bytes' );
+			expect( formatBytes( 1024 ) ).toStrictEqual( '1 KB' );
+			expect( formatBytes( 1000000 ) ).toStrictEqual( '976.56 KB' );
+			expect( formatBytes( 10004008 ) ).toStrictEqual( '9.54 MB' );
 		} );
 	} );
 } );

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -75,6 +75,7 @@
         "vip-dev-env-start": "dist/bin/vip-dev-env-start.js",
         "vip-dev-env-stop": "dist/bin/vip-dev-env-stop.js",
         "vip-dev-env-update": "dist/bin/vip-dev-env-update.js",
+        "vip-export-sql": "dist/bin/vip-export-sql.js",
         "vip-import": "dist/bin/vip-import.js",
         "vip-import-media": "dist/bin/vip-import-media.js",
         "vip-import-media-abort": "dist/bin/vip-import-media-abort.js",

--- a/package.json
+++ b/package.json
@@ -33,6 +33,8 @@
     "vip-dev-env-start": "dist/bin/vip-dev-env-start.js",
     "vip-dev-env-stop": "dist/bin/vip-dev-env-stop.js",
     "vip-dev-env-logs": "dist/bin/vip-dev-env-logs.js",
+    "vip-export": "dist/bin/vip-export.js",
+    "vip-export-sql": "dist/bin/vip-export-sql.js",
     "vip-import": "dist/bin/vip-import.js",
     "vip-import-media": "dist/bin/vip-import-media.js",
     "vip-import-media-abort": "dist/bin/vip-import-media-abort.js",

--- a/src/bin/vip-export-sql.js
+++ b/src/bin/vip-export-sql.js
@@ -1,0 +1,55 @@
+#!/usr/bin/env node
+
+/**
+ * @flow
+ * @format
+ */
+
+/**
+ * External dependencies
+ */
+
+/**
+ * Internal dependencies
+ */
+import command from '../lib/cli/command';
+import { ExportSQLCommand } from '../commands/export-sql';
+
+
+const examples = [
+  {
+    usage: 'vip export sql @mysite.develop --output=/home/user/export.sql.gz',
+    description: 'Export SQL file from your site and save it to the specified location',
+  }
+];
+
+const appQuery = `
+  id,
+  name,
+  type,
+  organization { id, name },
+  environments{
+    id
+    appId
+    type
+    name
+    primaryDomain { name }
+  }
+`;
+
+command( {
+	appContext: true,
+	appQuery,
+	envContext: true,
+	module: 'export-sql',
+	requiredArgs: 0,
+} )
+	.option(
+		'output',
+    'Specify the location where you want to save the export file',
+	)
+	.examples( examples )
+	.argv( process.argv, async ( arg: string[], { app, env, output } ) => {
+    const exportCommand = new ExportSQLCommand( app, env, output );
+    await exportCommand.run();
+  } );

--- a/src/bin/vip-export-sql.js
+++ b/src/bin/vip-export-sql.js
@@ -43,6 +43,7 @@ command( {
 	envContext: true,
 	module: 'export-sql',
 	requiredArgs: 0,
+  usage: 'vip export sql'
 } )
 	.option(
 		'output',

--- a/src/bin/vip-export-sql.js
+++ b/src/bin/vip-export-sql.js
@@ -14,6 +14,7 @@
  */
 import command from '../lib/cli/command';
 import { ExportSQLCommand } from '../commands/export-sql';
+import { makeCommandTracker } from '../lib/tracker';
 
 
 const examples = [
@@ -51,6 +52,10 @@ command( {
 	)
 	.examples( examples )
 	.argv( process.argv, async ( arg: string[], { app, env, output } ) => {
-    const exportCommand = new ExportSQLCommand( app, env, output );
+    const trackerFn = makeCommandTracker( 'export_sql', { app: app.id, env: env.uniqueLabel } );
+		await trackerFn( 'execute' );
+
+    const exportCommand = new ExportSQLCommand( app, env, output, trackerFn );
     await exportCommand.run();
+    await trackerFn( 'success' );
   } );

--- a/src/bin/vip-export-sql.js
+++ b/src/bin/vip-export-sql.js
@@ -19,8 +19,12 @@ import { makeCommandTracker } from '../lib/tracker';
 
 const examples = [
   {
-    usage: 'vip export sql @mysite.develop --output=/home/user/export.sql.gz',
-    description: 'Export SQL file from your site and save it to the specified location',
+    usage: 'vip export sql @mysite.develop',
+    description: 'Export SQL file from your site and save it to the current directory',
+  },
+  {
+    usage: 'vip export sql @mysite.develop --output=~/Desktop/export.sql.gz',
+    description: 'The output file can be specified with the --output flag',
   }
 ];
 

--- a/src/bin/vip-export.js
+++ b/src/bin/vip-export.js
@@ -11,8 +11,8 @@ import command from '../lib/cli/command';
 import { trackEvent } from '../lib/tracker';
 
 command()
-	.command( 'sql', 'Import SQL to your database from a file' )
-	.example( 'vip export sql @mysite.develop', 'Export SQL file from your site' )
+	.command( 'sql', 'Export the contents of your database to an SQL file' )
+	.example( 'vip export sql @mysite.develop', 'Export the contents of your database to an SQL file' )
 	.argv( process.argv, async () => {
 		await trackEvent( 'vip_export_command_execute' );
 	} );

--- a/src/bin/vip-export.js
+++ b/src/bin/vip-export.js
@@ -1,0 +1,18 @@
+#!/usr/bin/env node
+
+/**
+ * External dependencies
+ */
+
+/**
+ * Internal dependencies
+ */
+import command from '../lib/cli/command';
+import { trackEvent } from '../lib/tracker';
+
+command()
+	.command( 'sql', 'Import SQL to your database from a file' )
+	.example( 'vip export sql @mysite.develop', 'Export SQL file from your site' )
+	.argv( process.argv, async () => {
+		await trackEvent( 'vip_export_command_execute' );
+	} );

--- a/src/bin/vip.js
+++ b/src/bin/vip.js
@@ -43,6 +43,7 @@ const runCmd = async function() {
 		.command( 'cache', 'Manage page cache for your VIP applications' )
 		.command( 'config', 'Set configuration for your VIP applications' )
 		.command( 'dev-env', 'Use local dev-environment' )
+		.command( 'export', 'Export data from your VIP application' )
 		.command( 'import', 'Import media or SQL files into your VIP applications' )
 		.command( 'logs', 'Get logs from your VIP applications' )
 		.command( 'search-replace', 'Perform search and replace tasks on files' )

--- a/src/commands/export-sql.js
+++ b/src/commands/export-sql.js
@@ -339,7 +339,7 @@ export class ExportSQLCommand {
 					exit.withError(
 						'There is an export job already running for this site: ' +
 						`https://dashboard.wpvip.com/apps/${ this.app.id }/${ this.env.uniqueLabel }/data/database/backups\n` +
-						'Currently, we allow only one export job per site. Please try again later.'
+						'Currently, we allow only one export job at a time, per site. Please try again later.'
 					);
 				}
 				exit.withError( `Error creating export job: ${ err?.message }` );

--- a/src/lib/cli/format.js
+++ b/src/lib/cli/format.js
@@ -213,10 +213,10 @@ export const formatBytes = ( bytes, decimals = 2 ) => {
 		return '0 Bytes';
 	}
 
-	const k = 1024;
+	const kk = 1024;
 	const dm = decimals < 0 ? 0 : decimals;
 	const sizes = [ 'bytes', 'KB', 'MB', 'GB', 'TB' ];
-	const i = Math.floor( Math.log( bytes ) / Math.log( k ) );
+	const idx = Math.floor( Math.log( bytes ) / Math.log( kk ) );
 
-	return parseFloat( ( bytes / Math.pow( k, i ) ).toFixed( dm ) ) + ' ' + sizes[ i ];
+	return parseFloat( ( bytes / Math.pow( kk, idx ) ).toFixed( dm ) ) + ' ' + sizes[ idx ];
 }

--- a/src/lib/cli/format.js
+++ b/src/lib/cli/format.js
@@ -206,3 +206,17 @@ export const formatSearchReplaceValues = ( values, message ) => {
 	} );
 	return formattedOutput;
 };
+
+// Format bytes into kilobytes, megabytes, etc based on the size
+export const formatBytes = ( bytes, decimals = 2 ) => {
+	if ( 0 === bytes ) {
+		return '0 Bytes';
+	}
+
+	const k = 1024;
+	const dm = decimals < 0 ? 0 : decimals;
+	const sizes = [ 'bytes', 'KB', 'MB', 'GB', 'TB' ];
+	const i = Math.floor( Math.log( bytes ) / Math.log( k ) );
+
+	return parseFloat( ( bytes / Math.pow( k, i ) ).toFixed( dm ) ) + ' ' + sizes[ i ];
+}

--- a/src/lib/cli/progress.js
+++ b/src/lib/cli/progress.js
@@ -61,6 +61,15 @@ export class ProgressTracker {
 		this.stepsFromCaller.set( 'upload', { ...uploadStep, percentage } );
 	}
 
+	setProgress( progress: string ) {
+		const step = this.getCurrentStep();
+		if ( ! step ) {
+			return;
+		}
+
+		this.stepsFromCaller.set( step.id, { ...step, progress } );
+	}
+
 	setStepsFromServer( steps: Object[] ) {
 		const formattedSteps = steps.map( ( { name, status }, index ) => ( {
 			id: `server-${ index }-${ name }`,
@@ -86,6 +95,15 @@ export class ProgressTracker {
 		}
 		const steps = [ ...this.getSteps().values() ];
 		return steps.find( ( { status } ) => status === 'pending' );
+	}
+
+	getCurrentStep() {
+		if ( this.allStepsSucceeded() ) {
+			return undefined;
+		}
+
+		const steps = [ ...this.getSteps().values() ];
+		return steps.find( ( { status } ) => status === 'running' );
 	}
 
 	stepRunning( stepId: string ) {
@@ -153,13 +171,15 @@ export class ProgressTracker {
 			singleLogLine.clear();
 		}
 		const stepValues = [ ...this.getSteps().values() ];
-		const logs = stepValues.reduce( ( accumulator, { name, id, percentage, status } ) => {
+		const logs = stepValues.reduce( ( accumulator, { name, id, percentage, status, progress } ) => {
 			const statusIcon = getGlyphForStatus( status, this.runningSprite );
 			let suffix = '';
 			if ( id === 'upload' ) {
 				if ( status === 'running' && percentage ) {
 					suffix = percentage;
 				}
+			} else if ( progress ) {
+				suffix = progress;
 			}
 			return `${ accumulator }${ statusIcon } ${ name } ${ suffix }\n`;
 		}, '' );

--- a/src/lib/tracker.js
+++ b/src/lib/tracker.js
@@ -75,3 +75,11 @@ export async function aliasUser( vipUserId ): Promise<Response> {
 export async function trackEventWithEnv( appId, envId, eventName, eventProps = {} ): Promise<Response> {
 	return trackEvent( eventName, { ...eventProps, app_id: appId, env_id: envId } );
 }
+
+export function makeCommandTracker( command, trackingInfo = {} ) {
+	const trackerFn = async ( type, data = {} ) => {
+		await trackEvent( `${ command }_command_${ type }`, { ...trackingInfo, ...data } );
+	};
+
+	return trackerFn;
+}

--- a/src/lib/utils.js
+++ b/src/lib/utils.js
@@ -58,3 +58,22 @@ export function makeTempDir( prefix = 'vip-cli' ) {
 
 	return tempDir;
 }
+
+/**
+ * Get absolute path to a file
+ * 
+ * @param {string} filePath Path to the file
+ * 
+ * @return {string} Absolute path to the file
+ */
+export function getAbsolutePath( filePath ) {
+	if ( filePath.startsWith( '/' ) ) {
+		return filePath;
+	}
+
+	if ( filePath.startsWith( '~') ) {
+		return filePath.replace( '~', os.homedir() );
+	}
+
+	return path.join( process.cwd(), filePath );
+}


### PR DESCRIPTION
## Description

In this PR, we are adding the following commands:
```bash
$ vip export --help
  Usage: vip export [options] [command]
  
  Commands:
    sql  Import SQL to your database from a file
  
  Options:
    -d, --debug    Activate debug output
    -h, --help     Output the help for the (sub)command
    -v, --version  Output the version number
  
  Examples:
    - Export SQL file from your site
    $ vip export sql @mysite.develop
```

and,

```bash
$ vip export sql --help
  Usage: vip export-sql [options] 
  
  Options:
    -a, --app      Specify the app
    -d, --debug    Activate debug output
    -e, --env      Specify the environment
    -h, --help     Output the help for the (sub)command
    -o, --output   Specify the location where you want to save the export file
    -v, --version  Output the version number
  
  Examples:
    - Export SQL file from your site and save it to the specified location
    $ vip export sql @mysite.develop --output=/home/user/export.sql.gz
```

The `vip export sql` command exports the latest backup and saves it in user's filesystem.

## Steps to Test

1. Check out PR.
1. Run `rm -rf dist && npm link`
1. Run `node ./dist/bin/vip export sql @6721.production`
1. It should store the export SQL file in the current working directory. If you specify the file location using `/home/..../test.sql.gz` it would save the file there.
2. If you are an Automattician and using proxy, you will need to add the `VIP_PROXY` environment variable.

