### PR TITLE
chore(deps): update socket.io-client from 4.6.2 to 4.7.0

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -441,8 +441,16 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/@automattic/vip-search-replace/-/vip-search-replace-1.1.1.tgz",
       "integrity": "sha512-4soBqoMrjnXGNm54DwtVYVpI36KXo828prM17vs+2hRgjThVKv2atcCZj4FC88tKgnQzf14JccQZ1G1QR3eaZA==",
-      "cpu": [ "ia32", "x64", "arm64" ],
-      "os": [ "darwin", "linux", "win32" ],
+      "cpu": [
+        "ia32",
+        "x64",
+        "arm64"
+      ],
+      "os": [
+        "darwin",
+        "linux",
+        "win32"
+      ],
       "dependencies": {
         "debug": "^4.2.0",
         "follow-redirects": "^1.13.0"
@@ -6272,21 +6280,21 @@
       }
     },
     "node_modules/engine.io-client": {
-      "version": "6.4.0",
-      "resolved": "https://registry.npmjs.org/engine.io-client/-/engine.io-client-6.4.0.tgz",
-      "integrity": "sha512-GyKPDyoEha+XZ7iEqam49vz6auPnNJ9ZBfy89f+rMMas8AuiMWOZ9PVzu8xb9ZC6rafUqiGHSCfu22ih66E+1g==",
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/engine.io-client/-/engine.io-client-6.5.0.tgz",
+      "integrity": "sha512-C7eN3OKggSfd5g8IDgUA9guC8TNS6CEganKT7dL6Fp3q+FobcQ/WBn2Qq2XTL1vNTiFZfDzXohvqLuR9dWejdg==",
       "dependencies": {
         "@socket.io/component-emitter": "~3.1.0",
         "debug": "~4.3.1",
-        "engine.io-parser": "~5.0.3",
+        "engine.io-parser": "~5.1.0",
         "ws": "~8.11.0",
         "xmlhttprequest-ssl": "~2.0.0"
       }
     },
     "node_modules/engine.io-parser": {
-      "version": "5.0.6",
-      "resolved": "https://registry.npmjs.org/engine.io-parser/-/engine.io-parser-5.0.6.tgz",
-      "integrity": "sha512-tjuoZDMAdEhVnSFleYPCtdL2GXwVTGtNjoeJd9IhIG3C1xs9uwxqRNEu5WpnDZCaozwVlK/nuQhpodhXSIMaxw==",
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/engine.io-parser/-/engine.io-parser-5.1.0.tgz",
+      "integrity": "sha512-enySgNiK5tyZFynt3z7iqBR+Bto9EVVVvDFuTT0ioHCGbzirZVGDGiQjZzEp8hWl6hd5FSVytJGuScX1C1C35w==",
       "engines": {
         "node": ">=10.0.0"
       }
@@ -7739,7 +7747,9 @@
       "dev": true,
       "hasInstallScript": true,
       "optional": true,
-      "os": [ "darwin" ],
+      "os": [
+        "darwin"
+      ],
       "engines": {
         "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
@@ -10243,7 +10253,9 @@
       "version": "1.3.1",
       "resolved": "https://registry.npmjs.org/jsonparse/-/jsonparse-1.3.1.tgz",
       "integrity": "sha1-P02uSpH6wxX3EGL4UhzCOfE2YoA=",
-      "engines": [ "node >= 0.2.0" ]
+      "engines": [
+        "node >= 0.2.0"
+      ]
     },
     "node_modules/jsx-ast-utils": {
       "version": "3.3.3",
@@ -12303,13 +12315,13 @@
       }
     },
     "node_modules/socket.io-client": {
-      "version": "4.6.2",
-      "resolved": "https://registry.npmjs.org/socket.io-client/-/socket.io-client-4.6.2.tgz",
-      "integrity": "sha512-OwWrMbbA8wSqhBAR0yoPK6EdQLERQAYjXb3A0zLpgxfM1ZGLKoxHx8gVmCHA6pcclRX5oA/zvQf7bghAS11jRA==",
+      "version": "4.7.0",
+      "resolved": "https://registry.npmjs.org/socket.io-client/-/socket.io-client-4.7.0.tgz",
+      "integrity": "sha512-7Q8CeDrhuZzg4QLXl3tXlk5yb086oxYzehAVZRLiGCzCmtDneiHz1qHyyWcxhTgxXiokVpWQXoG/u60HoXSQew==",
       "dependencies": {
         "@socket.io/component-emitter": "~3.1.0",
         "debug": "~4.3.2",
-        "engine.io-client": "~6.4.0",
+        "engine.io-client": "~6.5.0",
         "socket.io-parser": "~4.2.4"
       },
       "engines": {
@@ -18478,21 +18490,21 @@
       }
     },
     "engine.io-client": {
-      "version": "6.4.0",
-      "resolved": "https://registry.npmjs.org/engine.io-client/-/engine.io-client-6.4.0.tgz",
-      "integrity": "sha512-GyKPDyoEha+XZ7iEqam49vz6auPnNJ9ZBfy89f+rMMas8AuiMWOZ9PVzu8xb9ZC6rafUqiGHSCfu22ih66E+1g==",
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/engine.io-client/-/engine.io-client-6.5.0.tgz",
+      "integrity": "sha512-C7eN3OKggSfd5g8IDgUA9guC8TNS6CEganKT7dL6Fp3q+FobcQ/WBn2Qq2XTL1vNTiFZfDzXohvqLuR9dWejdg==",
       "requires": {
         "@socket.io/component-emitter": "~3.1.0",
         "debug": "~4.3.1",
-        "engine.io-parser": "~5.0.3",
+        "engine.io-parser": "~5.1.0",
         "ws": "~8.11.0",
         "xmlhttprequest-ssl": "~2.0.0"
       }
     },
     "engine.io-parser": {
-      "version": "5.0.6",
-      "resolved": "https://registry.npmjs.org/engine.io-parser/-/engine.io-parser-5.0.6.tgz",
-      "integrity": "sha512-tjuoZDMAdEhVnSFleYPCtdL2GXwVTGtNjoeJd9IhIG3C1xs9uwxqRNEu5WpnDZCaozwVlK/nuQhpodhXSIMaxw=="
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/engine.io-parser/-/engine.io-parser-5.1.0.tgz",
+      "integrity": "sha512-enySgNiK5tyZFynt3z7iqBR+Bto9EVVVvDFuTT0ioHCGbzirZVGDGiQjZzEp8hWl6hd5FSVytJGuScX1C1C35w=="
     },
     "enhanced-resolve": {
       "version": "5.13.0",
@@ -22916,13 +22928,13 @@
       "integrity": "sha512-94hK0Hh8rPqQl2xXc3HsaBoOXKV20MToPkcXvwbISWLEs+64sBq5kFgn2kJDHb1Pry9yrP0dxrCI9RRci7RXKg=="
     },
     "socket.io-client": {
-      "version": "4.6.2",
-      "resolved": "https://registry.npmjs.org/socket.io-client/-/socket.io-client-4.6.2.tgz",
-      "integrity": "sha512-OwWrMbbA8wSqhBAR0yoPK6EdQLERQAYjXb3A0zLpgxfM1ZGLKoxHx8gVmCHA6pcclRX5oA/zvQf7bghAS11jRA==",
+      "version": "4.7.0",
+      "resolved": "https://registry.npmjs.org/socket.io-client/-/socket.io-client-4.7.0.tgz",
+      "integrity": "sha512-7Q8CeDrhuZzg4QLXl3tXlk5yb086oxYzehAVZRLiGCzCmtDneiHz1qHyyWcxhTgxXiokVpWQXoG/u60HoXSQew==",
       "requires": {
         "@socket.io/component-emitter": "~3.1.0",
         "debug": "~4.3.2",
-        "engine.io-client": "~6.4.0",
+        "engine.io-client": "~6.5.0",
         "socket.io-parser": "~4.2.4"
       }
     },


### PR DESCRIPTION
## Description

This PR‌ updates `socket.io-client` from 4.6.2 to [4.7.0](https://github.com/socketio/socket.io-client/releases/tag/4.7.0).

There seem to be no breaking changes to the code.

## Steps to Test

CI should pass.