### PR TITLE
fix(dev-env): Add error handling to readEnvironmentData()

### DIFF
--- a/__tests__/lib/dev-environment/dev-environment-core.js
+++ b/__tests__/lib/dev-environment/dev-environment-core.js
@@ -1,6 +1,4 @@
-/**
- * @format
- */
+// @format
 
 /**
  * External dependencies
@@ -11,6 +9,7 @@ import enquirer from 'enquirer';
 import os from 'os';
 import path from 'path';
 import child from 'child_process';
+import { EventEmitter } from 'stream';
 import { expect, jest } from '@jest/globals';
 
 /**
@@ -29,8 +28,6 @@ import { searchAndReplace } from '../../../src/lib/search-and-replace';
 import { resolvePath } from '../../../src/lib/dev-environment/dev-environment-cli';
 import { DEV_ENVIRONMENT_NOT_FOUND } from '../../../src/lib/constants/dev-environment';
 import { bootstrapLando } from '../../../src/lib/dev-environment/dev-environment-lando';
-import { EventEmitter } from 'stream';
-import UserError from '../../../src/lib/user-error';
 
 jest.mock( 'xdg-basedir', () => ( {} ) );
 jest.mock( '../../../src/lib/api/app' );

--- a/src/lib/dev-environment/dev-environment-core.js
+++ b/src/lib/dev-environment/dev-environment-core.js
@@ -337,9 +337,19 @@ export function readEnvironmentData( slug: string ): InstanceData {
 
 	const instanceDataTargetPath = path.join( instancePath, instanceDataFileName );
 
-	const instanceDataString = fs.readFileSync( instanceDataTargetPath, 'utf8' );
+	let instanceDataString;
+	let instanceData;
+	try {
+		instanceDataString = fs.readFileSync( instanceDataTargetPath, 'utf8' );
+	} catch ( err ) {
+		throw new UserError( `There was an error reading file "${instanceDataTargetPath}": ${err.message}.` );
+	}
 
-	const instanceData = JSON.parse( instanceDataString );
+	try {
+		instanceData = JSON.parse( instanceDataString );
+	} catch ( err ) {
+		throw new UserError( `There was an error parsing file "${instanceDataTargetPath}": ${err.message}. You may need to recreate the environment.` );
+	}
 
 	/**
 	 ***********************************


### PR DESCRIPTION
## Description

This PR tries to handle errors that might occur when reading the environment data. Unfortunately, there is not much that we can do if the file is broken. For now, we only try to explain what went wrong and where.

```
SyntaxError: Unexpected end of JSON input
    at JSON.parse (<anonymous>)
    at readEnvironmentData (C:\Users\redacted\AppData\Roaming\npm\node_modules\@automattic\vip\dist\lib\dev-environment\dev-environment-core.js:248:29)
    at AsyncEvents.<anonymous> (C:\Users\redacted\AppData\Roaming\npm\node_modules\@automattic\vip\dist\lib\dev-environment\dev-environment-lando.js:172:70)
    at Object.onceWrapper (node:events:628:26)
    at AsyncEvents.handle (C:\Users\redacted\AppData\Roaming\npm\node_modules\@automattic\vip\node_modules\lando\lib\events.js:84:25)
    at C:\Users\redacted\AppData\Roaming\npm\node_modules\@automattic\vip\node_modules\lando\lib\events.js:117:21
    at tryCatcher (C:\Users\redacted\AppData\Roaming\npm\node_modules\@automattic\vip\node_modules\bluebird\js\release\util.js:16:23)
    at Object.gotValue (C:\Users\redacted\AppData\Roaming\npm\node_modules\@automattic\vip\node_modules\bluebird\js\release\reduce.js:166:18)
```

```
Error: EACCES: permission denied, open '/Users/redacted/.local/share/vip/dev-environment/docker/instance_data.json'
```

## Steps to Test

CI should pass: I have added unit tests for this fix.
