### PR TITLE
chore(dev-deps): Remove jest-environment-jsdom

### DIFF
--- a/__tests__/bin/vip-config-envvar-delete.js
+++ b/__tests__/bin/vip-config-envvar-delete.js
@@ -39,7 +39,7 @@ jest.mock( 'lib/cli/command', () => {
 	return jest.fn( () => commandMock );
 } );
 
-jest.mock( 'lib/cli/format', () => ( {
+jest.mock( '../../src/lib/cli/format', () => ( {
 	formatData: jest.fn(),
 } ) );
 

--- a/__tests__/bin/vip-config-envvar-get-all.js
+++ b/__tests__/bin/vip-config-envvar-get-all.js
@@ -27,7 +27,7 @@ jest.mock( 'lib/cli/command', () => {
 	return jest.fn( () => commandMock );
 } );
 
-jest.mock( 'lib/cli/format', () => ( {
+jest.mock( '../../src/lib/cli/format', () => ( {
 	formatData: jest.fn(),
 } ) );
 

--- a/__tests__/bin/vip-config-envvar-list.js
+++ b/__tests__/bin/vip-config-envvar-list.js
@@ -27,7 +27,7 @@ jest.mock( 'lib/cli/command', () => {
 	return jest.fn( () => commandMock );
 } );
 
-jest.mock( 'lib/cli/format', () => ( {
+jest.mock( '../../src/lib/cli/format', () => ( {
 	formatData: jest.fn(),
 } ) );
 

--- a/__tests__/bin/vip-config-envvar-set.js
+++ b/__tests__/bin/vip-config-envvar-set.js
@@ -40,7 +40,7 @@ jest.mock( 'lib/cli/command', () => {
 	return jest.fn( () => commandMock );
 } );
 
-jest.mock( 'lib/cli/format', () => ( {
+jest.mock( '../../src/lib/cli/format', () => ( {
 	formatData: jest.fn(),
 } ) );
 

--- a/__tests__/bin/vip-import-sql.js
+++ b/__tests__/bin/vip-import-sql.js
@@ -11,7 +11,7 @@ import * as exit from '../../src/lib/cli/exit';
 jest.mock( '../../src/lib/tracker' );
 jest.mock( 'lib/validations/site-type' );
 jest.mock( 'lib/validations/is-multi-site' );
-jest.mock( 'lib/api/feature-flags' );
+jest.mock( '../../src/lib/api/feature-flags' );
 jest.spyOn( process, 'exit' ).mockImplementation( () => {} );
 jest.spyOn( exit, 'withError' );
 

--- a/__tests__/commands/export-sql.js
+++ b/__tests__/commands/export-sql.js
@@ -63,7 +63,7 @@ const queryMock = jest.fn().mockImplementation( () => {
 	};
 } );
 
-jest.mock( 'lib/api', () => jest.fn() );
+jest.mock( '../../src/lib/api', () => jest.fn() );
 API.mockImplementation( () => {
 	return {
 		query: queryMock,

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,11 +1,7 @@
 module.exports = {
-	testEnvironment: 'jsdom',
 	setupFiles: [
 		'./jest.setup.js',
 		'./jest.setupMocks.js',
 	],
-	testEnvironmentOptions: {
-		url: 'http://localhost/',
-	},
 	maxWorkers: 4,
 };

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -6739,9 +6739,9 @@
       }
     },
     "node_modules/entities": {
-      "version": "4.4.0",
-      "resolved": "https://registry.npmjs.org/entities/-/entities-4.4.0.tgz",
-      "integrity": "sha512-oYp7156SP8LkeGD0GF85ad1X9Ai79WtRsZ2gxJqtBuzH+98YUV6jkHEKlZkMbcrjJjIVJNIDP/3WL9wQkoPbWA==",
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-4.5.0.tgz",
+      "integrity": "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==",
       "dev": true,
       "engines": {
         "node": ">=0.12"
@@ -12169,9 +12169,9 @@
       }
     },
     "node_modules/nwsapi": {
-      "version": "2.2.2",
-      "resolved": "https://registry.npmjs.org/nwsapi/-/nwsapi-2.2.2.tgz",
-      "integrity": "sha512-90yv+6538zuvUMnN+zCr8LuV6bPFdq50304114vJYJ8RDyK8D5O9Phpbd6SZWgI7PwzmmfN1upeOJlvybDSgCw==",
+      "version": "2.2.5",
+      "resolved": "https://registry.npmjs.org/nwsapi/-/nwsapi-2.2.5.tgz",
+      "integrity": "sha512-6xpotnECFy/og7tKSBVmUNft7J3jyXAka4XvG6AUhFWRz+Q/Ljus7znJAA3bxColfQLdS+XsjoodtJfCgeTEFQ==",
       "dev": true
     },
     "node_modules/object-assign": {
@@ -20742,9 +20742,9 @@
       }
     },
     "entities": {
-      "version": "4.4.0",
-      "resolved": "https://registry.npmjs.org/entities/-/entities-4.4.0.tgz",
-      "integrity": "sha512-oYp7156SP8LkeGD0GF85ad1X9Ai79WtRsZ2gxJqtBuzH+98YUV6jkHEKlZkMbcrjJjIVJNIDP/3WL9wQkoPbWA==",
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-4.5.0.tgz",
+      "integrity": "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==",
       "dev": true
     },
     "error-ex": {
@@ -24833,9 +24833,9 @@
       "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0="
     },
     "nwsapi": {
-      "version": "2.2.2",
-      "resolved": "https://registry.npmjs.org/nwsapi/-/nwsapi-2.2.2.tgz",
-      "integrity": "sha512-90yv+6538zuvUMnN+zCr8LuV6bPFdq50304114vJYJ8RDyK8D5O9Phpbd6SZWgI7PwzmmfN1upeOJlvybDSgCw==",
+      "version": "2.2.5",
+      "resolved": "https://registry.npmjs.org/nwsapi/-/nwsapi-2.2.5.tgz",
+      "integrity": "sha512-6xpotnECFy/og7tKSBVmUNft7J3jyXAka4XvG6AUhFWRz+Q/Ljus7znJAA3bxColfQLdS+XsjoodtJfCgeTEFQ==",
       "dev": true
     },
     "object-assign": {

--- a/package.json
+++ b/package.json
@@ -129,7 +129,6 @@
     "eslint-plugin-flowtype": "^8.0.3",
     "flow-bin": "^0.206.0",
     "jest": "^29.5.0",
-    "jest-environment-jsdom": "^29.5.0",
     "nock": "13.3.1",
     "prettier": "^2.0.5",
     "publish-please": "5.5.2",


### PR DESCRIPTION
## Description

Now that we have removed the browser keychain in #1376, it is time to say goodbye to `jest-environment-jsdom`, and reduce the size of node_modules by 11 MB.

## Steps to Test

This change only affects tests; the CI should pass.
