### PR TITLE
fix(api): Set non-zero exit code on error

### DIFF
--- a/src/lib/api.js
+++ b/src/lib/api.js
@@ -47,7 +47,7 @@ export default async function API( { exitOnError = true } = {} ): Promise<Apollo
 				chalk.red( 'Unauthorized:' ),
 				'You are unauthorized to perform this request, please logout with `vip logout` then try again.'
 			);
-			process.exit();
+			process.exit( 1 );
 		}
 
 		if ( graphQLErrors && graphQLErrors.length && globalGraphQLErrorHandlingEnabled ) {
@@ -56,7 +56,7 @@ export default async function API( { exitOnError = true } = {} ): Promise<Apollo
 			} );
 
 			if ( exitOnError ) {
-				process.exit();
+				process.exit( 1 );
 			}
 		}
 	} );


### PR DESCRIPTION
## Description

Many commands exit with a 0 exit code even if they fail. This is very inconvenient when VIP CLI is invoked from a script.

This PR fixes one of such cases.

## Steps to Test

1. Make sure you are logged in.
2. Modify the token in `~/.config/configstore/vip-go-cli.json` (could be a different location on a Mac)
3. Run `vip whoami; echo $?`. Observe the exit code of 0.
4. Check out PR, `npm run build`, `npm link`
5. Run `vip whoami; echo $?`. Observe the exit code of 1.
