### PR TITLE
test: Reduce noise from tests

### DIFF
--- a/__tests__/bin/vip-import-sql.js
+++ b/__tests__/bin/vip-import-sql.js
@@ -14,6 +14,7 @@ jest.mock( 'lib/validations/is-multi-site' );
 jest.mock( '../../src/lib/api/feature-flags' );
 jest.spyOn( process, 'exit' ).mockImplementation( () => {} );
 jest.spyOn( exit, 'withError' );
+jest.spyOn( console, 'log' ).mockImplementation( () => {} );
 
 describe( 'vip-import-sql', () => {
 	describe( 'validateAndGetTableNames', () => {

--- a/__tests__/commands/dev-env-sync-sql.js
+++ b/__tests__/commands/dev-env-sync-sql.js
@@ -66,6 +66,8 @@ replace.mockResolvedValue( mockReadStream );
 unzipFile.mockResolvedValue();
 getReadInterface.mockReturnValue( getMockStream( [ { name: 'close' } ] ), 100 );
 
+jest.spyOn( console, 'log' ).mockImplementation( () => {} );
+
 describe( 'commands/DevEnvSyncSQLCommand', () => {
 	const app = { id: 123, name: 'test-app' };
 	const env = { id: 456, name: 'test-env' };

--- a/__tests__/commands/export-sql.js
+++ b/__tests__/commands/export-sql.js
@@ -94,6 +94,8 @@ API.mockImplementation( () => {
 	};
 } );
 
+jest.spyOn( console, 'log' ).mockImplementation( () => {} );
+
 describe( 'commands/ExportSQLCommand', () => {
 	beforeEach( () => {
 	} );

--- a/__tests__/lib/app-logs/app-logs.js
+++ b/__tests__/lib/app-logs/app-logs.js
@@ -59,7 +59,7 @@ describe( 'getRecentLogs()', () => {
 		} );
 	} );
 
-	it( 'should throw when logs field is not returned', async () => {
+	it( 'should throw when logs field is not returned', () => {
 		const queryMock = jest.fn();
 
 		API.mockImplementation( () => ( {
@@ -70,7 +70,7 @@ describe( 'getRecentLogs()', () => {
 
 		const result = getRecentLogs( 1, 3, 'batch', 1200 );
 
-		await expect( result ).rejects.toThrow( 'Unable to query logs' );
+		return expect( result ).rejects.toThrow( 'Unable to query logs' );
 	} );
 } );
 

--- a/__tests__/lib/cli/apiConfig.js
+++ b/__tests__/lib/cli/apiConfig.js
@@ -5,6 +5,7 @@
 /**
  * External dependencies
  */
+import { describe, it, expect, jest } from '@jest/globals';
 
 /**
  * Internal dependencies
@@ -15,6 +16,9 @@ import Token from '../../../src/lib/token';
 
 jest.mock( '../../../src/lib/tracker' );
 const getFeatureSpy = jest.spyOn( featureFlags, 'get' );
+
+jest.spyOn( console, 'error' ).mockImplementation( () => {} );
+jest.spyOn( console, 'log' ).mockImplementation( () => {} );
 
 describe( 'apiConfig', () => {
 	beforeEach( () => {

--- a/__tests__/lib/dev-environment/dev-environment-cli.js
+++ b/__tests__/lib/dev-environment/dev-environment-cli.js
@@ -27,6 +27,8 @@ import * as devEnvCore from '../../../src/lib/dev-environment/dev-environment-co
 import * as devEnvConfiguration from '../../../src/lib/dev-environment/dev-environment-configuration-file';
 import { DEV_ENVIRONMENT_PHP_VERSIONS } from '../../../src/lib/constants/dev-environment';
 
+jest.spyOn( console, 'log' ).mockImplementation( () => {} );
+
 jest.mock( 'enquirer', () => {
 	const _selectRunMock = jest.fn();
 	const SelectClass = class {};


### PR DESCRIPTION
## Description

Our tests generate a lot of noise because of the `console` statements all over the code.

This PR reduces the noise by mocking calls to `console.log()` and `console.error()` with an empty function.

## Steps to Test

CI should pass.
