### PR TITLE
refactor: Convert `lib/config` to TypeScript

### DIFF
--- a/src/lib/cli/prompt.ts
+++ b/src/lib/cli/prompt.ts
@@ -1,5 +1,3 @@
-// @flow
-
 /**
  * External dependencies
  */

--- a/src/lib/config/software.generated.d.ts
+++ b/src/lib/config/software.generated.d.ts
@@ -1,0 +1,19 @@
+import * as Types from '../../../graphqlTypes';
+
+export type UpdateSoftwareSettingsMutationVariables = Types.Exact<{
+  appId: Types.Scalars['Int']['input'];
+  envId: Types.Scalars['Int']['input'];
+  component: Types.Scalars['String']['input'];
+  version: Types.Scalars['String']['input'];
+}>;
+
+
+export type UpdateSoftwareSettingsMutation = { __typename?: 'Mutation', updateSoftwareSettings?: { __typename?: 'AppEnvironmentSoftwareSettings', php?: { __typename?: 'AppEnvironmentSoftwareSettingsSoftware' } | null, wordpress?: { __typename?: 'AppEnvironmentSoftwareSettingsSoftware' } | null, muplugins?: { __typename?: 'AppEnvironmentSoftwareSettingsSoftware' } | null, nodejs?: { __typename?: 'AppEnvironmentSoftwareSettingsSoftware' } | null } | null };
+
+export type UpdateJobQueryVariables = Types.Exact<{
+  appId: Types.Scalars['Int']['input'];
+  envId: Types.Scalars['Int']['input'];
+}>;
+
+
+export type UpdateJobQuery = { __typename?: 'Query', app?: { __typename?: 'App', environments?: Array<{ __typename?: 'AppEnvironment', jobs?: Array<{ __typename?: 'Job', type?: string | null, completedAt?: string | null, createdAt?: string | null, inProgressLock?: boolean | null, progress?: { __typename?: 'JobProgress', status?: string | null, steps?: Array<{ __typename?: 'JobProgressStep', step?: string | null, name?: string | null, status?: string | null } | null> | null } | null } | { __typename?: 'PrimaryDomainSwitchJob', type?: string | null, completedAt?: string | null, createdAt?: string | null, inProgressLock?: boolean | null, progress?: { __typename?: 'JobProgress', status?: string | null, steps?: Array<{ __typename?: 'JobProgressStep', step?: string | null, name?: string | null, status?: string | null } | null> | null } | null } | null> | null } | null> | null } | null };

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -1,0 +1,21 @@
+import { ArrayPromptOptions } from 'enquirer';
+
+// These types are not 100% correct, but they are close enough for now.
+declare module 'enquirer' {
+	interface ConfirmOption {
+		name?: string | (() => string);
+		message: string | (() => string);
+		initial?: boolean | (() => boolean);
+		actions?: {'ctrl': {[key: string]: string}}
+	}
+
+	class Confirm extends NodeJS.EventEmitter {
+		constructor(option: ConfirmOption);
+		run: () => Promise<boolean>;
+	}
+
+	class Select extends NodeJS.EventEmitter {
+		constructor(option: ArrayPromptOptions);
+		run: () => Promise<string>;
+	}
+}


### PR DESCRIPTION
## Description

This PR converts files from `lib/config` to TypeScript.

PS: Enquirer's type definitions suck. I had to add my own definitions to augment `enquirer`, but they are incomplete and not 100% correct. Maybe it makes sense to replace enquirer with inquirer - the latter is actively maintained.

See https://github.com/enquirer/enquirer/pull/307 for the number of issues with TS definitions.

## Steps to Test

CI should pass.
