### PR TITLE
feat(dev-env): Update wording around dev-env start --vscode

### DIFF
--- a/src/bin/vip-dev-env-start.js
+++ b/src/bin/vip-dev-env-start.js
@@ -38,6 +38,11 @@ const examples = [
 		usage: `${ DEV_ENVIRONMENT_FULL_COMMAND } start`,
 		description: 'Starts a local dev environment',
 	},
+	{
+		usage: `${ DEV_ENVIRONMENT_FULL_COMMAND } start --vscode`,
+		description:
+			'Start a local environment and generate a Workspace file for developing in Visual Studio Code',
+	},
 ];
 
 command()
@@ -47,7 +52,7 @@ command()
 		[ 'w', 'skip-wp-versions-check' ],
 		'Skip prompt to update WordPress version if not on latest'
 	)
-	.option( 'vscode', 'Generate a Visual Studio Code Workspace file and open it' )
+	.option( 'vscode', 'Generate a Visual Studio Code Workspace file' )
 	.examples( examples )
 	.argv( process.argv, async ( arg, opt ) => {
 		const slug = await getEnvironmentName( opt );


### PR DESCRIPTION

## Description
Few more changes in text based on @yolih 's input.

## Steps to Test

```
$ ./dist/bin/vip-dev-env-start.js --help
  Usage: vip dev-env-start.js [options] 
  
  Options:
    -d, --debug                   Activate debug output
    -h, --help                    Output the help for the (sub)command
    -S, --skip-rebuild            Only start stopped services
    -w, --skip-wp-versions-check  Skip prompt to update WordPress version if not on latest
    -s, --slug                    Custom name of the dev environment
    -v, --version                 Output the version number
    -V, --vscode                  Generate a Visual Studio Code Workspace file
  
  Examples:
    - Starts a local dev environment
    $ vip dev-env start

    - Start a local environment and generate a Workspace file for developing in Visual Studio Code
    $ vip dev-env start --vscode

  
```
