### PR TITLE
fix(dev-env): Fix "Cannot read properties of undefined" in `preProcessInstanceData()`

### DIFF
--- a/src/lib/constants/dev-environment.js
+++ b/src/lib/constants/dev-environment.js
@@ -23,11 +23,11 @@ export const DEV_ENVIRONMENT_WORDPRESS_CACHE_KEY = 'wordpress-versions.json';
 export const DEV_ENVIRONMENT_WORDPRESS_VERSION_TTL = 86400; // once per day
 
 export const DEV_ENVIRONMENT_PHP_VERSIONS = {
+	'8.0': 'ghcr.io/automattic/vip-container-images/php-fpm:8.0',
 	// eslint-disable-next-line quote-props
 	'8.2': 'ghcr.io/automattic/vip-container-images/php-fpm:8.2',
 	// eslint-disable-next-line quote-props
 	'8.1': 'ghcr.io/automattic/vip-container-images/php-fpm:8.1',
-	'8.0': 'ghcr.io/automattic/vip-container-images/php-fpm:8.0',
 	// eslint-disable-next-line quote-props -- flow does not support non-string keys
 	'7.4': 'ghcr.io/automattic/vip-container-images/php-fpm:7.4',
 };

--- a/src/lib/dev-environment/dev-environment-core.js
+++ b/src/lib/dev-environment/dev-environment-core.js
@@ -162,7 +162,7 @@ function preProcessInstanceData( instanceData: InstanceData ): InstanceData {
 
 	newInstanceData.elasticsearch = instanceData.elasticsearch || false;
 
-	newInstanceData.php = instanceData.php || DEV_ENVIRONMENT_PHP_VERSIONS.default;
+	newInstanceData.php = instanceData.php || DEV_ENVIRONMENT_PHP_VERSIONS[ Object.keys( DEV_ENVIRONMENT_PHP_VERSIONS )[0] ];
 	if ( newInstanceData.php.startsWith( 'image:' ) ) {
 		newInstanceData.php = newInstanceData.php.slice( 'image:'.length );
 	}


### PR DESCRIPTION

#1065 introduced a bug that causes "TypeError: Cannot read properties of undefined (reading 'startsWith')" at `preProcessInstanceData()`.

When `instanceData.php` is falsy, the system falls back to reading `DEV_ENVIRONMENT_PHP_VERSIONS.default` which is not there. As a result, we get `undefined`, and our attempt to call `startsWith()` on it fails miserably.

```
TypeError: Cannot read properties of undefined (reading 'startsWith')
at preProcessInstanceData (/Users/redacted/.nvm/versions/node/v18.15.0/lib/node_modules/@automattic/vip/dist/lib/dev-environment/dev-environment-core.js:131:27)
at updateEnvironment (/Users/redacted/.nvm/versions/node/v18.15.0/lib/node_modules/@automattic/vip/dist/lib/dev-environment/dev-environment-core.js:117:36)
at regenerateLandofile (/Users/redacted/.nvm/versions/node/v18.15.0/lib/node_modules/@automattic/vip/dist/lib/dev-environment/dev-environment-lando.js:114:51)
at async landoRecovery (/Users/redacted/.nvm/versions/node/v18.15.0/lib/node_modules/@automattic/vip/dist/lib/dev-environment/dev-environment-lando.js:120:5)
at async getLandoApplication (/Users/redacted/.nvm/versions/node/v18.15.0/lib/node_modules/@automattic/vip/dist/lib/dev-environment/dev-environment-lando.js:149:11)
```

## Description

CI should pass.
