### PR TITLE
chore(dev-deps): Update flow-bin to 0.209.0

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+flow-typed/npm/*.js     linguist-generated=true

--- a/.npmignore
+++ b/.npmignore
@@ -43,6 +43,7 @@ node_modules/
 babel.config.js
 renovate.json
 .github
+.gitattributes
 
 .vscode
 .idea

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -128,7 +128,7 @@
         "dockerode": "^3.3.4",
         "eslint": "^8.35.0",
         "eslint-plugin-flowtype": "^8.0.3",
-        "flow-bin": "^0.208.0",
+        "flow-bin": "^0.209.0",
         "jest": "^29.5.0",
         "nock": "13.3.1",
         "prettier": "^2.0.5",
@@ -8074,9 +8074,9 @@
       "dev": true
     },
     "node_modules/flow-bin": {
-      "version": "0.208.0",
-      "resolved": "https://registry.npmjs.org/flow-bin/-/flow-bin-0.208.0.tgz",
-      "integrity": "sha512-xUoQogaQXnixDRHnfOZkcx4BmLskn+lVN6bjFU6igjIHoZWfmzg0JYkmf9Z2rrMVUDtn+8f7shyjOpTAlFX7aQ==",
+      "version": "0.209.0",
+      "resolved": "https://registry.npmjs.org/flow-bin/-/flow-bin-0.209.0.tgz",
+      "integrity": "sha512-HRc6+bKE8AN23SnuKaxdUjcQcjaIp6pksrGJ6pltFO5tIEvZmPrbT99P7Yb3ybqwcKU/Ry8yfJbuW92Ed2V3nw==",
       "dev": true,
       "bin": {
         "flow": "cli.js"
@@ -21114,9 +21114,9 @@
       "dev": true
     },
     "flow-bin": {
-      "version": "0.208.0",
-      "resolved": "https://registry.npmjs.org/flow-bin/-/flow-bin-0.208.0.tgz",
-      "integrity": "sha512-xUoQogaQXnixDRHnfOZkcx4BmLskn+lVN6bjFU6igjIHoZWfmzg0JYkmf9Z2rrMVUDtn+8f7shyjOpTAlFX7aQ==",
+      "version": "0.209.0",
+      "resolved": "https://registry.npmjs.org/flow-bin/-/flow-bin-0.209.0.tgz",
+      "integrity": "sha512-HRc6+bKE8AN23SnuKaxdUjcQcjaIp6pksrGJ6pltFO5tIEvZmPrbT99P7Yb3ybqwcKU/Ry8yfJbuW92Ed2V3nw==",
       "dev": true
     },
     "follow-redirects": {

--- a/package.json
+++ b/package.json
@@ -125,7 +125,7 @@
     "dockerode": "^3.3.4",
     "eslint": "^8.35.0",
     "eslint-plugin-flowtype": "^8.0.3",
-    "flow-bin": "^0.208.0",
+    "flow-bin": "^0.209.0",
     "jest": "^29.5.0",
     "nock": "13.3.1",
     "prettier": "^2.0.5",


### PR DESCRIPTION
## Description

This PR updates `flow-bin` from 0.208.0 to 0.209.0. As a bonus, it marks all files managed by `flow-typed` as generated in GitHub UI.

## Steps to Test

CI should pass.
