### PR TITLE
feature(dev-env): Add ability to sync multisites

### DIFF
--- a/__tests__/commands/dev-env-sync-sql.js
+++ b/__tests__/commands/dev-env-sync-sql.js
@@ -70,7 +70,7 @@ jest.spyOn( console, 'log' ).mockImplementation( () => {} );
 
 describe( 'commands/DevEnvSyncSQLCommand', () => {
 	const app = { id: 123, name: 'test-app' };
-	const env = { id: 456, name: 'test-env', wpSites: {} };
+	const env = { id: 456, name: 'test-env', wpSitesSDS: {} };
 
 	describe( '.generateExport', () => {
 		it( 'should create an instance of ExportSQLCommand and run', async () => {

--- a/__tests__/commands/dev-env-sync-sql.js
+++ b/__tests__/commands/dev-env-sync-sql.js
@@ -70,7 +70,7 @@ jest.spyOn( console, 'log' ).mockImplementation( () => {} );
 
 describe( 'commands/DevEnvSyncSQLCommand', () => {
 	const app = { id: 123, name: 'test-app' };
-	const env = { id: 456, name: 'test-env' };
+	const env = { id: 456, name: 'test-env', wpSites: {} };
 
 	describe( '.generateExport', () => {
 		it( 'should create an instance of ExportSQLCommand and run', async () => {
@@ -84,14 +84,25 @@ describe( 'commands/DevEnvSyncSQLCommand', () => {
 		} );
 	} );
 
+	describe( 'generateSearchReplaceMap', () => {
+		it( 'should return a map of search-replace values', () => {
+			const cmd = new DevEnvSyncSQLCommand( app, env, 'test-slug' );
+			cmd.slug = 'test-slug';
+			cmd.siteUrls = [ 'test.go-vip.com' ];
+			cmd.generateSearchReplaceMap();
+
+			expect( cmd.searchReplaceMap ).toEqual( { 'test.go-vip.com': 'test-slug.vipdev.lndo.site' } );
+		} );
+	} );
+
 	describe( '.runSearchReplace', () => {
 		it( 'should run search-replace operation on the SQL file', async () => {
 			const cmd = new DevEnvSyncSQLCommand( app, env, 'test-slug' );
-			cmd.siteUrls = [ '//test.go-vip.com' ];
+			cmd.searchReplaceMap = { 'test.go-vip.com': 'test-slug.vipdev.lndo.site' };
 			cmd.slug = 'test-slug';
 
 			await cmd.runSearchReplace();
-			expect( replace ).toHaveBeenCalledWith( mockReadStream, [ '//test.go-vip.com', '//test-slug.vipdev.lndo.site' ] );
+			expect( replace ).toHaveBeenCalledWith( mockReadStream, [ 'test.go-vip.com', 'test-slug.vipdev.lndo.site' ] );
 		} );
 	} );
 
@@ -110,6 +121,7 @@ describe( 'commands/DevEnvSyncSQLCommand', () => {
 	describe( '.run', () => {
 		const syncCommand = new DevEnvSyncSQLCommand( app, env, 'test-slug' );
 		const exportSpy = jest.spyOn( syncCommand, 'generateExport' );
+		const generateSearchReplaceMapSpy = jest.spyOn( syncCommand, 'generateSearchReplaceMap' );
 		const searchReplaceSpy = jest.spyOn( syncCommand, 'runSearchReplace' );
 		const importSpy = jest.spyOn( syncCommand, 'runImport' );
 
@@ -130,6 +142,7 @@ describe( 'commands/DevEnvSyncSQLCommand', () => {
 
 			expect( exportSpy ).toHaveBeenCalled();
 			expect( unzipFile ).toHaveBeenCalled();
+			expect( generateSearchReplaceMapSpy ).toHaveBeenCalled();
 			expect( searchReplaceSpy ).toHaveBeenCalled();
 			expect( importSpy ).toHaveBeenCalled();
 		} );

--- a/src/bin/vip-dev-env-sync-sql.js
+++ b/src/bin/vip-dev-env-sync-sql.js
@@ -40,8 +40,9 @@ const appQuery = `
 		primaryDomain { name }
 		uniqueLabel
 		isMultisite
-		wpSites {
+		wpSitesSDS {
 			nodes {
+				id
 				blogId
 				homeUrl
 			}

--- a/src/bin/vip-dev-env-sync-sql.js
+++ b/src/bin/vip-dev-env-sync-sql.js
@@ -60,7 +60,7 @@ command( {
 	.option( 'slug', 'Custom name of the dev environment' )
 	.examples( examples )
 	.argv( process.argv, async ( arg: string[], { app, env, slug } ) => {
-		const trackerFn = makeCommandTracker( 'dev_env_sync_sql', { app: app.id, env: env.uniqueLabel, slug } );
+		const trackerFn = makeCommandTracker( 'dev_env_sync_sql', { app: app.id, env: env.uniqueLabel, slug, multisite: env.isMultisite } );
 		await trackerFn( 'execute' );
 
 		const lando = await bootstrapLando();

--- a/src/bin/vip-dev-env-sync-sql.js
+++ b/src/bin/vip-dev-env-sync-sql.js
@@ -40,7 +40,7 @@ const appQuery = `
 		primaryDomain { name }
 		uniqueLabel
 		isMultisite
-		wpSitesSDS {
+		wpSitesSDS(first:500) {
 			nodes {
 				id
 				blogId

--- a/src/bin/vip-dev-env-sync-sql.js
+++ b/src/bin/vip-dev-env-sync-sql.js
@@ -8,7 +8,6 @@
 /**
  * External dependencies
  */
-import chalk from 'chalk';
 
 /**
  * Internal dependencies
@@ -41,6 +40,12 @@ const appQuery = `
 		primaryDomain { name }
 		uniqueLabel
 		isMultisite
+		wpSites {
+			nodes {
+				blogId
+				homeUrl
+			}
+		}
 	}
 `;
 
@@ -56,20 +61,6 @@ command( {
 	.argv( process.argv, async ( arg: string[], { app, env, slug } ) => {
 		const trackerFn = makeCommandTracker( 'dev_env_sync_sql', { app: app.id, env: env.uniqueLabel, slug } );
 		await trackerFn( 'execute' );
-
-		if ( env.isMultisite ) {
-			console.log( chalk.yellow( 'You seem to be trying to sync a SQL database for a network site.' ) );
-			console.log( chalk.yellow( 'Unfortunately, the current version of our tool does not yet support syncing network sites.\n' ) );
-			console.log( chalk.yellow( 'However, you can manually export the database using the following command:' ) );
-			console.log( chalk.yellow( chalk.bold( `vip export sql @${ app.id }.${ env.uniqueLabel } --output=${ app.id }-${ env.uniqueLabel }-exported.sql.gz\n` ) ) );
-			console.log( chalk.yellow( 'After exporting the database, you\'ll need to perform the necessary search and replace operations on the exported file to update any relevant data or configurations.' ) );
-			console.log( chalk.yellow( 'See: https://docs.wpvip.com/how-tos/dev-env-add-content/#h-3-import-the-sql-file\n' ) );
-			console.log( chalk.yellow( 'Once you\'ve made the required changes, you can import the modified SQL file into your development environment using the following command:' ) );
-			console.log( chalk.yellow( chalk.bold( `vip dev-env import sql ${ app.id }-${ env.uniqueLabel }-exported.sql.gz --slug=${ slug }` ) ) );
-
-			await trackerFn( 'aborted', { error_type: 'multisite_not_supported' } );
-			process.exit( 0 );
-		}
 
 		const lando = await bootstrapLando();
 		const envPath = getEnvironmentPath( slug );

--- a/src/commands/dev-env-sync-sql.js
+++ b/src/commands/dev-env-sync-sql.js
@@ -145,7 +145,7 @@ export class DevEnvSyncSQLCommand {
 			this.searchReplaceMap[ url ] = this.landoDomain;
 		}
 
-		const networkSites = this.env.wpSites.nodes
+		const networkSites = this.env.wpSitesSDS.nodes
 		if ( ! networkSites ) return;
 
 		for ( const site of networkSites ) {

--- a/src/commands/dev-env-sync-sql.js
+++ b/src/commands/dev-env-sync-sql.js
@@ -152,7 +152,7 @@ export class DevEnvSyncSQLCommand {
 			if ( ! site.blogId || site.blogId === 1 ) continue;
 
 			const url = site.homeUrl.replace( /https?:\/\//, '' );
-			if ( ! this.searchReplaceMap[ url ] ) return;
+			if ( ! this.searchReplaceMap[ url ] ) continue;
 
 			this.searchReplaceMap[ url ] = `${ site.blogId }.${ this.landoDomain }`;
 		}


### PR DESCRIPTION
## Description

Presently, the command `vip dev-env sync sql` works only for single sites. For the multisites, it shows the user a message to basically divert them towards using `vip dev-env export sql` and `vip dev-env import sql` commands.

In this PR, we are adding multisite support for the `vip dev-env sync sql` command to seamlessly sync database backups to the dev-env multisites. The search-replace operation will take happen as follows:

```
root-site -> [slug].[lando-domain]
subsite-1 -> [slug].[lando-domain]
subsite-2 -> 2.[slug].[lando-domain]
subsite-3 -> 3.[slug].[lando-domain]
.
.
.
```

## Steps to Test

1. Pull the PR.
2. Create a dev-env environment for a multisite: `vip dev-env create @0000.production --slug testsite`. When creating the environment, do not use the skeleton repository. Instead, clone the actual repository from `wpcomvip`.
3. Build VIP-CLI: `rm -rf dist && npm link`
4. Run the sync command: `./dist/bin/vip dev-env sync sql @0000.production --slug testsite`