### PR TITLE
[dev-env] Command options text fixes

### DIFF
--- a/src/bin/vip-dev-env-start.js
+++ b/src/bin/vip-dev-env-start.js
@@ -37,8 +37,8 @@ const examples = [
 command()
 	.option( 'slug', 'Custom name of the dev environment' )
 	.option( 'skip-rebuild', 'Only start stopped services' )
-	.option( [ 'w', 'skip-wp-versions-check' ], 'Skip propting for wordpress update if non latest' )
-	.option( 'vscode', 'Open environment workspace in VSCode' )
+	.option( [ 'w', 'skip-wp-versions-check' ], 'Skip prompt to update WordPress version if not on latest' )
+	.option( 'vscode', 'Generate a Visual Studio Code Workspace file and open it' )
 	.examples( examples )
 	.argv( process.argv, async ( arg, opt ) => {
 		const slug = await getEnvironmentName( opt );


### PR DESCRIPTION


## Description

Few text changes during vip `dev-env start`

## Steps to Test

Outline the steps to test and verify the PR here.

Example:

1. Check out PR.
1. Run `npm run build`
1. Run `./dist/bin/vip-dev-env-start.js --help`
1. See the clarity of the help

