### PR TITLE
Remove enums from GraphQL codegen and make sure that prettier actually runs

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,6 +1,4 @@
-*.generated.d.ts
 /CHANGELOG.md
 /__fixtures__/
 /dist/
 /flow-typed/
-/src/graphqlTypes.d.ts

--- a/codegen.ts
+++ b/codegen.ts
@@ -4,10 +4,14 @@ import { CodegenConfig } from '@graphql-codegen/cli';
 const config: CodegenConfig = {
 	schema: './schema.gql',
 	ignoreNoDocuments: true, // for better experience with the watcher
-	hooks: { afterAllFileWrite: [ 'prettier --write' ] },
+	// the following line doesn't seem to work
+	// hooks: { afterAllFileWrite: [ 'npx prettier --write' ] },
 	generates: {
 		'./src/graphqlTypes.d.ts': {
 			plugins: [ 'typescript' ],
+			config: {
+				enumsAsTypes: true,
+			},
 		},
 		'./src/': {
 			documents: [ 'src/**/*.js', 'src/**/*.ts' ],

--- a/codegen.ts
+++ b/codegen.ts
@@ -4,8 +4,7 @@ import { CodegenConfig } from '@graphql-codegen/cli';
 const config: CodegenConfig = {
 	schema: './schema.gql',
 	ignoreNoDocuments: true, // for better experience with the watcher
-	// the following line doesn't seem to work
-	// hooks: { afterAllFileWrite: [ 'npx prettier --write' ] },
+	hooks: { afterAllFileWrite: [ 'npx prettier --write' ] },
 	generates: {
 		'./src/graphqlTypes.d.ts': {
 			plugins: [ 'typescript' ],

--- a/codegen.ts
+++ b/codegen.ts
@@ -4,7 +4,7 @@ import { CodegenConfig } from '@graphql-codegen/cli';
 const config: CodegenConfig = {
 	schema: './schema.gql',
 	ignoreNoDocuments: true, // for better experience with the watcher
-	hooks: { afterAllFileWrite: [ 'npx prettier --write' ] },
+	hooks: { afterAllFileWrite: [ 'prettier --write' ] },
 	generates: {
 		'./src/graphqlTypes.d.ts': {
 			plugins: [ 'typescript' ],

--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
   },
   "scripts": {
     "typescript:codegen:install-dependencies": "npm install --no-save @graphql-codegen/cli @graphql-codegen/typescript @graphql-codegen/near-operation-file-preset @graphql-codegen/typescript-operations",
-    "typescript:codegen:generate": "npx graphql-codegen",
+    "typescript:codegen:generate": "graphql-codegen",
     "test": "npm run lint && npm run flow && npm run check-types && jest --coverage --testPathIgnorePatterns __tests__/devenv-e2e/",
     "test:e2e:dev-env": "jest -c __tests__/devenv-e2e/jest/jest.config.js",
     "clean": "rimraf dist",

--- a/src/bin/vip-app-list.generated.d.ts
+++ b/src/bin/vip-app-list.generated.d.ts
@@ -1,21 +1,21 @@
 import * as Types from '../graphqlTypes';
 
-export type AppsQueryVariables = Types.Exact<{
-  first?: Types.InputMaybe<Types.Scalars['Int']['input']>;
-  after?: Types.InputMaybe<Types.Scalars['String']['input']>;
-}>;
+export type AppsQueryVariables = Types.Exact< {
+	first?: Types.InputMaybe< Types.Scalars[ 'Int' ][ 'input' ] >;
+	after?: Types.InputMaybe< Types.Scalars[ 'String' ][ 'input' ] >;
+} >;
 
 export type AppsQuery = {
-  __typename?: 'Query',
-  apps?: {
-    __typename?: 'AppList',
-    total?: number | null,
-    nextCursor?: string | null,
-    edges?: Array<{
-      __typename?: 'App',
-      id?: number | null,
-      name?: string | null,
-      repo?: string | null
-    } | null> | null
-  } | null
+	__typename?: 'Query';
+	apps?: {
+		__typename?: 'AppList';
+		total?: number | null;
+		nextCursor?: string | null;
+		edges?: Array< {
+			__typename?: 'App';
+			id?: number | null;
+			name?: string | null;
+			repo?: string | null;
+		} | null > | null;
+	} | null;
 };

--- a/src/bin/vip-import-media-abort.generated.d.ts
+++ b/src/bin/vip-import-media-abort.generated.d.ts
@@ -1,21 +1,21 @@
 import * as Types from '../graphqlTypes';
 
-export type AbortMediaImportMutationVariables = Types.Exact<{
-	input?: Types.InputMaybe<Types.AppEnvironmentAbortMediaImportInput>;
-}>;
+export type AbortMediaImportMutationVariables = Types.Exact< {
+	input?: Types.InputMaybe< Types.AppEnvironmentAbortMediaImportInput >;
+} >;
 
 export type AbortMediaImportMutation = {
-	__typename?: 'Mutation',
+	__typename?: 'Mutation';
 	abortMediaImport?: {
-		__typename?: 'AppEnvironmentAbortMediaImportPayload',
-		applicationId?: number | null,
-		environmentId?: number | null,
+		__typename?: 'AppEnvironmentAbortMediaImportPayload';
+		applicationId?: number | null;
+		environmentId?: number | null;
 		mediaImportStatusChange?: {
-			__typename?: 'AppEnvironmentMediaImportStatusChange',
-			importId?: number | null,
-			siteId?: number | null,
-			statusFrom?: string | null,
-			statusTo?: string | null
-		} | null
-	} | null
+			__typename?: 'AppEnvironmentMediaImportStatusChange';
+			importId?: number | null;
+			siteId?: number | null;
+			statusFrom?: string | null;
+			statusTo?: string | null;
+		} | null;
+	} | null;
 };

--- a/src/bin/vip-import-media.generated.d.ts
+++ b/src/bin/vip-import-media.generated.d.ts
@@ -1,20 +1,20 @@
 import * as Types from '../graphqlTypes';
 
-export type StartMediaImportMutationVariables = Types.Exact<{
-	input?: Types.InputMaybe<Types.AppEnvironmentStartMediaImportInput>;
-}>;
+export type StartMediaImportMutationVariables = Types.Exact< {
+	input?: Types.InputMaybe< Types.AppEnvironmentStartMediaImportInput >;
+} >;
 
 export type StartMediaImportMutation = {
-	__typename?: 'Mutation',
+	__typename?: 'Mutation';
 	startMediaImport?: {
-		__typename?: 'AppEnvironmentMediaImportPayload',
-		applicationId?: number | null,
-		environmentId?: number | null,
+		__typename?: 'AppEnvironmentMediaImportPayload';
+		applicationId?: number | null;
+		environmentId?: number | null;
 		mediaImportStatus: {
-			__typename?: 'AppEnvironmentMediaImportStatus',
-			importId?: number | null,
-			siteId?: number | null,
-			status?: string | null
-		}
-	} | null
+			__typename?: 'AppEnvironmentMediaImportStatus';
+			importId?: number | null;
+			siteId?: number | null;
+			status?: string | null;
+		};
+	} | null;
 };

--- a/src/bin/vip-import-sql.generated.d.ts
+++ b/src/bin/vip-import-sql.generated.d.ts
@@ -1,15 +1,15 @@
 import * as Types from '../graphqlTypes';
 
-export type StartImportMutationVariables = Types.Exact<{
-	input?: Types.InputMaybe<Types.AppEnvironmentImportInput>;
-}>;
+export type StartImportMutationVariables = Types.Exact< {
+	input?: Types.InputMaybe< Types.AppEnvironmentImportInput >;
+} >;
 
 export type StartImportMutation = {
-	__typename?: 'Mutation',
+	__typename?: 'Mutation';
 	startImport?: {
-		__typename?: 'AppEnvironmentImportPayload',
-		message?: string | null,
-		success?: boolean | null,
-		app?: { __typename?: 'App', id?: number | null, name?: string | null } | null
-	} | null
+		__typename?: 'AppEnvironmentImportPayload';
+		message?: string | null;
+		success?: boolean | null;
+		app?: { __typename?: 'App'; id?: number | null; name?: string | null } | null;
+	} | null;
 };

--- a/src/bin/vip-sync.generated.d.ts
+++ b/src/bin/vip-sync.generated.d.ts
@@ -1,45 +1,45 @@
 import * as Types from '../graphqlTypes';
 
-export type SyncEnvironmentMutationMutationVariables = Types.Exact<{
-	input?: Types.InputMaybe<Types.AppEnvironmentSyncInput>;
-}>;
+export type SyncEnvironmentMutationMutationVariables = Types.Exact< {
+	input?: Types.InputMaybe< Types.AppEnvironmentSyncInput >;
+} >;
 
 export type SyncEnvironmentMutationMutation = {
-	__typename?: 'Mutation',
+	__typename?: 'Mutation';
 	syncEnvironment?: {
-		__typename?: 'AppEnvironmentSyncPayload',
-		environment?: { __typename?: 'AppEnvironment', id?: number | null } | null
-	} | null
+		__typename?: 'AppEnvironmentSyncPayload';
+		environment?: { __typename?: 'AppEnvironment'; id?: number | null } | null;
+	} | null;
 };
 
-export type AppQueryVariables = Types.Exact<{
-	id?: Types.InputMaybe<Types.Scalars['Int']['input']>;
-	sync?: Types.InputMaybe<Types.Scalars['Int']['input']>;
-}>;
+export type AppQueryVariables = Types.Exact< {
+	id?: Types.InputMaybe< Types.Scalars[ 'Int' ][ 'input' ] >;
+	sync?: Types.InputMaybe< Types.Scalars[ 'Int' ][ 'input' ] >;
+} >;
 
 export type AppQuery = {
-	__typename?: 'Query',
+	__typename?: 'Query';
 	app?: {
-		__typename?: 'App',
-		id?: number | null,
-		name?: string | null,
-		environments?: Array<{
-			__typename?: 'AppEnvironment',
-			id?: number | null,
-			name?: string | null,
-			defaultDomain?: string | null,
-			branch?: string | null,
-			datacenter?: string | null,
+		__typename?: 'App';
+		id?: number | null;
+		name?: string | null;
+		environments?: Array< {
+			__typename?: 'AppEnvironment';
+			id?: number | null;
+			name?: string | null;
+			defaultDomain?: string | null;
+			branch?: string | null;
+			datacenter?: string | null;
 			syncProgress?: {
-				__typename?: 'AppEnvironmentSyncProgress',
-				status?: string | null,
-				sync?: number | null,
-				steps?: Array<{
-					__typename?: 'AppEnvironmentSyncStep',
-					name?: string | null,
-					status?: string | null
-				} | null> | null
-			} | null
-		} | null> | null
-	} | null
+				__typename?: 'AppEnvironmentSyncProgress';
+				status?: string | null;
+				sync?: number | null;
+				steps?: Array< {
+					__typename?: 'AppEnvironmentSyncStep';
+					name?: string | null;
+					status?: string | null;
+				} | null > | null;
+			} | null;
+		} | null > | null;
+	} | null;
 };

--- a/src/bin/vip-validate-preflight.generated.d.ts
+++ b/src/bin/vip-validate-preflight.generated.d.ts
@@ -1,24 +1,24 @@
 import * as Types from '../graphqlTypes';
 
-export type BuildConfigQueryVariables = Types.Exact<{
-	appId?: Types.InputMaybe<Types.Scalars['Int']['input']>;
-	envId?: Types.InputMaybe<Types.Scalars['Int']['input']>;
-}>;
+export type BuildConfigQueryVariables = Types.Exact< {
+	appId?: Types.InputMaybe< Types.Scalars[ 'Int' ][ 'input' ] >;
+	envId?: Types.InputMaybe< Types.Scalars[ 'Int' ][ 'input' ] >;
+} >;
 
 export type BuildConfigQuery = {
-	__typename?: 'Query',
+	__typename?: 'Query';
 	app?: {
-		__typename?: 'App',
-		environments?: Array<{
-			__typename?: 'AppEnvironment',
-			id?: number | null,
+		__typename?: 'App';
+		environments?: Array< {
+			__typename?: 'AppEnvironment';
+			id?: number | null;
 			buildConfiguration?: {
-				__typename?: 'BuildConfiguration',
-				buildType: string,
-				nodeBuildDockerEnv: string,
-				nodeJSVersion: string,
-				npmToken?: string | null
-			} | null
-		} | null> | null
-	} | null
+				__typename?: 'BuildConfiguration';
+				buildType: string;
+				nodeBuildDockerEnv: string;
+				nodeJSVersion: string;
+				npmToken?: string | null;
+			} | null;
+		} | null > | null;
+	} | null;
 };

--- a/src/bin/vip-wp.generated.d.ts
+++ b/src/bin/vip-wp.generated.d.ts
@@ -1,26 +1,26 @@
 import * as Types from '../graphqlTypes';
 
-export type TriggerWpcliCommandMutationMutationVariables = Types.Exact<{
-	input?: Types.InputMaybe<Types.AppEnvironmentTriggerWpcliCommandInput>;
-}>;
+export type TriggerWpcliCommandMutationMutationVariables = Types.Exact< {
+	input?: Types.InputMaybe< Types.AppEnvironmentTriggerWpcliCommandInput >;
+} >;
 
 export type TriggerWpcliCommandMutationMutation = {
-	__typename?: 'Mutation',
+	__typename?: 'Mutation';
 	triggerWPCLICommandOnAppEnvironment?: {
-		__typename?: 'AppEnvironmentTriggerWPCLICommandPayload',
-		inputToken?: string | null,
-		command?: { __typename?: 'WPCLICommand', guid?: string | null } | null
-	} | null
+		__typename?: 'AppEnvironmentTriggerWPCLICommandPayload';
+		inputToken?: string | null;
+		command?: { __typename?: 'WPCLICommand'; guid?: string | null } | null;
+	} | null;
 };
 
-export type CancelWpcliCommandMutationVariables = Types.Exact<{
-	input?: Types.InputMaybe<Types.CancelWpcliCommandInput>;
-}>;
+export type CancelWpcliCommandMutationVariables = Types.Exact< {
+	input?: Types.InputMaybe< Types.CancelWpcliCommandInput >;
+} >;
 
 export type CancelWpcliCommandMutation = {
-	__typename?: 'Mutation',
+	__typename?: 'Mutation';
 	cancelWPCLICommand?: {
-		__typename?: 'CancelWPCLICommandPayload',
-		command?: { __typename?: 'WPCLICommand', id?: number | null } | null
-	} | null
+		__typename?: 'CancelWPCLICommandPayload';
+		command?: { __typename?: 'WPCLICommand'; id?: number | null } | null;
+	} | null;
 };

--- a/src/commands/backup-db.generated.d.ts
+++ b/src/commands/backup-db.generated.d.ts
@@ -1,0 +1,61 @@
+import * as Types from '../graphqlTypes';
+
+export type TriggerDatabaseBackupMutationVariables = Types.Exact< {
+	input?: Types.InputMaybe< Types.AppEnvironmentTriggerDbBackupInput >;
+} >;
+
+export type TriggerDatabaseBackupMutation = {
+	__typename?: 'Mutation';
+	triggerDatabaseBackup?: {
+		__typename?: 'AppEnvironmentTriggerDBBackupPayload';
+		success?: boolean | null;
+	} | null;
+};
+
+export type AppBackupJobStatusQueryVariables = Types.Exact< {
+	appId: Types.Scalars[ 'Int' ][ 'input' ];
+	envId: Types.Scalars[ 'Int' ][ 'input' ];
+} >;
+
+export type AppBackupJobStatusQuery = {
+	__typename?: 'Query';
+	app?: {
+		__typename?: 'App';
+		id?: number | null;
+		environments?: Array< {
+			__typename?: 'AppEnvironment';
+			id?: number | null;
+			jobs?: Array<
+				| {
+						__typename?: 'Job';
+						id?: number | null;
+						type?: string | null;
+						completedAt?: string | null;
+						createdAt?: string | null;
+						inProgressLock?: boolean | null;
+						metadata?: Array< {
+							__typename?: 'JobMetadata';
+							name?: string | null;
+							value?: string | null;
+						} | null > | null;
+						progress?: { __typename?: 'JobProgress'; status?: string | null } | null;
+				  }
+				| {
+						__typename?: 'PrimaryDomainSwitchJob';
+						id?: number | null;
+						type?: string | null;
+						completedAt?: string | null;
+						createdAt?: string | null;
+						inProgressLock?: boolean | null;
+						metadata?: Array< {
+							__typename?: 'JobMetadata';
+							name?: string | null;
+							value?: string | null;
+						} | null > | null;
+						progress?: { __typename?: 'JobProgress'; status?: string | null } | null;
+				  }
+				| null
+			> | null;
+		} | null > | null;
+	} | null;
+};

--- a/src/commands/export-sql.generated.d.ts
+++ b/src/commands/export-sql.generated.d.ts
@@ -1,96 +1,103 @@
 import * as Types from '../graphqlTypes';
 
-export type AppBackupAndJobStatusQueryVariables = Types.Exact<{
-  appId: Types.Scalars['Int']['input'];
-  envId: Types.Scalars['Int']['input'];
-}>;
+export type AppBackupAndJobStatusQueryVariables = Types.Exact< {
+	appId: Types.Scalars[ 'Int' ][ 'input' ];
+	envId: Types.Scalars[ 'Int' ][ 'input' ];
+} >;
 
 export type AppBackupAndJobStatusQuery = {
-  __typename?: 'Query', app?: {
-    __typename?: 'App', id?: number | null, environments?: Array<{
-      __typename?: 'AppEnvironment',
-      id?: number | null,
-      latestBackup?: {
-        __typename?: 'Backup',
-        id?: number | null,
-        type?: string | null,
-        size?: number | null,
-        filename?: string | null,
-        createdAt?: string | null
-      } | null,
-      jobs?: Array<{
-        __typename?: 'Job',
-        id?: number | null,
-        type?: string | null,
-        completedAt?: string | null,
-        createdAt?: string | null,
-        inProgressLock?: boolean | null,
-        metadata?: Array<{
-          __typename?: 'JobMetadata',
-          name?: string | null,
-          value?: string | null
-        } | null> | null,
-        progress?: {
-          __typename?: 'JobProgress',
-          status?: string | null,
-          steps?: Array<{
-            __typename?: 'JobProgressStep',
-            id?: string | null,
-            name?: string | null,
-            step?: string | null,
-            status?: string | null
-          } | null> | null
-        } | null
-      } | {
-        __typename?: 'PrimaryDomainSwitchJob',
-        id?: number | null,
-        type?: string | null,
-        completedAt?: string | null,
-        createdAt?: string | null,
-        inProgressLock?: boolean | null,
-        metadata?: Array<{
-          __typename?: 'JobMetadata',
-          name?: string | null,
-          value?: string | null
-        } | null> | null,
-        progress?: {
-          __typename?: 'JobProgress',
-          status?: string | null,
-          steps?: Array<{
-            __typename?: 'JobProgressStep',
-            id?: string | null,
-            name?: string | null,
-            step?: string | null,
-            status?: string | null
-          } | null> | null
-        } | null
-      } | null> | null
-    } | null> | null
-  } | null
+	__typename?: 'Query';
+	app?: {
+		__typename?: 'App';
+		id?: number | null;
+		environments?: Array< {
+			__typename?: 'AppEnvironment';
+			id?: number | null;
+			latestBackup?: {
+				__typename?: 'Backup';
+				id?: number | null;
+				type?: string | null;
+				size?: number | null;
+				filename?: string | null;
+				createdAt?: string | null;
+			} | null;
+			jobs?: Array<
+				| {
+						__typename?: 'Job';
+						id?: number | null;
+						type?: string | null;
+						completedAt?: string | null;
+						createdAt?: string | null;
+						inProgressLock?: boolean | null;
+						metadata?: Array< {
+							__typename?: 'JobMetadata';
+							name?: string | null;
+							value?: string | null;
+						} | null > | null;
+						progress?: {
+							__typename?: 'JobProgress';
+							status?: string | null;
+							steps?: Array< {
+								__typename?: 'JobProgressStep';
+								id?: string | null;
+								name?: string | null;
+								step?: string | null;
+								status?: string | null;
+							} | null > | null;
+						} | null;
+				  }
+				| {
+						__typename?: 'PrimaryDomainSwitchJob';
+						id?: number | null;
+						type?: string | null;
+						completedAt?: string | null;
+						createdAt?: string | null;
+						inProgressLock?: boolean | null;
+						metadata?: Array< {
+							__typename?: 'JobMetadata';
+							name?: string | null;
+							value?: string | null;
+						} | null > | null;
+						progress?: {
+							__typename?: 'JobProgress';
+							status?: string | null;
+							steps?: Array< {
+								__typename?: 'JobProgressStep';
+								id?: string | null;
+								name?: string | null;
+								step?: string | null;
+								status?: string | null;
+							} | null > | null;
+						} | null;
+				  }
+				| null
+			> | null;
+		} | null > | null;
+	} | null;
 };
 
-export type GenerateDbBackupCopyUrlMutationVariables = Types.Exact<{
-  input?: Types.InputMaybe<Types.AppEnvironmentGenerateDbBackupCopyUrlInput>;
-}>;
+export type GenerateDbBackupCopyUrlMutationVariables = Types.Exact< {
+	input?: Types.InputMaybe< Types.AppEnvironmentGenerateDbBackupCopyUrlInput >;
+} >;
 
 export type GenerateDbBackupCopyUrlMutation = {
-  __typename?: 'Mutation',
-  generateDBBackupCopyUrl?: {
-    __typename?: 'AppEnvironmentGenerateDBBackupCopyUrlPayload',
-    url?: string | null,
-    success?: boolean | null
-  } | null
+	__typename?: 'Mutation';
+	generateDBBackupCopyUrl?: {
+		__typename?: 'AppEnvironmentGenerateDBBackupCopyUrlPayload';
+		url?: string | null;
+		success?: boolean | null;
+	} | null;
 };
 
-export type BackupDbCopyMutationVariables = Types.Exact<{
-  input?: Types.InputMaybe<Types.AppEnvironmentStartDbBackupCopyInput>;
-}>;
+export type BackupDbCopyMutationVariables = Types.Exact< {
+	input?: Types.InputMaybe< Types.AppEnvironmentStartDbBackupCopyInput >;
+} >;
 
 export type BackupDbCopyMutation = {
-  __typename?: 'Mutation',
-  startDBBackupCopy?: {
-    __typename?: 'AppEnvironmentStartDBBackupCopyPayload',
-    message?: string | null,
-    success?: boolean | null
-  } | null
+	__typename?: 'Mutation';
+	startDBBackupCopy?: {
+		__typename?: 'AppEnvironmentStartDBBackupCopyPayload';
+		message?: string | null;
+		success?: boolean | null;
+	} | null;
 };

--- a/src/graphqlTypes.d.ts
+++ b/src/graphqlTypes.d.ts
@@ -1,3318 +1,3193 @@
-export type Maybe<T> = T | null;
-export type InputMaybe<T> = Maybe<T>;
-export type Exact<T extends { [ key: string ]: unknown }> = { [K in keyof T]: T[K] };
-export type MakeOptional<T, K extends keyof T> = Omit<T, K> & { [SubKey in K]?: Maybe<T[SubKey]> };
-export type MakeMaybe<T, K extends keyof T> = Omit<T, K> & { [SubKey in K]: Maybe<T[SubKey]> };
-export type MakeEmpty<T extends {
-  [ key: string ]: unknown
-}, K extends keyof T> = { [_ in K]?: never };
-export type Incremental<T> =
-  T
-  | { [P in keyof T]?: P extends ' $fragmentName' | '__typename' ? T[P] : never };
+export type Maybe< T > = T | null;
+export type InputMaybe< T > = Maybe< T >;
+export type Exact< T extends { [ key: string ]: unknown } > = { [ K in keyof T ]: T[ K ] };
+export type MakeOptional< T, K extends keyof T > = Omit< T, K > & {
+	[ SubKey in K ]?: Maybe< T[ SubKey ] >;
+};
+export type MakeMaybe< T, K extends keyof T > = Omit< T, K > & {
+	[ SubKey in K ]: Maybe< T[ SubKey ] >;
+};
+export type MakeEmpty< T extends { [ key: string ]: unknown }, K extends keyof T > = {
+	[ _ in K ]?: never;
+};
+export type Incremental< T > =
+	| T
+	| { [ P in keyof T ]?: P extends ' $fragmentName' | '__typename' ? T[ P ] : never };
 /** All built-in and custom scalars, mapped to their actual values */
 export type Scalars = {
-  ID: { input: string; output: string; }
-  String: { input: string; output: string; }
-  Boolean: { input: boolean; output: boolean; }
-  Int: { input: number; output: number; }
-  Float: { input: number; output: number; }
-  BigInt: { input: any; output: any; }
-  /** Date custom scalar type */
-  Date: { input: any; output: any; }
+	ID: { input: string; output: string };
+	String: { input: string; output: string };
+	Boolean: { input: boolean; output: boolean };
+	Int: { input: number; output: number };
+	Float: { input: number; output: number };
+	BigInt: { input: any; output: any };
+	/** Date custom scalar type */
+	Date: { input: any; output: any };
 };
 
 export type AcceptInvitationInput = {
-  invitationCode?: InputMaybe<Scalars['String']['input']>;
+	invitationCode?: InputMaybe< Scalars[ 'String' ][ 'input' ] >;
 };
 
 export type AcceptInvitationPayload = {
-  __typename?: 'AcceptInvitationPayload';
-  status?: Maybe<Scalars['String']['output']>;
+	__typename?: 'AcceptInvitationPayload';
+	status?: Maybe< Scalars[ 'String' ][ 'output' ] >;
 };
 
 export type ActivateCertificateInput = {
-  certificateId?: InputMaybe<Scalars['Int']['input']>;
-  domainNames?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+	certificateId?: InputMaybe< Scalars[ 'Int' ][ 'input' ] >;
+	domainNames?: InputMaybe< Array< InputMaybe< Scalars[ 'String' ][ 'input' ] > > >;
 };
 
 export type ActivateCertificatePayload = {
-  __typename?: 'ActivateCertificatePayload';
-  certificateId?: Maybe<Scalars['Int']['output']>;
+	__typename?: 'ActivateCertificatePayload';
+	certificateId?: Maybe< Scalars[ 'Int' ][ 'output' ] >;
 };
 
 export type AddCertificateInput = {
-  certificate: Scalars['String']['input'];
-  clientId: Scalars['Int']['input'];
-  csr: Scalars['String']['input'];
-  domainName?: InputMaybe<Scalars['String']['input']>;
-  key: Scalars['String']['input'];
-  trustedCertificate?: InputMaybe<Scalars['String']['input']>;
+	certificate: Scalars[ 'String' ][ 'input' ];
+	clientId: Scalars[ 'Int' ][ 'input' ];
+	csr: Scalars[ 'String' ][ 'input' ];
+	domainName?: InputMaybe< Scalars[ 'String' ][ 'input' ] >;
+	key: Scalars[ 'String' ][ 'input' ];
+	trustedCertificate?: InputMaybe< Scalars[ 'String' ][ 'input' ] >;
 };
 
 export type AddCertificatePayload = {
-  __typename?: 'AddCertificatePayload';
-  certificate?: Maybe<Scalars['String']['output']>;
-  certificateId?: Maybe<Scalars['Int']['output']>;
+	__typename?: 'AddCertificatePayload';
+	certificate?: Maybe< Scalars[ 'String' ][ 'output' ] >;
+	certificateId?: Maybe< Scalars[ 'Int' ][ 'output' ] >;
 };
 
 export type AddNotificationRecipientInput = {
-  active?: InputMaybe<Scalars['Boolean']['input']>;
-  description?: InputMaybe<Scalars['String']['input']>;
-  meta?: InputMaybe<Scalars['String']['input']>;
-  name: Scalars['String']['input'];
-  organizationId: Scalars['BigInt']['input'];
-  recipientType: NotificationRecipientType;
-  recipientValue: Scalars['String']['input'];
+	active?: InputMaybe< Scalars[ 'Boolean' ][ 'input' ] >;
+	description?: InputMaybe< Scalars[ 'String' ][ 'input' ] >;
+	meta?: InputMaybe< Scalars[ 'String' ][ 'input' ] >;
+	name: Scalars[ 'String' ][ 'input' ];
+	organizationId: Scalars[ 'BigInt' ][ 'input' ];
+	recipientType: NotificationRecipientType;
+	recipientValue: Scalars[ 'String' ][ 'input' ];
 };
 
 export type AddNotificationRecipientPayload = {
-  __typename?: 'AddNotificationRecipientPayload';
-  notificationRecipient?: Maybe<NotificationRecipient>;
+	__typename?: 'AddNotificationRecipientPayload';
+	notificationRecipient?: Maybe< NotificationRecipient >;
 };
 
 export type AddNotificationSubscriptionInput = {
-  active?: InputMaybe<Scalars['Boolean']['input']>;
-  applicationId?: InputMaybe<Scalars['Int']['input']>;
-  description: Scalars['String']['input'];
-  environmentId?: InputMaybe<Scalars['Int']['input']>;
-  meta?: InputMaybe<Scalars['String']['input']>;
-  notificationRecipientId: Scalars['BigInt']['input'];
-  organizationId?: InputMaybe<Scalars['Int']['input']>;
+	active?: InputMaybe< Scalars[ 'Boolean' ][ 'input' ] >;
+	applicationId?: InputMaybe< Scalars[ 'Int' ][ 'input' ] >;
+	description: Scalars[ 'String' ][ 'input' ];
+	environmentId?: InputMaybe< Scalars[ 'Int' ][ 'input' ] >;
+	meta?: InputMaybe< Scalars[ 'String' ][ 'input' ] >;
+	notificationRecipientId: Scalars[ 'BigInt' ][ 'input' ];
+	organizationId?: InputMaybe< Scalars[ 'Int' ][ 'input' ] >;
 };
 
 export type AddNotificationSubscriptionPayload = {
-  __typename?: 'AddNotificationSubscriptionPayload';
-  notificationRecipientId?: Maybe<Scalars['Int']['output']>;
-  notificationSubscriptionId?: Maybe<Scalars['Int']['output']>;
+	__typename?: 'AddNotificationSubscriptionPayload';
+	notificationRecipientId?: Maybe< Scalars[ 'Int' ][ 'output' ] >;
+	notificationSubscriptionId?: Maybe< Scalars[ 'Int' ][ 'output' ] >;
 };
 
 export type AggregatedMetricMeasurements = {
-  __typename?: 'AggregatedMetricMeasurements';
-  measurementUnit?: Maybe<Scalars['String']['output']>;
-  measurements: Array<Maybe<MetricMeasurement>>;
-  metricDisplayName?: Maybe<Scalars['String']['output']>;
-  metricName: Scalars['String']['output'];
-  resolution?: Maybe<Scalars['Int']['output']>;
+	__typename?: 'AggregatedMetricMeasurements';
+	measurementUnit?: Maybe< Scalars[ 'String' ][ 'output' ] >;
+	measurements: Array< Maybe< MetricMeasurement > >;
+	metricDisplayName?: Maybe< Scalars[ 'String' ][ 'output' ] >;
+	metricName: Scalars[ 'String' ][ 'output' ];
+	resolution?: Maybe< Scalars[ 'Int' ][ 'output' ] >;
 };
 
 export type App = Model & {
-  __typename?: 'App';
-  active?: Maybe<Scalars['Boolean']['output']>;
-  createdAt?: Maybe<Scalars['String']['output']>;
-  environments?: Maybe<Array<Maybe<AppEnvironment>>>;
-  features?: Maybe<Array<Maybe<Feature>>>;
-  id?: Maybe<Scalars['Int']['output']>;
-  name?: Maybe<Scalars['String']['output']>;
-  organization?: Maybe<Organization>;
-  organizationId?: Maybe<Scalars['Int']['output']>;
-  pageviews?: Maybe<Pageviews>;
-  permissions?: Maybe<Array<Maybe<PermissionResult>>>;
-  primaryEnvironment?: Maybe<AppEnvironment>;
-  repo?: Maybe<Scalars['String']['output']>;
-  repository?: Maybe<GitRepository>;
-  serviceStatus?: Maybe<Scalars['String']['output']>;
-  supportPackage?: Maybe<Scalars['String']['output']>;
-  type?: Maybe<Scalars['String']['output']>;
-  typeId?: Maybe<Scalars['Int']['output']>;
+	__typename?: 'App';
+	active?: Maybe< Scalars[ 'Boolean' ][ 'output' ] >;
+	createdAt?: Maybe< Scalars[ 'String' ][ 'output' ] >;
+	environments?: Maybe< Array< Maybe< AppEnvironment > > >;
+	features?: Maybe< Array< Maybe< Feature > > >;
+	id?: Maybe< Scalars[ 'Int' ][ 'output' ] >;
+	name?: Maybe< Scalars[ 'String' ][ 'output' ] >;
+	organization?: Maybe< Organization >;
+	organizationId?: Maybe< Scalars[ 'Int' ][ 'output' ] >;
+	pageviews?: Maybe< Pageviews >;
+	permissions?: Maybe< Array< Maybe< PermissionResult > > >;
+	primaryEnvironment?: Maybe< AppEnvironment >;
+	repo?: Maybe< Scalars[ 'String' ][ 'output' ] >;
+	repository?: Maybe< GitRepository >;
+	serviceStatus?: Maybe< Scalars[ 'String' ][ 'output' ] >;
+	supportPackage?: Maybe< Scalars[ 'String' ][ 'output' ] >;
+	type?: Maybe< Scalars[ 'String' ][ 'output' ] >;
+	typeId?: Maybe< Scalars[ 'Int' ][ 'output' ] >;
 };
-
 
 export type AppEnvironmentsArgs = {
-  id?: InputMaybe<Scalars['Int']['input']>;
-  name?: InputMaybe<Scalars['String']['input']>;
-  type?: InputMaybe<Scalars['String']['input']>;
+	id?: InputMaybe< Scalars[ 'Int' ][ 'input' ] >;
+	name?: InputMaybe< Scalars[ 'String' ][ 'input' ] >;
+	type?: InputMaybe< Scalars[ 'String' ][ 'input' ] >;
 };
 
-
 export type AppPermissionsArgs = {
-  permissions?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+	permissions?: InputMaybe< Array< InputMaybe< Scalars[ 'String' ][ 'input' ] > > >;
 };
 
 export type AppEnvironment = {
-  __typename?: 'AppEnvironment';
-  active?: Maybe<Scalars['Boolean']['output']>;
-  activeBackup?: Maybe<Backup>;
-  allowedIPs?: Maybe<AppEnvironmentIpAllowList>;
-  appId?: Maybe<Scalars['Int']['output']>;
-  backupPolicyId?: Maybe<Scalars['Int']['output']>;
-  backupShippingConfig?: Maybe<AppEnvironmentBackupShipping>;
-  backups?: Maybe<BackupsList>;
-  basicAuth?: Maybe<AppEnvironmentBasicAuth>;
-  branch?: Maybe<Scalars['String']['output']>;
-  buildConfiguration?: Maybe<BuildConfiguration>;
-  builds?: Maybe<BuildList>;
-  /** Get codebase related information */
-  codebase?: Maybe<CodebaseInfo>;
-  commands?: Maybe<WpcliCommandList>;
-  commits?: Maybe<GitCommitList>;
-  createdAt?: Maybe<Scalars['String']['output']>;
-  currentCommit?: Maybe<Scalars['String']['output']>;
-  datacenter?: Maybe<Scalars['String']['output']>;
-  dbBackupCopies?: Maybe<DbBackupCopyList>;
-  dbOperationInProgress?: Maybe<Scalars['Boolean']['output']>;
-  defaultDomain?: Maybe<Scalars['String']['output']>;
-  deployments?: Maybe<DeploymentList>;
-  deploys?: Maybe<DeployList>;
-  domains?: Maybe<DomainList>;
-  environmentVariables?: Maybe<EnvironmentVariablesList>;
-  events?: Maybe<AuditEventList>;
-  health?: Maybe<AppEnvironmentHealth>;
-  hstsSettings?: Maybe<AppEnvironmentHstsSettings>;
-  icon?: Maybe<AppEnvironmentIcon>;
-  id?: Maybe<Scalars['Int']['output']>;
-  importStatus?: Maybe<AppEnvironmentImportStatus>;
-  ips?: Maybe<AppEnvironmentIPs>;
-  isDBPartitioningEnabled?: Maybe<Scalars['Boolean']['output']>;
-  isK8sResident?: Maybe<Scalars['Boolean']['output']>;
-  isMultisite?: Maybe<Scalars['Boolean']['output']>;
-  isOnLatestCode?: Maybe<Scalars['Boolean']['output']>;
-  isSubdirectoryMultisite?: Maybe<Scalars['Boolean']['output']>;
-  jobs?: Maybe<Array<Maybe<JobInterface>>>;
-  latestBackup?: Maybe<Backup>;
-  latestMediaExport?: Maybe<MediaExport>;
-  launchModeEndAt?: Maybe<Scalars['String']['output']>;
-  launched?: Maybe<Scalars['Boolean']['output']>;
-  logs?: Maybe<AppEnvironmentLogsList>;
-  logsConfig?: Maybe<AppEnvironmentLogShipping>;
-  mediaExports?: Maybe<MediaExportsList>;
-  mediaImportStatus?: Maybe<AppEnvironmentMediaImportStatus>;
-  metrics?: Maybe<AggregatedMetricMeasurements>;
-  name?: Maybe<Scalars['String']['output']>;
-  notificationSubscriptions?: Maybe<NotificationSubscriptionList>;
-  permissions?: Maybe<Array<Maybe<PermissionResult>>>;
-  primaryDomain?: Maybe<Domain>;
-  primaryDomainSwitchProgress?: Maybe<AppEnvironmentPrimaryDomainSwitchProgress>;
-  pullRequests?: Maybe<GitHubPullRequestList>;
-  repo?: Maybe<Scalars['String']['output']>;
-  requestStats?: Maybe<RequestStatsList>;
-  slowlogs?: Maybe<AppEnvironmentSlowlogsList>;
-  software?: Maybe<AppEnvironmentSoftwareDetails>;
-  softwareSettings?: Maybe<AppEnvironmentSoftwareSettings>;
-  syncPreview?: Maybe<AppEnvironmentSyncPreview>;
-  syncProgress?: Maybe<AppEnvironmentSyncProgress>;
-  type?: Maybe<Scalars['String']['output']>;
-  uniqueLabel?: Maybe<Scalars['String']['output']>;
-  updateSubsiteDomainStatus?: Maybe<AppEnvironmentUpdateSubsiteDomainStatus>;
-  /** Get WordPress Site Installation Details */
-  wpInstallation?: Maybe<WpInstallation>;
-  /** Get WordPress Site Details */
-  wpSites?: Maybe<WpSiteList>;
-  /** Get WordPress Site Details from SDS */
-  wpSitesSDS?: Maybe<WpSiteList>;
+	__typename?: 'AppEnvironment';
+	active?: Maybe< Scalars[ 'Boolean' ][ 'output' ] >;
+	activeBackup?: Maybe< Backup >;
+	allowedIPs?: Maybe< AppEnvironmentIpAllowList >;
+	appId?: Maybe< Scalars[ 'Int' ][ 'output' ] >;
+	backupPolicyId?: Maybe< Scalars[ 'Int' ][ 'output' ] >;
+	backupShippingConfig?: Maybe< AppEnvironmentBackupShipping >;
+	backups?: Maybe< BackupsList >;
+	basicAuth?: Maybe< AppEnvironmentBasicAuth >;
+	branch?: Maybe< Scalars[ 'String' ][ 'output' ] >;
+	buildConfiguration?: Maybe< BuildConfiguration >;
+	builds?: Maybe< BuildList >;
+	/** Get codebase related information */
+	codebase?: Maybe< CodebaseInfo >;
+	commands?: Maybe< WpcliCommandList >;
+	commits?: Maybe< GitCommitList >;
+	createdAt?: Maybe< Scalars[ 'String' ][ 'output' ] >;
+	currentCommit?: Maybe< Scalars[ 'String' ][ 'output' ] >;
+	datacenter?: Maybe< Scalars[ 'String' ][ 'output' ] >;
+	dbBackupCopies?: Maybe< DbBackupCopyList >;
+	dbOperationInProgress?: Maybe< Scalars[ 'Boolean' ][ 'output' ] >;
+	defaultDomain?: Maybe< Scalars[ 'String' ][ 'output' ] >;
+	deployments?: Maybe< DeploymentList >;
+	deploys?: Maybe< DeployList >;
+	domains?: Maybe< DomainList >;
+	environmentVariables?: Maybe< EnvironmentVariablesList >;
+	events?: Maybe< AuditEventList >;
+	health?: Maybe< AppEnvironmentHealth >;
+	hstsSettings?: Maybe< AppEnvironmentHstsSettings >;
+	icon?: Maybe< AppEnvironmentIcon >;
+	id?: Maybe< Scalars[ 'Int' ][ 'output' ] >;
+	importStatus?: Maybe< AppEnvironmentImportStatus >;
+	ips?: Maybe< AppEnvironmentIPs >;
+	isDBPartitioningEnabled?: Maybe< Scalars[ 'Boolean' ][ 'output' ] >;
+	isK8sResident?: Maybe< Scalars[ 'Boolean' ][ 'output' ] >;
+	isMultisite?: Maybe< Scalars[ 'Boolean' ][ 'output' ] >;
+	isOnLatestCode?: Maybe< Scalars[ 'Boolean' ][ 'output' ] >;
+	isSubdirectoryMultisite?: Maybe< Scalars[ 'Boolean' ][ 'output' ] >;
+	jobs?: Maybe< Array< Maybe< JobInterface > > >;
+	latestBackup?: Maybe< Backup >;
+	latestMediaExport?: Maybe< MediaExport >;
+	launchModeEndAt?: Maybe< Scalars[ 'String' ][ 'output' ] >;
+	launched?: Maybe< Scalars[ 'Boolean' ][ 'output' ] >;
+	logs?: Maybe< AppEnvironmentLogsList >;
+	logsConfig?: Maybe< AppEnvironmentLogShipping >;
+	mediaExports?: Maybe< MediaExportsList >;
+	mediaImportStatus?: Maybe< AppEnvironmentMediaImportStatus >;
+	metrics?: Maybe< AggregatedMetricMeasurements >;
+	name?: Maybe< Scalars[ 'String' ][ 'output' ] >;
+	notificationSubscriptions?: Maybe< NotificationSubscriptionList >;
+	permissions?: Maybe< Array< Maybe< PermissionResult > > >;
+	primaryDomain?: Maybe< Domain >;
+	primaryDomainSwitchProgress?: Maybe< AppEnvironmentPrimaryDomainSwitchProgress >;
+	pullRequests?: Maybe< GitHubPullRequestList >;
+	repo?: Maybe< Scalars[ 'String' ][ 'output' ] >;
+	requestStats?: Maybe< RequestStatsList >;
+	slowlogs?: Maybe< AppEnvironmentSlowlogsList >;
+	software?: Maybe< AppEnvironmentSoftwareDetails >;
+	softwareSettings?: Maybe< AppEnvironmentSoftwareSettings >;
+	syncPreview?: Maybe< AppEnvironmentSyncPreview >;
+	syncProgress?: Maybe< AppEnvironmentSyncProgress >;
+	type?: Maybe< Scalars[ 'String' ][ 'output' ] >;
+	uniqueLabel?: Maybe< Scalars[ 'String' ][ 'output' ] >;
+	updateSubsiteDomainStatus?: Maybe< AppEnvironmentUpdateSubsiteDomainStatus >;
+	/** Get WordPress Site Installation Details */
+	wpInstallation?: Maybe< WpInstallation >;
+	/** Get WordPress Site Details */
+	wpSites?: Maybe< WpSiteList >;
+	/** Get WordPress Site Details from SDS */
+	wpSitesSDS?: Maybe< WpSiteList >;
 };
-
 
 export type AppEnvironmentBackupsArgs = {
-  after?: InputMaybe<Scalars['String']['input']>;
-  endDate?: InputMaybe<Scalars['String']['input']>;
-  first?: InputMaybe<Scalars['Int']['input']>;
-  id?: InputMaybe<Scalars['Float']['input']>;
-  startDate?: InputMaybe<Scalars['String']['input']>;
+	after?: InputMaybe< Scalars[ 'String' ][ 'input' ] >;
+	endDate?: InputMaybe< Scalars[ 'String' ][ 'input' ] >;
+	first?: InputMaybe< Scalars[ 'Int' ][ 'input' ] >;
+	id?: InputMaybe< Scalars[ 'Float' ][ 'input' ] >;
+	startDate?: InputMaybe< Scalars[ 'String' ][ 'input' ] >;
 };
-
 
 export type AppEnvironmentCommandsArgs = {
-  after?: InputMaybe<Scalars['String']['input']>;
-  first?: InputMaybe<Scalars['Int']['input']>;
-  order?: InputMaybe<Scalars['String']['input']>;
-  sort?: InputMaybe<Scalars['String']['input']>;
-  status?: InputMaybe<Scalars['String']['input']>;
+	after?: InputMaybe< Scalars[ 'String' ][ 'input' ] >;
+	first?: InputMaybe< Scalars[ 'Int' ][ 'input' ] >;
+	order?: InputMaybe< Scalars[ 'String' ][ 'input' ] >;
+	sort?: InputMaybe< Scalars[ 'String' ][ 'input' ] >;
+	status?: InputMaybe< Scalars[ 'String' ][ 'input' ] >;
 };
-
 
 export type AppEnvironmentCommitsArgs = {
-  first?: InputMaybe<Scalars['Int']['input']>;
+	first?: InputMaybe< Scalars[ 'Int' ][ 'input' ] >;
 };
-
 
 export type AppEnvironmentDbBackupCopiesArgs = {
-  fileNames?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+	fileNames?: InputMaybe< Array< InputMaybe< Scalars[ 'String' ][ 'input' ] > > >;
 };
-
 
 export type AppEnvironmentDeploymentsArgs = {
-  first?: InputMaybe<Scalars['Int']['input']>;
-  id?: InputMaybe<Scalars['Int']['input']>;
-  nextCursor?: InputMaybe<Scalars['String']['input']>;
+	first?: InputMaybe< Scalars[ 'Int' ][ 'input' ] >;
+	id?: InputMaybe< Scalars[ 'Int' ][ 'input' ] >;
+	nextCursor?: InputMaybe< Scalars[ 'String' ][ 'input' ] >;
 };
-
 
 export type AppEnvironmentDeploysArgs = {
-  first?: InputMaybe<Scalars['Int']['input']>;
+	first?: InputMaybe< Scalars[ 'Int' ][ 'input' ] >;
 };
-
 
 export type AppEnvironmentDomainsArgs = {
-  after?: InputMaybe<Scalars['String']['input']>;
-  first?: InputMaybe<Scalars['Int']['input']>;
-  matching?: InputMaybe<Scalars['String']['input']>;
+	after?: InputMaybe< Scalars[ 'String' ][ 'input' ] >;
+	first?: InputMaybe< Scalars[ 'Int' ][ 'input' ] >;
+	matching?: InputMaybe< Scalars[ 'String' ][ 'input' ] >;
 };
-
 
 export type AppEnvironmentEventsArgs = {
-  after?: InputMaybe<Scalars['String']['input']>;
-  first?: InputMaybe<Scalars['Int']['input']>;
+	after?: InputMaybe< Scalars[ 'String' ][ 'input' ] >;
+	first?: InputMaybe< Scalars[ 'Int' ][ 'input' ] >;
 };
-
 
 export type AppEnvironmentHealthArgs = {
-  startDate?: InputMaybe<Scalars['String']['input']>;
+	startDate?: InputMaybe< Scalars[ 'String' ][ 'input' ] >;
 };
-
 
 export type AppEnvironmentIconArgs = {
-  size?: InputMaybe<Scalars['Int']['input']>;
+	size?: InputMaybe< Scalars[ 'Int' ][ 'input' ] >;
 };
-
 
 export type AppEnvironmentJobsArgs = {
-  jobTypes?: InputMaybe<Array<AppEnvironmentJobType>>;
-  types?: InputMaybe<Array<Scalars['String']['input']>>;
+	jobTypes?: InputMaybe< Array< AppEnvironmentJobType > >;
+	types?: InputMaybe< Array< Scalars[ 'String' ][ 'input' ] > >;
 };
-
 
 export type AppEnvironmentLogsArgs = {
-  after?: InputMaybe<Scalars['String']['input']>;
-  limit?: InputMaybe<Scalars['Int']['input']>;
-  type?: InputMaybe<AppEnvironmentLogType>;
+	after?: InputMaybe< Scalars[ 'String' ][ 'input' ] >;
+	limit?: InputMaybe< Scalars[ 'Int' ][ 'input' ] >;
+	type?: InputMaybe< AppEnvironmentLogType >;
 };
-
 
 export type AppEnvironmentMediaExportsArgs = {
-  nextCursor?: InputMaybe<Scalars['String']['input']>;
+	nextCursor?: InputMaybe< Scalars[ 'String' ][ 'input' ] >;
 };
-
 
 export type AppEnvironmentMetricsArgs = {
-  fromDate?: InputMaybe<Scalars['Date']['input']>;
-  metricName?: InputMaybe<Scalars['String']['input']>;
-  toDate?: InputMaybe<Scalars['Date']['input']>;
+	fromDate?: InputMaybe< Scalars[ 'Date' ][ 'input' ] >;
+	metricName?: InputMaybe< Scalars[ 'String' ][ 'input' ] >;
+	toDate?: InputMaybe< Scalars[ 'Date' ][ 'input' ] >;
 };
-
 
 export type AppEnvironmentPermissionsArgs = {
-  permissions?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+	permissions?: InputMaybe< Array< InputMaybe< Scalars[ 'String' ][ 'input' ] > > >;
 };
-
 
 export type AppEnvironmentPrimaryDomainSwitchProgressArgs = {
-  primaryDomainSwitchId?: InputMaybe<Scalars['Int']['input']>;
+	primaryDomainSwitchId?: InputMaybe< Scalars[ 'Int' ][ 'input' ] >;
 };
-
 
 export type AppEnvironmentPullRequestsArgs = {
-  first?: InputMaybe<Scalars['Int']['input']>;
+	first?: InputMaybe< Scalars[ 'Int' ][ 'input' ] >;
 };
-
 
 export type AppEnvironmentRequestStatsArgs = {
-  date?: InputMaybe<Scalars['String']['input']>;
-  days?: InputMaybe<Scalars['Int']['input']>;
-  from?: InputMaybe<Scalars['String']['input']>;
-  months?: InputMaybe<Scalars['Int']['input']>;
-  to?: InputMaybe<Scalars['String']['input']>;
+	date?: InputMaybe< Scalars[ 'String' ][ 'input' ] >;
+	days?: InputMaybe< Scalars[ 'Int' ][ 'input' ] >;
+	from?: InputMaybe< Scalars[ 'String' ][ 'input' ] >;
+	months?: InputMaybe< Scalars[ 'Int' ][ 'input' ] >;
+	to?: InputMaybe< Scalars[ 'String' ][ 'input' ] >;
 };
-
 
 export type AppEnvironmentSlowlogsArgs = {
-  after?: InputMaybe<Scalars['String']['input']>;
-  limit?: InputMaybe<Scalars['Int']['input']>;
+	after?: InputMaybe< Scalars[ 'String' ][ 'input' ] >;
+	limit?: InputMaybe< Scalars[ 'Int' ][ 'input' ] >;
 };
-
 
 export type AppEnvironmentSyncProgressArgs = {
-  sync?: InputMaybe<Scalars['Int']['input']>;
+	sync?: InputMaybe< Scalars[ 'Int' ][ 'input' ] >;
 };
-
 
 export type AppEnvironmentWpSitesArgs = {
-  after?: InputMaybe<Scalars['String']['input']>;
-  first?: InputMaybe<Scalars['Int']['input']>;
+	after?: InputMaybe< Scalars[ 'String' ][ 'input' ] >;
+	first?: InputMaybe< Scalars[ 'Int' ][ 'input' ] >;
 };
 
-
 export type AppEnvironmentWpSitesSdsArgs = {
-  after?: InputMaybe<Scalars['String']['input']>;
-  blogId?: InputMaybe<Scalars['Int']['input']>;
-  first?: InputMaybe<Scalars['Int']['input']>;
-  launchStatus?: InputMaybe<WpSiteLaunchStatus>;
-  matching?: InputMaybe<Scalars['String']['input']>;
-  order?: InputMaybe<Scalars['String']['input']>;
-  sort?: InputMaybe<Scalars['String']['input']>;
+	after?: InputMaybe< Scalars[ 'String' ][ 'input' ] >;
+	blogId?: InputMaybe< Scalars[ 'Int' ][ 'input' ] >;
+	first?: InputMaybe< Scalars[ 'Int' ][ 'input' ] >;
+	launchStatus?: InputMaybe< WpSiteLaunchStatus >;
+	matching?: InputMaybe< Scalars[ 'String' ][ 'input' ] >;
+	order?: InputMaybe< Scalars[ 'String' ][ 'input' ] >;
+	sort?: InputMaybe< Scalars[ 'String' ][ 'input' ] >;
 };
 
 /** Mutation request input to abort a Media Import */
 export type AppEnvironmentAbortMediaImportInput = {
-  /** The unique ID of the Application */
-  applicationId: Scalars['Int']['input'];
-  /** The uniqueID of the Environment */
-  environmentId: Scalars['Int']['input'];
+	/** The unique ID of the Application */
+	applicationId: Scalars[ 'Int' ][ 'input' ];
+	/** The uniqueID of the Environment */
+	environmentId: Scalars[ 'Int' ][ 'input' ];
 };
 
 /** Response payload for aborting a Media Import */
 export type AppEnvironmentAbortMediaImportPayload = {
-  __typename?: 'AppEnvironmentAbortMediaImportPayload';
-  /** The unique ID of the Application */
-  applicationId?: Maybe<Scalars['Int']['output']>;
-  /** The unique ID of the Environment */
-  environmentId?: Maybe<Scalars['Int']['output']>;
-  /** Media Import Abort Action Response */
-  mediaImportStatusChange?: Maybe<AppEnvironmentMediaImportStatusChange>;
+	__typename?: 'AppEnvironmentAbortMediaImportPayload';
+	/** The unique ID of the Application */
+	applicationId?: Maybe< Scalars[ 'Int' ][ 'output' ] >;
+	/** The unique ID of the Environment */
+	environmentId?: Maybe< Scalars[ 'Int' ][ 'output' ] >;
+	/** Media Import Abort Action Response */
+	mediaImportStatusChange?: Maybe< AppEnvironmentMediaImportStatusChange >;
 };
 
 /** Variables for the Activate Let's Encrypt Mutation */
 export type AppEnvironmentActivateLetsEncryptOnDomainInput = {
-  /** The unique ID for the domain */
-  domainId?: InputMaybe<Scalars['Int']['input']>;
-  /** The ID of the environment that this domain belongs to */
-  environmentId?: InputMaybe<Scalars['Int']['input']>;
-  /** The unique ID for the domain */
-  id?: InputMaybe<Scalars['Int']['input']>;
-  /** Provisions the www-alt domain */
-  includeWWW?: InputMaybe<Scalars['Boolean']['input']>;
-  /** Overrides the existing certificate (if any) on the domain */
-  overrideExisting?: InputMaybe<Scalars['Boolean']['input']>;
+	/** The unique ID for the domain */
+	domainId?: InputMaybe< Scalars[ 'Int' ][ 'input' ] >;
+	/** The ID of the environment that this domain belongs to */
+	environmentId?: InputMaybe< Scalars[ 'Int' ][ 'input' ] >;
+	/** The unique ID for the domain */
+	id?: InputMaybe< Scalars[ 'Int' ][ 'input' ] >;
+	/** Provisions the www-alt domain */
+	includeWWW?: InputMaybe< Scalars[ 'Boolean' ][ 'input' ] >;
+	/** Overrides the existing certificate (if any) on the domain */
+	overrideExisting?: InputMaybe< Scalars[ 'Boolean' ][ 'input' ] >;
 };
 
 /** Response from the Activate Let's Encrypt Mutation */
 export type AppEnvironmentActivateLetsEncryptOnDomainPayload = {
-  __typename?: 'AppEnvironmentActivateLetsEncryptOnDomainPayload';
-  /** The domain that Let's Encrypt was activated on */
-  domain?: Maybe<Domain>;
+	__typename?: 'AppEnvironmentActivateLetsEncryptOnDomainPayload';
+	/** The domain that Let's Encrypt was activated on */
+	domain?: Maybe< Domain >;
 };
 
 /** Variables for the Add Domain mutation */
 export type AppEnvironmentAddDomainInput = {
-  /** The domain name (i.e. something like example.com or sub.example.com) */
-  domain?: InputMaybe<NewDomain>;
-  /** The ID of the environment that this domain belongs to */
-  environmentId?: InputMaybe<Scalars['Int']['input']>;
-  /** The unique ID for the domain */
-  id?: InputMaybe<Scalars['Int']['input']>;
+	/** The domain name (i.e. something like example.com or sub.example.com) */
+	domain?: InputMaybe< NewDomain >;
+	/** The ID of the environment that this domain belongs to */
+	environmentId?: InputMaybe< Scalars[ 'Int' ][ 'input' ] >;
+	/** The unique ID for the domain */
+	id?: InputMaybe< Scalars[ 'Int' ][ 'input' ] >;
 };
 
 export type AppEnvironmentAddDomainPayload = {
-  __typename?: 'AppEnvironmentAddDomainPayload';
-  domain?: Maybe<Domain>;
+	__typename?: 'AppEnvironmentAddDomainPayload';
+	domain?: Maybe< Domain >;
 };
 
 /** Variables for the AddRequestStats mutation */
 export type AppEnvironmentAddRequestStatsInput = {
-  /** The application ID */
-  applicationId: Scalars['Int']['input'];
-  /** Date for which we want to sync - if we want to sync only for one day */
-  date?: InputMaybe<Scalars['String']['input']>;
-  /** The environment ID where we want to run the command */
-  environmentId: Scalars['Int']['input'];
-  /** Date range for which we want to sync - if we want to sync for a range */
-  fromDate?: InputMaybe<Scalars['String']['input']>;
-  toDate?: InputMaybe<Scalars['String']['input']>;
+	/** The application ID */
+	applicationId: Scalars[ 'Int' ][ 'input' ];
+	/** Date for which we want to sync - if we want to sync only for one day */
+	date?: InputMaybe< Scalars[ 'String' ][ 'input' ] >;
+	/** The environment ID where we want to run the command */
+	environmentId: Scalars[ 'Int' ][ 'input' ];
+	/** Date range for which we want to sync - if we want to sync for a range */
+	fromDate?: InputMaybe< Scalars[ 'String' ][ 'input' ] >;
+	toDate?: InputMaybe< Scalars[ 'String' ][ 'input' ] >;
 };
 
 /** Response payload for Request Stats */
 export type AppEnvironmentAddRequestStatsPayload = {
-  __typename?: 'AppEnvironmentAddRequestStatsPayload';
-  /** The unique ID of the Application */
-  applicationId: Scalars['Int']['output'];
-  /** The unique ID of the environment */
-  environmentId: Scalars['Int']['output'];
+	__typename?: 'AppEnvironmentAddRequestStatsPayload';
+	/** The unique ID of the Application */
+	applicationId: Scalars[ 'Int' ][ 'output' ];
+	/** The unique ID of the environment */
+	environmentId: Scalars[ 'Int' ][ 'output' ];
 };
 
 export type AppEnvironmentBackup = {
-  __typename?: 'AppEnvironmentBackup';
-  createdAt?: Maybe<Scalars['String']['output']>;
-  id?: Maybe<Scalars['Int']['output']>;
-  size?: Maybe<Scalars['Int']['output']>;
+	__typename?: 'AppEnvironmentBackup';
+	createdAt?: Maybe< Scalars[ 'String' ][ 'output' ] >;
+	id?: Maybe< Scalars[ 'Int' ][ 'output' ] >;
+	size?: Maybe< Scalars[ 'Int' ][ 'output' ] >;
 };
 
 export type AppEnvironmentBackupShipping = {
-  __typename?: 'AppEnvironmentBackupShipping';
-  awsAccountId?: Maybe<Scalars['String']['output']>;
-  bucket?: Maybe<Scalars['String']['output']>;
-  dailyHour?: Maybe<Scalars['Int']['output']>;
-  enabled?: Maybe<Scalars['Boolean']['output']>;
-  region?: Maybe<Scalars['String']['output']>;
-  schedule?: Maybe<Scalars['String']['output']>;
+	__typename?: 'AppEnvironmentBackupShipping';
+	awsAccountId?: Maybe< Scalars[ 'String' ][ 'output' ] >;
+	bucket?: Maybe< Scalars[ 'String' ][ 'output' ] >;
+	dailyHour?: Maybe< Scalars[ 'Int' ][ 'output' ] >;
+	enabled?: Maybe< Scalars[ 'Boolean' ][ 'output' ] >;
+	region?: Maybe< Scalars[ 'String' ][ 'output' ] >;
+	schedule?: Maybe< Scalars[ 'String' ][ 'output' ] >;
 };
 
 export type AppEnvironmentBackupShippingInput = {
-  awsAccountId?: InputMaybe<Scalars['String']['input']>;
-  bucket?: InputMaybe<Scalars['String']['input']>;
-  dailyHour?: InputMaybe<Scalars['Int']['input']>;
-  enabled?: InputMaybe<Scalars['Boolean']['input']>;
-  environmentId?: InputMaybe<Scalars['Int']['input']>;
-  id?: InputMaybe<Scalars['Int']['input']>;
-  region?: InputMaybe<Scalars['String']['input']>;
-  schedule?: InputMaybe<Scalars['String']['input']>;
+	awsAccountId?: InputMaybe< Scalars[ 'String' ][ 'input' ] >;
+	bucket?: InputMaybe< Scalars[ 'String' ][ 'input' ] >;
+	dailyHour?: InputMaybe< Scalars[ 'Int' ][ 'input' ] >;
+	enabled?: InputMaybe< Scalars[ 'Boolean' ][ 'input' ] >;
+	environmentId?: InputMaybe< Scalars[ 'Int' ][ 'input' ] >;
+	id?: InputMaybe< Scalars[ 'Int' ][ 'input' ] >;
+	region?: InputMaybe< Scalars[ 'String' ][ 'input' ] >;
+	schedule?: InputMaybe< Scalars[ 'String' ][ 'input' ] >;
 };
 
 export type AppEnvironmentBackupShippingPayload = {
-  __typename?: 'AppEnvironmentBackupShippingPayload';
-  app?: Maybe<App>;
-  awsAccountId?: Maybe<Scalars['String']['output']>;
-  bucket?: Maybe<Scalars['String']['output']>;
-  dailyHour?: Maybe<Scalars['Int']['output']>;
-  enabled?: Maybe<Scalars['Boolean']['output']>;
-  region?: Maybe<Scalars['String']['output']>;
-  schedule?: Maybe<Scalars['String']['output']>;
+	__typename?: 'AppEnvironmentBackupShippingPayload';
+	app?: Maybe< App >;
+	awsAccountId?: Maybe< Scalars[ 'String' ][ 'output' ] >;
+	bucket?: Maybe< Scalars[ 'String' ][ 'output' ] >;
+	dailyHour?: Maybe< Scalars[ 'Int' ][ 'output' ] >;
+	enabled?: Maybe< Scalars[ 'Boolean' ][ 'output' ] >;
+	region?: Maybe< Scalars[ 'String' ][ 'output' ] >;
+	schedule?: Maybe< Scalars[ 'String' ][ 'output' ] >;
 };
 
 export type AppEnvironmentBackupShippingValidationPayload = {
-  __typename?: 'AppEnvironmentBackupShippingValidationPayload';
-  app?: Maybe<App>;
-  message?: Maybe<Scalars['String']['output']>;
-  success?: Maybe<Scalars['Boolean']['output']>;
+	__typename?: 'AppEnvironmentBackupShippingValidationPayload';
+	app?: Maybe< App >;
+	message?: Maybe< Scalars[ 'String' ][ 'output' ] >;
+	success?: Maybe< Scalars[ 'Boolean' ][ 'output' ] >;
 };
 
 export type AppEnvironmentBasicAuth = {
-  __typename?: 'AppEnvironmentBasicAuth';
-  total?: Maybe<Scalars['Int']['output']>;
-  users?: Maybe<Array<Maybe<Scalars['String']['output']>>>;
+	__typename?: 'AppEnvironmentBasicAuth';
+	total?: Maybe< Scalars[ 'Int' ][ 'output' ] >;
+	users?: Maybe< Array< Maybe< Scalars[ 'String' ][ 'output' ] > > >;
 };
 
 export type AppEnvironmentBasicAuthDeleteInput = {
-  environmentId?: InputMaybe<Scalars['Int']['input']>;
-  id?: InputMaybe<Scalars['Int']['input']>;
-  username?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+	environmentId?: InputMaybe< Scalars[ 'Int' ][ 'input' ] >;
+	id?: InputMaybe< Scalars[ 'Int' ][ 'input' ] >;
+	username?: InputMaybe< Array< InputMaybe< Scalars[ 'String' ][ 'input' ] > > >;
 };
 
 export type AppEnvironmentBasicAuthInput = {
-  basicAuth?: InputMaybe<Array<InputMaybe<AppEnvironmentBasicAuthUserInput>>>;
-  environmentId?: InputMaybe<Scalars['Int']['input']>;
-  id?: InputMaybe<Scalars['Int']['input']>;
+	basicAuth?: InputMaybe< Array< InputMaybe< AppEnvironmentBasicAuthUserInput > > >;
+	environmentId?: InputMaybe< Scalars[ 'Int' ][ 'input' ] >;
+	id?: InputMaybe< Scalars[ 'Int' ][ 'input' ] >;
 };
 
 export type AppEnvironmentBasicAuthPayload = {
-  __typename?: 'AppEnvironmentBasicAuthPayload';
-  app?: Maybe<App>;
-  user?: Maybe<Scalars['String']['output']>;
+	__typename?: 'AppEnvironmentBasicAuthPayload';
+	app?: Maybe< App >;
+	user?: Maybe< Scalars[ 'String' ][ 'output' ] >;
 };
 
 export type AppEnvironmentBasicAuthUserInput = {
-  password?: InputMaybe<Scalars['String']['input']>;
-  username?: InputMaybe<Scalars['String']['input']>;
+	password?: InputMaybe< Scalars[ 'String' ][ 'input' ] >;
+	username?: InputMaybe< Scalars[ 'String' ][ 'input' ] >;
 };
 
 export type AppEnvironmentDeactivateDomainInput = {
-  domainId?: InputMaybe<Scalars['Int']['input']>;
-  environmentId?: InputMaybe<Scalars['Int']['input']>;
-  id?: InputMaybe<Scalars['Int']['input']>;
+	domainId?: InputMaybe< Scalars[ 'Int' ][ 'input' ] >;
+	environmentId?: InputMaybe< Scalars[ 'Int' ][ 'input' ] >;
+	id?: InputMaybe< Scalars[ 'Int' ][ 'input' ] >;
 };
 
 export type AppEnvironmentDeactivateDomainPayload = {
-  __typename?: 'AppEnvironmentDeactivateDomainPayload';
-  domain?: Maybe<Domain>;
+	__typename?: 'AppEnvironmentDeactivateDomainPayload';
+	domain?: Maybe< Domain >;
 };
 
 export type AppEnvironmentEnableLaunchModeInput = {
-  environmentId?: InputMaybe<Scalars['Int']['input']>;
-  id?: InputMaybe<Scalars['Int']['input']>;
-  launchModeEndAt?: InputMaybe<Scalars['String']['input']>;
+	environmentId?: InputMaybe< Scalars[ 'Int' ][ 'input' ] >;
+	id?: InputMaybe< Scalars[ 'Int' ][ 'input' ] >;
+	launchModeEndAt?: InputMaybe< Scalars[ 'String' ][ 'input' ] >;
 };
 
 export type AppEnvironmentEnableLaunchModePayload = {
-  __typename?: 'AppEnvironmentEnableLaunchModePayload';
-  app?: Maybe<App>;
-  environment?: Maybe<AppEnvironment>;
+	__typename?: 'AppEnvironmentEnableLaunchModePayload';
+	app?: Maybe< App >;
+	environment?: Maybe< AppEnvironment >;
 };
 
 export type AppEnvironmentGenerateDbBackupCopyUrlInput = {
-  backupId?: InputMaybe<Scalars['Float']['input']>;
-  environmentId?: InputMaybe<Scalars['Int']['input']>;
-  id?: InputMaybe<Scalars['Int']['input']>;
+	backupId?: InputMaybe< Scalars[ 'Float' ][ 'input' ] >;
+	environmentId?: InputMaybe< Scalars[ 'Int' ][ 'input' ] >;
+	id?: InputMaybe< Scalars[ 'Int' ][ 'input' ] >;
 };
 
 export type AppEnvironmentGenerateDbBackupCopyUrlPayload = {
-  __typename?: 'AppEnvironmentGenerateDBBackupCopyUrlPayload';
-  app?: Maybe<App>;
-  success?: Maybe<Scalars['Boolean']['output']>;
-  url?: Maybe<Scalars['String']['output']>;
+	__typename?: 'AppEnvironmentGenerateDBBackupCopyUrlPayload';
+	app?: Maybe< App >;
+	success?: Maybe< Scalars[ 'Boolean' ][ 'output' ] >;
+	url?: Maybe< Scalars[ 'String' ][ 'output' ] >;
 };
 
 export type AppEnvironmentGenerateMediaExportSignedUrlInput = {
-  appId?: InputMaybe<Scalars['Int']['input']>;
-  environmentId?: InputMaybe<Scalars['Int']['input']>;
-  mediaExportId?: InputMaybe<Scalars['Float']['input']>;
-  target?: InputMaybe<AppEnvironmentGenerateMediaExportSignedUrlTarget>;
+	appId?: InputMaybe< Scalars[ 'Int' ][ 'input' ] >;
+	environmentId?: InputMaybe< Scalars[ 'Int' ][ 'input' ] >;
+	mediaExportId?: InputMaybe< Scalars[ 'Float' ][ 'input' ] >;
+	target?: InputMaybe< AppEnvironmentGenerateMediaExportSignedUrlTarget >;
 };
 
 export type AppEnvironmentGenerateMediaExportSignedUrlPayload = {
-  __typename?: 'AppEnvironmentGenerateMediaExportSignedUrlPayload';
-  success?: Maybe<Scalars['Boolean']['output']>;
-  url?: Maybe<Scalars['String']['output']>;
+	__typename?: 'AppEnvironmentGenerateMediaExportSignedUrlPayload';
+	success?: Maybe< Scalars[ 'Boolean' ][ 'output' ] >;
+	url?: Maybe< Scalars[ 'String' ][ 'output' ] >;
 };
 
-export enum AppEnvironmentGenerateMediaExportSignedUrlTarget {
-  Media = 'media',
-  Report = 'report'
-}
+export type AppEnvironmentGenerateMediaExportSignedUrlTarget = 'media' | 'report';
 
 export type AppEnvironmentGenericSoftware = AppEnvironmentSoftware & {
-  __typename?: 'AppEnvironmentGenericSoftware';
-  version: Scalars['String']['output'];
+	__typename?: 'AppEnvironmentGenericSoftware';
+	version: Scalars[ 'String' ][ 'output' ];
 };
 
 /** Details about the environment's HSTS settings */
 export type AppEnvironmentHstsSettings = {
-  __typename?: 'AppEnvironmentHSTSSettings';
-  /** Whether HSTS is enabled for an App Environment */
-  enabled?: Maybe<Scalars['Boolean']['output']>;
-  /** Whether the header includes the includesSubdomains directive */
-  includeSubdomains?: Maybe<Scalars['Boolean']['output']>;
-  /** The value of the max-age directive */
-  maxAge?: Maybe<Scalars['Int']['output']>;
-  /** Whether the header includes the preload directive */
-  preload?: Maybe<Scalars['Boolean']['output']>;
-  /** Whether the App Environment enforces HTTPS everywhere */
-  sslEverywhere?: Maybe<Scalars['Boolean']['output']>;
+	__typename?: 'AppEnvironmentHSTSSettings';
+	/** Whether HSTS is enabled for an App Environment */
+	enabled?: Maybe< Scalars[ 'Boolean' ][ 'output' ] >;
+	/** Whether the header includes the includesSubdomains directive */
+	includeSubdomains?: Maybe< Scalars[ 'Boolean' ][ 'output' ] >;
+	/** The value of the max-age directive */
+	maxAge?: Maybe< Scalars[ 'Int' ][ 'output' ] >;
+	/** Whether the header includes the preload directive */
+	preload?: Maybe< Scalars[ 'Boolean' ][ 'output' ] >;
+	/** Whether the App Environment enforces HTTPS everywhere */
+	sslEverywhere?: Maybe< Scalars[ 'Boolean' ][ 'output' ] >;
 };
 
 /** Variables for the UpdateHSTSSettings mutation */
 export type AppEnvironmentHstsSettingsInput = {
-  /** The unique ID of the Environment */
-  environmentId: Scalars['Int']['input'];
-  /** The unique ID of the Application */
-  id: Scalars['Int']['input'];
-  /** Whether the header should include the includesSubdomains directive */
-  includeSubdomains?: InputMaybe<Scalars['Boolean']['input']>;
-  /** The value of the max-age directive */
-  maxAge?: InputMaybe<Scalars['Int']['input']>;
-  /** Whether the header should include the preload directive */
-  preload?: InputMaybe<Scalars['Boolean']['input']>;
+	/** The unique ID of the Environment */
+	environmentId: Scalars[ 'Int' ][ 'input' ];
+	/** The unique ID of the Application */
+	id: Scalars[ 'Int' ][ 'input' ];
+	/** Whether the header should include the includesSubdomains directive */
+	includeSubdomains?: InputMaybe< Scalars[ 'Boolean' ][ 'input' ] >;
+	/** The value of the max-age directive */
+	maxAge?: InputMaybe< Scalars[ 'Int' ][ 'input' ] >;
+	/** Whether the header should include the preload directive */
+	preload?: InputMaybe< Scalars[ 'Boolean' ][ 'input' ] >;
 };
 
 /** Response payload for HSTS Settings updates */
 export type AppEnvironmentHstsSettingsPayload = {
-  __typename?: 'AppEnvironmentHSTSSettingsPayload';
-  /** The Application that was updated */
-  app?: Maybe<App>;
-  /** The response message from GOOP */
-  message?: Maybe<Scalars['String']['output']>;
-  /** Whether the update was successful */
-  success?: Maybe<Scalars['Boolean']['output']>;
+	__typename?: 'AppEnvironmentHSTSSettingsPayload';
+	/** The Application that was updated */
+	app?: Maybe< App >;
+	/** The response message from GOOP */
+	message?: Maybe< Scalars[ 'String' ][ 'output' ] >;
+	/** Whether the update was successful */
+	success?: Maybe< Scalars[ 'Boolean' ][ 'output' ] >;
 };
 
 export type AppEnvironmentHealth = {
-  __typename?: 'AppEnvironmentHealth';
-  cacheHit?: Maybe<AppEnvironmentHealthCacheList>;
-  cacheMiss?: Maybe<AppEnvironmentHealthCacheList>;
-  responseCodes?: Maybe<AppEnvironmentHealthList>;
+	__typename?: 'AppEnvironmentHealth';
+	cacheHit?: Maybe< AppEnvironmentHealthCacheList >;
+	cacheMiss?: Maybe< AppEnvironmentHealthCacheList >;
+	responseCodes?: Maybe< AppEnvironmentHealthList >;
 };
 
 export type AppEnvironmentHealthCacheList = {
-  __typename?: 'AppEnvironmentHealthCacheList';
-  nodes?: Maybe<Array<Maybe<AppEnvironmentHealthCacheNodes>>>;
-  total?: Maybe<Scalars['BigInt']['output']>;
+	__typename?: 'AppEnvironmentHealthCacheList';
+	nodes?: Maybe< Array< Maybe< AppEnvironmentHealthCacheNodes > > >;
+	total?: Maybe< Scalars[ 'BigInt' ][ 'output' ] >;
 };
 
 export type AppEnvironmentHealthCacheNodes = {
-  __typename?: 'AppEnvironmentHealthCacheNodes';
-  from?: Maybe<Scalars['String']['output']>;
-  to?: Maybe<Scalars['String']['output']>;
-  total?: Maybe<Scalars['BigInt']['output']>;
+	__typename?: 'AppEnvironmentHealthCacheNodes';
+	from?: Maybe< Scalars[ 'String' ][ 'output' ] >;
+	to?: Maybe< Scalars[ 'String' ][ 'output' ] >;
+	total?: Maybe< Scalars[ 'BigInt' ][ 'output' ] >;
 };
 
 export type AppEnvironmentHealthList = {
-  __typename?: 'AppEnvironmentHealthList';
-  codes?: Maybe<Array<Maybe<Scalars['String']['output']>>>;
-  nodes?: Maybe<Array<Maybe<AppEnvironmentHealthNodes>>>;
-  total?: Maybe<Scalars['BigInt']['output']>;
+	__typename?: 'AppEnvironmentHealthList';
+	codes?: Maybe< Array< Maybe< Scalars[ 'String' ][ 'output' ] > > >;
+	nodes?: Maybe< Array< Maybe< AppEnvironmentHealthNodes > > >;
+	total?: Maybe< Scalars[ 'BigInt' ][ 'output' ] >;
 };
 
 export type AppEnvironmentHealthNodes = {
-  __typename?: 'AppEnvironmentHealthNodes';
-  _200?: Maybe<Scalars['BigInt']['output']>;
-  _201?: Maybe<Scalars['BigInt']['output']>;
-  _206?: Maybe<Scalars['BigInt']['output']>;
-  _301?: Maybe<Scalars['BigInt']['output']>;
-  _302?: Maybe<Scalars['BigInt']['output']>;
-  _304?: Maybe<Scalars['BigInt']['output']>;
-  _400?: Maybe<Scalars['BigInt']['output']>;
-  _401?: Maybe<Scalars['BigInt']['output']>;
-  _403?: Maybe<Scalars['BigInt']['output']>;
-  _404?: Maybe<Scalars['BigInt']['output']>;
-  _405?: Maybe<Scalars['BigInt']['output']>;
-  _408?: Maybe<Scalars['BigInt']['output']>;
-  _412?: Maybe<Scalars['BigInt']['output']>;
-  _416?: Maybe<Scalars['BigInt']['output']>;
-  _429?: Maybe<Scalars['BigInt']['output']>;
-  _499?: Maybe<Scalars['BigInt']['output']>;
-  _500?: Maybe<Scalars['BigInt']['output']>;
-  _502?: Maybe<Scalars['BigInt']['output']>;
-  _503?: Maybe<Scalars['BigInt']['output']>;
-  _504?: Maybe<Scalars['BigInt']['output']>;
-  from?: Maybe<Scalars['String']['output']>;
-  to?: Maybe<Scalars['String']['output']>;
-  total?: Maybe<Scalars['BigInt']['output']>;
+	__typename?: 'AppEnvironmentHealthNodes';
+	_200?: Maybe< Scalars[ 'BigInt' ][ 'output' ] >;
+	_201?: Maybe< Scalars[ 'BigInt' ][ 'output' ] >;
+	_206?: Maybe< Scalars[ 'BigInt' ][ 'output' ] >;
+	_301?: Maybe< Scalars[ 'BigInt' ][ 'output' ] >;
+	_302?: Maybe< Scalars[ 'BigInt' ][ 'output' ] >;
+	_304?: Maybe< Scalars[ 'BigInt' ][ 'output' ] >;
+	_400?: Maybe< Scalars[ 'BigInt' ][ 'output' ] >;
+	_401?: Maybe< Scalars[ 'BigInt' ][ 'output' ] >;
+	_403?: Maybe< Scalars[ 'BigInt' ][ 'output' ] >;
+	_404?: Maybe< Scalars[ 'BigInt' ][ 'output' ] >;
+	_405?: Maybe< Scalars[ 'BigInt' ][ 'output' ] >;
+	_408?: Maybe< Scalars[ 'BigInt' ][ 'output' ] >;
+	_412?: Maybe< Scalars[ 'BigInt' ][ 'output' ] >;
+	_416?: Maybe< Scalars[ 'BigInt' ][ 'output' ] >;
+	_429?: Maybe< Scalars[ 'BigInt' ][ 'output' ] >;
+	_499?: Maybe< Scalars[ 'BigInt' ][ 'output' ] >;
+	_500?: Maybe< Scalars[ 'BigInt' ][ 'output' ] >;
+	_502?: Maybe< Scalars[ 'BigInt' ][ 'output' ] >;
+	_503?: Maybe< Scalars[ 'BigInt' ][ 'output' ] >;
+	_504?: Maybe< Scalars[ 'BigInt' ][ 'output' ] >;
+	from?: Maybe< Scalars[ 'String' ][ 'output' ] >;
+	to?: Maybe< Scalars[ 'String' ][ 'output' ] >;
+	total?: Maybe< Scalars[ 'BigInt' ][ 'output' ] >;
 };
 
 export type AppEnvironmentIpAllowList = {
-  __typename?: 'AppEnvironmentIPAllowList';
-  ips?: Maybe<Array<Maybe<Scalars['String']['output']>>>;
-  total?: Maybe<Scalars['Int']['output']>;
+	__typename?: 'AppEnvironmentIPAllowList';
+	ips?: Maybe< Array< Maybe< Scalars[ 'String' ][ 'output' ] > > >;
+	total?: Maybe< Scalars[ 'Int' ][ 'output' ] >;
 };
 
 export type AppEnvironmentIpAllowListInput = {
-  environmentId?: InputMaybe<Scalars['Int']['input']>;
-  id?: InputMaybe<Scalars['Int']['input']>;
-  ips?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+	environmentId?: InputMaybe< Scalars[ 'Int' ][ 'input' ] >;
+	id?: InputMaybe< Scalars[ 'Int' ][ 'input' ] >;
+	ips?: InputMaybe< Array< InputMaybe< Scalars[ 'String' ][ 'input' ] > > >;
 };
 
 export type AppEnvironmentIpAllowListPayload = {
-  __typename?: 'AppEnvironmentIPAllowListPayload';
-  app?: Maybe<App>;
-  ips?: Maybe<Array<Maybe<Scalars['String']['output']>>>;
+	__typename?: 'AppEnvironmentIPAllowListPayload';
+	app?: Maybe< App >;
+	ips?: Maybe< Array< Maybe< Scalars[ 'String' ][ 'output' ] > > >;
 };
 
 export type AppEnvironmentIPs = {
-  __typename?: 'AppEnvironmentIPs';
-  ipv4?: Maybe<Array<Maybe<Scalars['String']['output']>>>;
-  ipv6?: Maybe<Array<Maybe<Scalars['String']['output']>>>;
+	__typename?: 'AppEnvironmentIPs';
+	ipv4?: Maybe< Array< Maybe< Scalars[ 'String' ][ 'output' ] > > >;
+	ipv6?: Maybe< Array< Maybe< Scalars[ 'String' ][ 'output' ] > > >;
 };
 
 export type AppEnvironmentIcon = {
-  __typename?: 'AppEnvironmentIcon';
-  height?: Maybe<Scalars['Int']['output']>;
-  type?: Maybe<Scalars['String']['output']>;
-  url?: Maybe<Scalars['String']['output']>;
-  width?: Maybe<Scalars['Int']['output']>;
+	__typename?: 'AppEnvironmentIcon';
+	height?: Maybe< Scalars[ 'Int' ][ 'output' ] >;
+	type?: Maybe< Scalars[ 'String' ][ 'output' ] >;
+	url?: Maybe< Scalars[ 'String' ][ 'output' ] >;
+	width?: Maybe< Scalars[ 'Int' ][ 'output' ] >;
 };
 
 export type AppEnvironmentImportInput = {
-  basename?: InputMaybe<Scalars['String']['input']>;
-  environmentId?: InputMaybe<Scalars['Int']['input']>;
-  id?: InputMaybe<Scalars['Int']['input']>;
-  md5?: InputMaybe<Scalars['String']['input']>;
-  searchReplace?: InputMaybe<Array<InputMaybe<AppEnvironmentImportSearchReplace>>>;
+	basename?: InputMaybe< Scalars[ 'String' ][ 'input' ] >;
+	environmentId?: InputMaybe< Scalars[ 'Int' ][ 'input' ] >;
+	id?: InputMaybe< Scalars[ 'Int' ][ 'input' ] >;
+	md5?: InputMaybe< Scalars[ 'String' ][ 'input' ] >;
+	searchReplace?: InputMaybe< Array< InputMaybe< AppEnvironmentImportSearchReplace > > >;
 };
 
 export type AppEnvironmentImportPayload = {
-  __typename?: 'AppEnvironmentImportPayload';
-  app?: Maybe<App>;
-  message?: Maybe<Scalars['String']['output']>;
-  success?: Maybe<Scalars['Boolean']['output']>;
+	__typename?: 'AppEnvironmentImportPayload';
+	app?: Maybe< App >;
+	message?: Maybe< Scalars[ 'String' ][ 'output' ] >;
+	success?: Maybe< Scalars[ 'Boolean' ][ 'output' ] >;
 };
 
 export type AppEnvironmentImportSearchReplace = {
-  from?: InputMaybe<Scalars['String']['input']>;
-  to?: InputMaybe<Scalars['String']['input']>;
+	from?: InputMaybe< Scalars[ 'String' ][ 'input' ] >;
+	to?: InputMaybe< Scalars[ 'String' ][ 'input' ] >;
 };
 
 export type AppEnvironmentImportStatus = {
-  __typename?: 'AppEnvironmentImportStatus';
-  dbOperationInProgress?: Maybe<Scalars['Boolean']['output']>;
-  importInProgress?: Maybe<Scalars['Boolean']['output']>;
-  progress?: Maybe<AppEnvironmentStatusProgress>;
+	__typename?: 'AppEnvironmentImportStatus';
+	dbOperationInProgress?: Maybe< Scalars[ 'Boolean' ][ 'output' ] >;
+	importInProgress?: Maybe< Scalars[ 'Boolean' ][ 'output' ] >;
+	progress?: Maybe< AppEnvironmentStatusProgress >;
 };
 
-export enum AppEnvironmentJobType {
-  DbBackup = 'db_backup',
-  DbBackupCopy = 'db_backup_copy',
-  SetPrimaryDomain = 'set_primary_domain',
-  SqlImport = 'sql_import',
-  UpdateSubsiteDomain = 'update_subsite_domain',
-  UpgradeMuplugins = 'upgrade_muplugins',
-  UpgradeNodejs = 'upgrade_nodejs',
-  UpgradePhp = 'upgrade_php',
-  UpgradeWordpress = 'upgrade_wordpress'
-}
+export type AppEnvironmentJobType =
+	| 'db_backup'
+	| 'db_backup_copy'
+	| 'set_primary_domain'
+	| 'sql_import'
+	| 'update_subsite_domain'
+	| 'upgrade_muplugins'
+	| 'upgrade_nodejs'
+	| 'upgrade_php'
+	| 'upgrade_wordpress';
 
 export type AppEnvironmentLaunchedInput = {
-  environmentId?: InputMaybe<Scalars['Int']['input']>;
-  id?: InputMaybe<Scalars['Int']['input']>;
+	environmentId?: InputMaybe< Scalars[ 'Int' ][ 'input' ] >;
+	id?: InputMaybe< Scalars[ 'Int' ][ 'input' ] >;
 };
 
 export type AppEnvironmentLaunchedPayload = {
-  __typename?: 'AppEnvironmentLaunchedPayload';
-  app?: Maybe<App>;
-  environment?: Maybe<AppEnvironment>;
+	__typename?: 'AppEnvironmentLaunchedPayload';
+	app?: Maybe< App >;
+	environment?: Maybe< AppEnvironment >;
 };
 
 export type AppEnvironmentLog = {
-  __typename?: 'AppEnvironmentLog';
-  message?: Maybe<Scalars['String']['output']>;
-  timestamp?: Maybe<Scalars['String']['output']>;
+	__typename?: 'AppEnvironmentLog';
+	message?: Maybe< Scalars[ 'String' ][ 'output' ] >;
+	timestamp?: Maybe< Scalars[ 'String' ][ 'output' ] >;
 };
 
 export type AppEnvironmentLogShipping = {
-  __typename?: 'AppEnvironmentLogShipping';
-  awsAccountId?: Maybe<Scalars['String']['output']>;
-  bucket?: Maybe<Scalars['String']['output']>;
-  enabled?: Maybe<Scalars['Boolean']['output']>;
-  region?: Maybe<Scalars['String']['output']>;
+	__typename?: 'AppEnvironmentLogShipping';
+	awsAccountId?: Maybe< Scalars[ 'String' ][ 'output' ] >;
+	bucket?: Maybe< Scalars[ 'String' ][ 'output' ] >;
+	enabled?: Maybe< Scalars[ 'Boolean' ][ 'output' ] >;
+	region?: Maybe< Scalars[ 'String' ][ 'output' ] >;
 };
 
 export type AppEnvironmentLogShippingInput = {
-  awsAccountId?: InputMaybe<Scalars['String']['input']>;
-  bucket?: InputMaybe<Scalars['String']['input']>;
-  enabled?: InputMaybe<Scalars['Boolean']['input']>;
-  environmentId?: InputMaybe<Scalars['Int']['input']>;
-  id?: InputMaybe<Scalars['Int']['input']>;
-  region?: InputMaybe<Scalars['String']['input']>;
+	awsAccountId?: InputMaybe< Scalars[ 'String' ][ 'input' ] >;
+	bucket?: InputMaybe< Scalars[ 'String' ][ 'input' ] >;
+	enabled?: InputMaybe< Scalars[ 'Boolean' ][ 'input' ] >;
+	environmentId?: InputMaybe< Scalars[ 'Int' ][ 'input' ] >;
+	id?: InputMaybe< Scalars[ 'Int' ][ 'input' ] >;
+	region?: InputMaybe< Scalars[ 'String' ][ 'input' ] >;
 };
 
 export type AppEnvironmentLogShippingPayload = {
-  __typename?: 'AppEnvironmentLogShippingPayload';
-  app?: Maybe<App>;
-  awsAccountId?: Maybe<Scalars['String']['output']>;
-  bucket?: Maybe<Scalars['String']['output']>;
-  enabled?: Maybe<Scalars['Boolean']['output']>;
-  region?: Maybe<Scalars['String']['output']>;
+	__typename?: 'AppEnvironmentLogShippingPayload';
+	app?: Maybe< App >;
+	awsAccountId?: Maybe< Scalars[ 'String' ][ 'output' ] >;
+	bucket?: Maybe< Scalars[ 'String' ][ 'output' ] >;
+	enabled?: Maybe< Scalars[ 'Boolean' ][ 'output' ] >;
+	region?: Maybe< Scalars[ 'String' ][ 'output' ] >;
 };
 
 export type AppEnvironmentLogShippingValidationPayload = {
-  __typename?: 'AppEnvironmentLogShippingValidationPayload';
-  app?: Maybe<App>;
-  message?: Maybe<Scalars['String']['output']>;
-  success?: Maybe<Scalars['Boolean']['output']>;
+	__typename?: 'AppEnvironmentLogShippingValidationPayload';
+	app?: Maybe< App >;
+	message?: Maybe< Scalars[ 'String' ][ 'output' ] >;
+	success?: Maybe< Scalars[ 'Boolean' ][ 'output' ] >;
 };
 
-export enum AppEnvironmentLogType {
-  App = 'app',
-  Batch = 'batch'
-}
+export type AppEnvironmentLogType = 'app' | 'batch';
 
 export type AppEnvironmentLogsList = {
-  __typename?: 'AppEnvironmentLogsList';
-  nextCursor?: Maybe<Scalars['String']['output']>;
-  nodes?: Maybe<Array<Maybe<AppEnvironmentLog>>>;
-  pollingDelaySeconds: Scalars['Int']['output'];
-  total?: Maybe<Scalars['BigInt']['output']>;
+	__typename?: 'AppEnvironmentLogsList';
+	nextCursor?: Maybe< Scalars[ 'String' ][ 'output' ] >;
+	nodes?: Maybe< Array< Maybe< AppEnvironmentLog > > >;
+	pollingDelaySeconds: Scalars[ 'Int' ][ 'output' ];
+	total?: Maybe< Scalars[ 'BigInt' ][ 'output' ] >;
 };
 
 /** Response payload for starting and fetching a Media Import */
 export type AppEnvironmentMediaImportPayload = {
-  __typename?: 'AppEnvironmentMediaImportPayload';
-  /** The unique ID of the Application */
-  applicationId?: Maybe<Scalars['Int']['output']>;
-  /** The unique ID of the Environment */
-  environmentId?: Maybe<Scalars['Int']['output']>;
-  /** Media Import Status */
-  mediaImportStatus: AppEnvironmentMediaImportStatus;
+	__typename?: 'AppEnvironmentMediaImportPayload';
+	/** The unique ID of the Application */
+	applicationId?: Maybe< Scalars[ 'Int' ][ 'output' ] >;
+	/** The unique ID of the Environment */
+	environmentId?: Maybe< Scalars[ 'Int' ][ 'output' ] >;
+	/** Media Import Status */
+	mediaImportStatus: AppEnvironmentMediaImportStatus;
 };
 
 /** Current status of a Media Import */
 export type AppEnvironmentMediaImportStatus = {
-  __typename?: 'AppEnvironmentMediaImportStatus';
-  /** Media Import failure details */
-  failureDetails?: Maybe<AppEnvironmentMediaImportStatusFailureDetails>;
-  /** Total number of media files that were imported */
-  filesProcessed?: Maybe<Scalars['Int']['output']>;
-  /** Total number of media files that are to be import */
-  filesTotal?: Maybe<Scalars['Int']['output']>;
-  /** Unique Identifier for a Media Import */
-  importId?: Maybe<Scalars['Int']['output']>;
-  /** Alias of environmentId */
-  siteId?: Maybe<Scalars['Int']['output']>;
-  /** The actual status of the Media Import */
-  status?: Maybe<Scalars['String']['output']>;
+	__typename?: 'AppEnvironmentMediaImportStatus';
+	/** Media Import failure details */
+	failureDetails?: Maybe< AppEnvironmentMediaImportStatusFailureDetails >;
+	/** Total number of media files that were imported */
+	filesProcessed?: Maybe< Scalars[ 'Int' ][ 'output' ] >;
+	/** Total number of media files that are to be import */
+	filesTotal?: Maybe< Scalars[ 'Int' ][ 'output' ] >;
+	/** Unique Identifier for a Media Import */
+	importId?: Maybe< Scalars[ 'Int' ][ 'output' ] >;
+	/** Alias of environmentId */
+	siteId?: Maybe< Scalars[ 'Int' ][ 'output' ] >;
+	/** The actual status of the Media Import */
+	status?: Maybe< Scalars[ 'String' ][ 'output' ] >;
 };
 
 /** Response payload for executing a status change action on a Media Import */
 export type AppEnvironmentMediaImportStatusChange = {
-  __typename?: 'AppEnvironmentMediaImportStatusChange';
-  /** Unique Identifier for a Media Import */
-  importId?: Maybe<Scalars['Int']['output']>;
-  /** Alias of environmentId */
-  siteId?: Maybe<Scalars['Int']['output']>;
-  /** The status of Media Import prior to status change action */
-  statusFrom?: Maybe<Scalars['String']['output']>;
-  /** The status of Media Import after the status change action */
-  statusTo?: Maybe<Scalars['String']['output']>;
+	__typename?: 'AppEnvironmentMediaImportStatusChange';
+	/** Unique Identifier for a Media Import */
+	importId?: Maybe< Scalars[ 'Int' ][ 'output' ] >;
+	/** Alias of environmentId */
+	siteId?: Maybe< Scalars[ 'Int' ][ 'output' ] >;
+	/** The status of Media Import prior to status change action */
+	statusFrom?: Maybe< Scalars[ 'String' ][ 'output' ] >;
+	/** The status of Media Import after the status change action */
+	statusTo?: Maybe< Scalars[ 'String' ][ 'output' ] >;
 };
 
 /** Media Import Failure details */
 export type AppEnvironmentMediaImportStatusFailureDetails = {
-  __typename?: 'AppEnvironmentMediaImportStatusFailureDetails';
-  /** List of errors per file */
-  fileErrors?: Maybe<Array<Maybe<AppEnvironmentMediaImportStatusFailureDetailsFileErrors>>>;
-  /** List of global errors per import */
-  globalErrors?: Maybe<Array<Maybe<Scalars['String']['output']>>>;
-  /** Status of the Media Import prior to failing */
-  previousStatus?: Maybe<Scalars['String']['output']>;
+	__typename?: 'AppEnvironmentMediaImportStatusFailureDetails';
+	/** List of errors per file */
+	fileErrors?: Maybe< Array< Maybe< AppEnvironmentMediaImportStatusFailureDetailsFileErrors > > >;
+	/** List of global errors per import */
+	globalErrors?: Maybe< Array< Maybe< Scalars[ 'String' ][ 'output' ] > > >;
+	/** Status of the Media Import prior to failing */
+	previousStatus?: Maybe< Scalars[ 'String' ][ 'output' ] >;
 };
 
 /** Media Import File Errors */
 export type AppEnvironmentMediaImportStatusFailureDetailsFileErrors = {
-  __typename?: 'AppEnvironmentMediaImportStatusFailureDetailsFileErrors';
-  /** List of Errors per file */
-  errors?: Maybe<Array<Maybe<Scalars['String']['output']>>>;
-  /** File Name */
-  fileName?: Maybe<Scalars['String']['output']>;
+	__typename?: 'AppEnvironmentMediaImportStatusFailureDetailsFileErrors';
+	/** List of Errors per file */
+	errors?: Maybe< Array< Maybe< Scalars[ 'String' ][ 'output' ] > > >;
+	/** File Name */
+	fileName?: Maybe< Scalars[ 'String' ][ 'output' ] >;
 };
 
 export type AppEnvironmentPrimaryDomainSwitchInput = {
-  domainId?: InputMaybe<Scalars['Int']['input']>;
-  environmentId?: InputMaybe<Scalars['Int']['input']>;
-  id?: InputMaybe<Scalars['Int']['input']>;
+	domainId?: InputMaybe< Scalars[ 'Int' ][ 'input' ] >;
+	environmentId?: InputMaybe< Scalars[ 'Int' ][ 'input' ] >;
+	id?: InputMaybe< Scalars[ 'Int' ][ 'input' ] >;
 };
 
 export type AppEnvironmentPrimaryDomainSwitchPayload = {
-  __typename?: 'AppEnvironmentPrimaryDomainSwitchPayload';
-  app?: Maybe<App>;
-  domain?: Maybe<Domain>;
-  environment?: Maybe<AppEnvironment>;
-  primaryDomainSwitchId?: Maybe<Scalars['Int']['output']>;
+	__typename?: 'AppEnvironmentPrimaryDomainSwitchPayload';
+	app?: Maybe< App >;
+	domain?: Maybe< Domain >;
+	environment?: Maybe< AppEnvironment >;
+	primaryDomainSwitchId?: Maybe< Scalars[ 'Int' ][ 'output' ] >;
 };
 
 export type AppEnvironmentPrimaryDomainSwitchProgress = {
-  __typename?: 'AppEnvironmentPrimaryDomainSwitchProgress';
-  destinationDomain?: Maybe<Scalars['String']['output']>;
-  primaryDomainSwitchId?: Maybe<Scalars['Int']['output']>;
-  sourceDomain?: Maybe<Scalars['String']['output']>;
-  status?: Maybe<Scalars['String']['output']>;
-  steps?: Maybe<Array<Maybe<AppEnvironmentPrimaryDomainSwitchProgressStep>>>;
+	__typename?: 'AppEnvironmentPrimaryDomainSwitchProgress';
+	destinationDomain?: Maybe< Scalars[ 'String' ][ 'output' ] >;
+	primaryDomainSwitchId?: Maybe< Scalars[ 'Int' ][ 'output' ] >;
+	sourceDomain?: Maybe< Scalars[ 'String' ][ 'output' ] >;
+	status?: Maybe< Scalars[ 'String' ][ 'output' ] >;
+	steps?: Maybe< Array< Maybe< AppEnvironmentPrimaryDomainSwitchProgressStep > > >;
 };
 
 export type AppEnvironmentPrimaryDomainSwitchProgressStep = {
-  __typename?: 'AppEnvironmentPrimaryDomainSwitchProgressStep';
-  name?: Maybe<Scalars['String']['output']>;
-  status?: Maybe<Scalars['String']['output']>;
-  step?: Maybe<Scalars['String']['output']>;
+	__typename?: 'AppEnvironmentPrimaryDomainSwitchProgressStep';
+	name?: Maybe< Scalars[ 'String' ][ 'output' ] >;
+	status?: Maybe< Scalars[ 'String' ][ 'output' ] >;
+	step?: Maybe< Scalars[ 'String' ][ 'output' ] >;
 };
 
 export type AppEnvironmentSlowlog = {
-  __typename?: 'AppEnvironmentSlowlog';
-  query?: Maybe<Scalars['String']['output']>;
-  queryTime?: Maybe<Scalars['String']['output']>;
-  requestUri?: Maybe<Scalars['String']['output']>;
-  rowsExamined?: Maybe<Scalars['String']['output']>;
-  rowsSent?: Maybe<Scalars['String']['output']>;
-  timestamp?: Maybe<Scalars['String']['output']>;
+	__typename?: 'AppEnvironmentSlowlog';
+	query?: Maybe< Scalars[ 'String' ][ 'output' ] >;
+	queryTime?: Maybe< Scalars[ 'String' ][ 'output' ] >;
+	requestUri?: Maybe< Scalars[ 'String' ][ 'output' ] >;
+	rowsExamined?: Maybe< Scalars[ 'String' ][ 'output' ] >;
+	rowsSent?: Maybe< Scalars[ 'String' ][ 'output' ] >;
+	timestamp?: Maybe< Scalars[ 'String' ][ 'output' ] >;
 };
 
 export type AppEnvironmentSlowlogsList = {
-  __typename?: 'AppEnvironmentSlowlogsList';
-  nextCursor?: Maybe<Scalars['String']['output']>;
-  nodes?: Maybe<Array<Maybe<AppEnvironmentSlowlog>>>;
-  pollingDelaySeconds: Scalars['Int']['output'];
-  total?: Maybe<Scalars['BigInt']['output']>;
+	__typename?: 'AppEnvironmentSlowlogsList';
+	nextCursor?: Maybe< Scalars[ 'String' ][ 'output' ] >;
+	nodes?: Maybe< Array< Maybe< AppEnvironmentSlowlog > > >;
+	pollingDelaySeconds: Scalars[ 'Int' ][ 'output' ];
+	total?: Maybe< Scalars[ 'BigInt' ][ 'output' ] >;
 };
 
 export type AppEnvironmentSoftware = {
-  version: Scalars['String']['output'];
+	version: Scalars[ 'String' ][ 'output' ];
 };
 
 export type AppEnvironmentSoftwareDetails = {
-  __typename?: 'AppEnvironmentSoftwareDetails';
-  nodejs?: Maybe<AppEnvironmentGenericSoftware>;
-  php?: Maybe<AppEnvironmentGenericSoftware>;
-  wordpress?: Maybe<AppEnvironmentGenericSoftware>;
+	__typename?: 'AppEnvironmentSoftwareDetails';
+	nodejs?: Maybe< AppEnvironmentGenericSoftware >;
+	php?: Maybe< AppEnvironmentGenericSoftware >;
+	wordpress?: Maybe< AppEnvironmentGenericSoftware >;
 };
 
 export type AppEnvironmentSoftwareSettings = {
-  __typename?: 'AppEnvironmentSoftwareSettings';
-  muplugins?: Maybe<AppEnvironmentSoftwareSettingsSoftware>;
-  nodejs?: Maybe<AppEnvironmentSoftwareSettingsSoftware>;
-  php?: Maybe<AppEnvironmentSoftwareSettingsSoftware>;
-  wordpress?: Maybe<AppEnvironmentSoftwareSettingsSoftware>;
+	__typename?: 'AppEnvironmentSoftwareSettings';
+	muplugins?: Maybe< AppEnvironmentSoftwareSettingsSoftware >;
+	nodejs?: Maybe< AppEnvironmentSoftwareSettingsSoftware >;
+	php?: Maybe< AppEnvironmentSoftwareSettingsSoftware >;
+	wordpress?: Maybe< AppEnvironmentSoftwareSettingsSoftware >;
 };
 
 /** Variables for the UpdateSoftwareSettings mutation */
 export type AppEnvironmentSoftwareSettingsInput = {
-  /** The unique ID of the Application */
-  appId: Scalars['Int']['input'];
-  /** The unique ID of the Environment */
-  environmentId: Scalars['Int']['input'];
-  /** The name of the software being updated */
-  softwareName: Scalars['String']['input'];
-  /** The version the software is being updated to */
-  softwareVersion: Scalars['String']['input'];
+	/** The unique ID of the Application */
+	appId: Scalars[ 'Int' ][ 'input' ];
+	/** The unique ID of the Environment */
+	environmentId: Scalars[ 'Int' ][ 'input' ];
+	/** The name of the software being updated */
+	softwareName: Scalars[ 'String' ][ 'input' ];
+	/** The version the software is being updated to */
+	softwareVersion: Scalars[ 'String' ][ 'input' ];
 };
 
 export type AppEnvironmentSoftwareSettingsSoftware = {
-  __typename?: 'AppEnvironmentSoftwareSettingsSoftware';
-  current: AppEnvironmentSoftwareSettingsVersion;
-  name: Scalars['String']['output'];
-  options: Array<AppEnvironmentSoftwareSettingsVersion>;
-  pinned: Scalars['Boolean']['output'];
-  slug: Scalars['String']['output'];
+	__typename?: 'AppEnvironmentSoftwareSettingsSoftware';
+	current: AppEnvironmentSoftwareSettingsVersion;
+	name: Scalars[ 'String' ][ 'output' ];
+	options: Array< AppEnvironmentSoftwareSettingsVersion >;
+	pinned: Scalars[ 'Boolean' ][ 'output' ];
+	slug: Scalars[ 'String' ][ 'output' ];
 };
 
 export type AppEnvironmentSoftwareSettingsVersion = {
-  __typename?: 'AppEnvironmentSoftwareSettingsVersion';
-  compatible: Scalars['Boolean']['output'];
-  default: Scalars['Boolean']['output'];
-  deprecated: Scalars['Boolean']['output'];
-  latestRelease: Scalars['String']['output'];
-  private: Scalars['Boolean']['output'];
-  unstable: Scalars['Boolean']['output'];
-  version: Scalars['String']['output'];
+	__typename?: 'AppEnvironmentSoftwareSettingsVersion';
+	compatible: Scalars[ 'Boolean' ][ 'output' ];
+	default: Scalars[ 'Boolean' ][ 'output' ];
+	deprecated: Scalars[ 'Boolean' ][ 'output' ];
+	latestRelease: Scalars[ 'String' ][ 'output' ];
+	private: Scalars[ 'Boolean' ][ 'output' ];
+	unstable: Scalars[ 'Boolean' ][ 'output' ];
+	version: Scalars[ 'String' ][ 'output' ];
 };
 
 export type AppEnvironmentStartDbBackupCopyInput = {
-  backupId?: InputMaybe<Scalars['Float']['input']>;
-  environmentId?: InputMaybe<Scalars['Int']['input']>;
-  id?: InputMaybe<Scalars['Int']['input']>;
-  subsiteId?: InputMaybe<Scalars['Int']['input']>;
-  tables?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+	backupId?: InputMaybe< Scalars[ 'Float' ][ 'input' ] >;
+	environmentId?: InputMaybe< Scalars[ 'Int' ][ 'input' ] >;
+	id?: InputMaybe< Scalars[ 'Int' ][ 'input' ] >;
+	subsiteId?: InputMaybe< Scalars[ 'Int' ][ 'input' ] >;
+	tables?: InputMaybe< Array< InputMaybe< Scalars[ 'String' ][ 'input' ] > > >;
 };
 
 export type AppEnvironmentStartDbBackupCopyPayload = {
-  __typename?: 'AppEnvironmentStartDBBackupCopyPayload';
-  app?: Maybe<App>;
-  message?: Maybe<Scalars['String']['output']>;
-  success?: Maybe<Scalars['Boolean']['output']>;
+	__typename?: 'AppEnvironmentStartDBBackupCopyPayload';
+	app?: Maybe< App >;
+	message?: Maybe< Scalars[ 'String' ][ 'output' ] >;
+	success?: Maybe< Scalars[ 'Boolean' ][ 'output' ] >;
 };
 
 /** Mutation request input to start a Media Import */
 export type AppEnvironmentStartMediaImportInput = {
-  /** The unique ID of the Application */
-  applicationId: Scalars['Int']['input'];
-  /** Publicly accessible URL that contains an archive of the media files to be imported */
-  archiveUrl: Scalars['String']['input'];
-  /** The uniqueID of the Environment */
-  environmentId: Scalars['Int']['input'];
-  /** Whether to import intermediate images or not */
-  importIntermediateImages?: InputMaybe<Scalars['Boolean']['input']>;
-  /** Whether to overwrite existing files or not */
-  overwriteExistingFiles?: InputMaybe<Scalars['Boolean']['input']>;
+	/** The unique ID of the Application */
+	applicationId: Scalars[ 'Int' ][ 'input' ];
+	/** Publicly accessible URL that contains an archive of the media files to be imported */
+	archiveUrl: Scalars[ 'String' ][ 'input' ];
+	/** The uniqueID of the Environment */
+	environmentId: Scalars[ 'Int' ][ 'input' ];
+	/** Whether to import intermediate images or not */
+	importIntermediateImages?: InputMaybe< Scalars[ 'Boolean' ][ 'input' ] >;
+	/** Whether to overwrite existing files or not */
+	overwriteExistingFiles?: InputMaybe< Scalars[ 'Boolean' ][ 'input' ] >;
 };
 
 export type AppEnvironmentStatusProgress = {
-  __typename?: 'AppEnvironmentStatusProgress';
-  finished_at?: Maybe<Scalars['Int']['output']>;
-  started_at?: Maybe<Scalars['Int']['output']>;
-  steps?: Maybe<Array<Maybe<AppEnvironmentStatusProgressStep>>>;
+	__typename?: 'AppEnvironmentStatusProgress';
+	finished_at?: Maybe< Scalars[ 'Int' ][ 'output' ] >;
+	started_at?: Maybe< Scalars[ 'Int' ][ 'output' ] >;
+	steps?: Maybe< Array< Maybe< AppEnvironmentStatusProgressStep > > >;
 };
 
 export type AppEnvironmentStatusProgressStep = {
-  __typename?: 'AppEnvironmentStatusProgressStep';
-  finished_at?: Maybe<Scalars['Int']['output']>;
-  name?: Maybe<Scalars['String']['output']>;
-  output?: Maybe<Array<Maybe<Scalars['String']['output']>>>;
-  result?: Maybe<Scalars['String']['output']>;
-  started_at?: Maybe<Scalars['Int']['output']>;
+	__typename?: 'AppEnvironmentStatusProgressStep';
+	finished_at?: Maybe< Scalars[ 'Int' ][ 'output' ] >;
+	name?: Maybe< Scalars[ 'String' ][ 'output' ] >;
+	output?: Maybe< Array< Maybe< Scalars[ 'String' ][ 'output' ] > > >;
+	result?: Maybe< Scalars[ 'String' ][ 'output' ] >;
+	started_at?: Maybe< Scalars[ 'Int' ][ 'output' ] >;
 };
 
 export type AppEnvironmentSyncConfig = {
-  __typename?: 'AppEnvironmentSyncConfig';
-  files?: Maybe<Array<Maybe<AppEnvironmentSyncConfigFile>>>;
-  settingsYml?: Maybe<Scalars['String']['output']>;
+	__typename?: 'AppEnvironmentSyncConfig';
+	files?: Maybe< Array< Maybe< AppEnvironmentSyncConfigFile > > >;
+	settingsYml?: Maybe< Scalars[ 'String' ][ 'output' ] >;
 };
 
 export type AppEnvironmentSyncConfigFile = {
-  __typename?: 'AppEnvironmentSyncConfigFile';
-  apiUrl?: Maybe<Scalars['String']['output']>;
-  branch?: Maybe<Scalars['String']['output']>;
-  contents?: Maybe<Scalars['String']['output']>;
-  filename?: Maybe<Scalars['String']['output']>;
-  htmlUrl?: Maybe<Scalars['String']['output']>;
-  repo?: Maybe<Scalars['String']['output']>;
+	__typename?: 'AppEnvironmentSyncConfigFile';
+	apiUrl?: Maybe< Scalars[ 'String' ][ 'output' ] >;
+	branch?: Maybe< Scalars[ 'String' ][ 'output' ] >;
+	contents?: Maybe< Scalars[ 'String' ][ 'output' ] >;
+	filename?: Maybe< Scalars[ 'String' ][ 'output' ] >;
+	htmlUrl?: Maybe< Scalars[ 'String' ][ 'output' ] >;
+	repo?: Maybe< Scalars[ 'String' ][ 'output' ] >;
 };
 
 export type AppEnvironmentSyncError = {
-  __typename?: 'AppEnvironmentSyncError';
-  code?: Maybe<Scalars['String']['output']>;
-  message?: Maybe<Scalars['String']['output']>;
+	__typename?: 'AppEnvironmentSyncError';
+	code?: Maybe< Scalars[ 'String' ][ 'output' ] >;
+	message?: Maybe< Scalars[ 'String' ][ 'output' ] >;
 };
 
 export type AppEnvironmentSyncInput = {
-  environmentId?: InputMaybe<Scalars['Int']['input']>;
-  id?: InputMaybe<Scalars['Int']['input']>;
+	environmentId?: InputMaybe< Scalars[ 'Int' ][ 'input' ] >;
+	id?: InputMaybe< Scalars[ 'Int' ][ 'input' ] >;
 };
 
 export type AppEnvironmentSyncPayload = {
-  __typename?: 'AppEnvironmentSyncPayload';
-  app?: Maybe<App>;
-  environment?: Maybe<AppEnvironment>;
+	__typename?: 'AppEnvironmentSyncPayload';
+	app?: Maybe< App >;
+	environment?: Maybe< AppEnvironment >;
 };
 
 export type AppEnvironmentSyncPreview = {
-  __typename?: 'AppEnvironmentSyncPreview';
-  backup?: Maybe<AppEnvironmentBackup>;
-  canSync?: Maybe<Scalars['Boolean']['output']>;
-  config?: Maybe<AppEnvironmentSyncConfig>;
-  errors?: Maybe<Array<Maybe<AppEnvironmentSyncError>>>;
-  from?: Maybe<AppEnvironment>;
-  replacements?: Maybe<Array<Maybe<AppEnvironmentSyncReplacement>>>;
-  sourceEnvironment?: Maybe<AppEnvironment>;
-  to?: Maybe<AppEnvironment>;
+	__typename?: 'AppEnvironmentSyncPreview';
+	backup?: Maybe< AppEnvironmentBackup >;
+	canSync?: Maybe< Scalars[ 'Boolean' ][ 'output' ] >;
+	config?: Maybe< AppEnvironmentSyncConfig >;
+	errors?: Maybe< Array< Maybe< AppEnvironmentSyncError > > >;
+	from?: Maybe< AppEnvironment >;
+	replacements?: Maybe< Array< Maybe< AppEnvironmentSyncReplacement > > >;
+	sourceEnvironment?: Maybe< AppEnvironment >;
+	to?: Maybe< AppEnvironment >;
 };
 
 export type AppEnvironmentSyncProgress = {
-  __typename?: 'AppEnvironmentSyncProgress';
-  finished_at?: Maybe<Scalars['Int']['output']>;
-  started_at?: Maybe<Scalars['Int']['output']>;
-  status?: Maybe<Scalars['String']['output']>;
-  steps?: Maybe<Array<Maybe<AppEnvironmentSyncStep>>>;
-  sync?: Maybe<Scalars['Int']['output']>;
+	__typename?: 'AppEnvironmentSyncProgress';
+	finished_at?: Maybe< Scalars[ 'Int' ][ 'output' ] >;
+	started_at?: Maybe< Scalars[ 'Int' ][ 'output' ] >;
+	status?: Maybe< Scalars[ 'String' ][ 'output' ] >;
+	steps?: Maybe< Array< Maybe< AppEnvironmentSyncStep > > >;
+	sync?: Maybe< Scalars[ 'Int' ][ 'output' ] >;
 };
 
 export type AppEnvironmentSyncReplacement = {
-  __typename?: 'AppEnvironmentSyncReplacement';
-  from?: Maybe<Scalars['String']['output']>;
-  to?: Maybe<Scalars['String']['output']>;
+	__typename?: 'AppEnvironmentSyncReplacement';
+	from?: Maybe< Scalars[ 'String' ][ 'output' ] >;
+	to?: Maybe< Scalars[ 'String' ][ 'output' ] >;
 };
 
 export type AppEnvironmentSyncStep = {
-  __typename?: 'AppEnvironmentSyncStep';
-  name?: Maybe<Scalars['String']['output']>;
-  status?: Maybe<Scalars['String']['output']>;
-  step?: Maybe<Scalars['String']['output']>;
+	__typename?: 'AppEnvironmentSyncStep';
+	name?: Maybe< Scalars[ 'String' ][ 'output' ] >;
+	status?: Maybe< Scalars[ 'String' ][ 'output' ] >;
+	step?: Maybe< Scalars[ 'String' ][ 'output' ] >;
 };
 
 export type AppEnvironmentTriggerDbBackupInput = {
-  environmentId?: InputMaybe<Scalars['Int']['input']>;
-  id?: InputMaybe<Scalars['Int']['input']>;
+	environmentId?: InputMaybe< Scalars[ 'Int' ][ 'input' ] >;
+	id?: InputMaybe< Scalars[ 'Int' ][ 'input' ] >;
 };
 
 export type AppEnvironmentTriggerDbBackupPayload = {
-  __typename?: 'AppEnvironmentTriggerDBBackupPayload';
-  success?: Maybe<Scalars['Boolean']['output']>;
+	__typename?: 'AppEnvironmentTriggerDBBackupPayload';
+	success?: Maybe< Scalars[ 'Boolean' ][ 'output' ] >;
 };
 
 /** Variables for the Run WP-CLI Command mutation */
 export type AppEnvironmentTriggerWpcliCommandInput = {
-  /** The command we want to run. Note: should not include 'wp' */
-  command?: InputMaybe<Scalars['String']['input']>;
-  /** The environment ID where we want to run the command */
-  environmentId?: InputMaybe<Scalars['Int']['input']>;
-  /** The application ID */
-  id?: InputMaybe<Scalars['Int']['input']>;
+	/** The command we want to run. Note: should not include 'wp' */
+	command?: InputMaybe< Scalars[ 'String' ][ 'input' ] >;
+	/** The environment ID where we want to run the command */
+	environmentId?: InputMaybe< Scalars[ 'Int' ][ 'input' ] >;
+	/** The application ID */
+	id?: InputMaybe< Scalars[ 'Int' ][ 'input' ] >;
 };
 
 /** Response from the Run WP-CLI Command mutation */
 export type AppEnvironmentTriggerWpcliCommandPayload = {
-  __typename?: 'AppEnvironmentTriggerWPCLICommandPayload';
-  /** The command that was executed */
-  command?: Maybe<WpcliCommand>;
-  /** The token for authenticating the socket connection */
-  inputToken?: Maybe<Scalars['String']['output']>;
+	__typename?: 'AppEnvironmentTriggerWPCLICommandPayload';
+	/** The command that was executed */
+	command?: Maybe< WpcliCommand >;
+	/** The token for authenticating the socket connection */
+	inputToken?: Maybe< Scalars[ 'String' ][ 'output' ] >;
 };
 
 export type AppEnvironmentUpdateSubsiteDomainInput = {
-  domainId?: InputMaybe<Scalars['Int']['input']>;
-  environmentId?: InputMaybe<Scalars['Int']['input']>;
-  id?: InputMaybe<Scalars['Int']['input']>;
-  subsiteId?: InputMaybe<Scalars['Int']['input']>;
-  subsitePath?: InputMaybe<Scalars['String']['input']>;
+	domainId?: InputMaybe< Scalars[ 'Int' ][ 'input' ] >;
+	environmentId?: InputMaybe< Scalars[ 'Int' ][ 'input' ] >;
+	id?: InputMaybe< Scalars[ 'Int' ][ 'input' ] >;
+	subsiteId?: InputMaybe< Scalars[ 'Int' ][ 'input' ] >;
+	subsitePath?: InputMaybe< Scalars[ 'String' ][ 'input' ] >;
 };
 
 export type AppEnvironmentUpdateSubsiteDomainPayload = {
-  __typename?: 'AppEnvironmentUpdateSubsiteDomainPayload';
-  app?: Maybe<App>;
-  domain?: Maybe<Domain>;
-  environment?: Maybe<AppEnvironment>;
+	__typename?: 'AppEnvironmentUpdateSubsiteDomainPayload';
+	app?: Maybe< App >;
+	domain?: Maybe< Domain >;
+	environment?: Maybe< AppEnvironment >;
 };
 
 export type AppEnvironmentUpdateSubsiteDomainStatus = {
-  __typename?: 'AppEnvironmentUpdateSubsiteDomainStatus';
-  dbOperationInProgress?: Maybe<Scalars['Boolean']['output']>;
-  progress?: Maybe<AppEnvironmentStatusProgress>;
-  updateSubsiteDomainInProgress?: Maybe<Scalars['Boolean']['output']>;
+	__typename?: 'AppEnvironmentUpdateSubsiteDomainStatus';
+	dbOperationInProgress?: Maybe< Scalars[ 'Boolean' ][ 'output' ] >;
+	progress?: Maybe< AppEnvironmentStatusProgress >;
+	updateSubsiteDomainInProgress?: Maybe< Scalars[ 'Boolean' ][ 'output' ] >;
 };
 
 export type AppFeatureInput = {
-  context?: InputMaybe<Scalars['String']['input']>;
-  id?: InputMaybe<Scalars['Int']['input']>;
-  name?: InputMaybe<Scalars['String']['input']>;
+	context?: InputMaybe< Scalars[ 'String' ][ 'input' ] >;
+	id?: InputMaybe< Scalars[ 'Int' ][ 'input' ] >;
+	name?: InputMaybe< Scalars[ 'String' ][ 'input' ] >;
 };
 
 export type AppFeaturePayload = {
-  __typename?: 'AppFeaturePayload';
-  features?: Maybe<Array<Maybe<Feature>>>;
-  total?: Maybe<Scalars['Int']['output']>;
+	__typename?: 'AppFeaturePayload';
+	features?: Maybe< Array< Maybe< Feature > > >;
+	total?: Maybe< Scalars[ 'Int' ][ 'output' ] >;
 };
 
 export type AppList = ModelList & {
-  __typename?: 'AppList';
-  edges?: Maybe<Array<Maybe<App>>>;
-  nextCursor?: Maybe<Scalars['String']['output']>;
-  nodes?: Maybe<Array<Maybe<App>>>;
-  total?: Maybe<Scalars['Int']['output']>;
+	__typename?: 'AppList';
+	edges?: Maybe< Array< Maybe< App > > >;
+	nextCursor?: Maybe< Scalars[ 'String' ][ 'output' ] >;
+	nodes?: Maybe< Array< Maybe< App > > >;
+	total?: Maybe< Scalars[ 'Int' ][ 'output' ] >;
 };
 
 export type ApplicationRole = {
-  __typename?: 'ApplicationRole';
-  extends?: Maybe<Scalars['String']['output']>;
-  name?: Maybe<Scalars['String']['output']>;
+	__typename?: 'ApplicationRole';
+	extends?: Maybe< Scalars[ 'String' ][ 'output' ] >;
+	name?: Maybe< Scalars[ 'String' ][ 'output' ] >;
 };
 
-export enum ApplicationRoleId {
-  Admin = 'admin',
-  Read = 'read',
-  Write = 'write'
-}
+export type ApplicationRoleId = 'admin' | 'read' | 'write';
 
 export type AuditEvent = {
-  __typename?: 'AuditEvent';
-  actor?: Maybe<AuditEventActor>;
-  app?: Maybe<App>;
-  description?: Maybe<Scalars['String']['output']>;
-  environment?: Maybe<AppEnvironment>;
-  environmentId?: Maybe<Scalars['Int']['output']>;
-  id?: Maybe<Scalars['String']['output']>;
-  meta?: Maybe<Array<Maybe<AuditEventMeta>>>;
-  recordedTime?: Maybe<Scalars['Date']['output']>;
-  source?: Maybe<AuditEventSource>;
-  target?: Maybe<AuditEventTarget>;
-  title?: Maybe<Scalars['String']['output']>;
-  type?: Maybe<Scalars['String']['output']>;
+	__typename?: 'AuditEvent';
+	actor?: Maybe< AuditEventActor >;
+	app?: Maybe< App >;
+	description?: Maybe< Scalars[ 'String' ][ 'output' ] >;
+	environment?: Maybe< AppEnvironment >;
+	environmentId?: Maybe< Scalars[ 'Int' ][ 'output' ] >;
+	id?: Maybe< Scalars[ 'String' ][ 'output' ] >;
+	meta?: Maybe< Array< Maybe< AuditEventMeta > > >;
+	recordedTime?: Maybe< Scalars[ 'Date' ][ 'output' ] >;
+	source?: Maybe< AuditEventSource >;
+	target?: Maybe< AuditEventTarget >;
+	title?: Maybe< Scalars[ 'String' ][ 'output' ] >;
+	type?: Maybe< Scalars[ 'String' ][ 'output' ] >;
 };
 
 export type AuditEventActor = {
-  __typename?: 'AuditEventActor';
-  avatarUrl?: Maybe<Scalars['String']['output']>;
-  displayName?: Maybe<Scalars['String']['output']>;
-  id?: Maybe<Scalars['String']['output']>;
-  isVIP?: Maybe<Scalars['Boolean']['output']>;
-  permission?: Maybe<Scalars['String']['output']>;
-  type?: Maybe<Scalars['String']['output']>;
+	__typename?: 'AuditEventActor';
+	avatarUrl?: Maybe< Scalars[ 'String' ][ 'output' ] >;
+	displayName?: Maybe< Scalars[ 'String' ][ 'output' ] >;
+	id?: Maybe< Scalars[ 'String' ][ 'output' ] >;
+	isVIP?: Maybe< Scalars[ 'Boolean' ][ 'output' ] >;
+	permission?: Maybe< Scalars[ 'String' ][ 'output' ] >;
+	type?: Maybe< Scalars[ 'String' ][ 'output' ] >;
 };
 
-
 export type AuditEventActorAvatarUrlArgs = {
-  width?: InputMaybe<Scalars['Int']['input']>;
+	width?: InputMaybe< Scalars[ 'Int' ][ 'input' ] >;
 };
 
 export type AuditEventList = {
-  __typename?: 'AuditEventList';
-  edges?: Maybe<Array<Maybe<AuditEvent>>>;
-  nextCursor?: Maybe<Scalars['String']['output']>;
-  nodes?: Maybe<Array<Maybe<AuditEvent>>>;
-  total?: Maybe<Scalars['Int']['output']>;
+	__typename?: 'AuditEventList';
+	edges?: Maybe< Array< Maybe< AuditEvent > > >;
+	nextCursor?: Maybe< Scalars[ 'String' ][ 'output' ] >;
+	nodes?: Maybe< Array< Maybe< AuditEvent > > >;
+	total?: Maybe< Scalars[ 'Int' ][ 'output' ] >;
 };
 
 export type AuditEventMeta = {
-  __typename?: 'AuditEventMeta';
-  key: Scalars['String']['output'];
-  value?: Maybe<Scalars['String']['output']>;
+	__typename?: 'AuditEventMeta';
+	key: Scalars[ 'String' ][ 'output' ];
+	value?: Maybe< Scalars[ 'String' ][ 'output' ] >;
 };
 
 export type AuditEventSource = {
-  __typename?: 'AuditEventSource';
-  type?: Maybe<Scalars['String']['output']>;
-  version?: Maybe<Scalars['String']['output']>;
+	__typename?: 'AuditEventSource';
+	type?: Maybe< Scalars[ 'String' ][ 'output' ] >;
+	version?: Maybe< Scalars[ 'String' ][ 'output' ] >;
 };
 
 export type AuditEventTarget = {
-  __typename?: 'AuditEventTarget';
-  id?: Maybe<Scalars['String']['output']>;
-  type?: Maybe<Scalars['String']['output']>;
+	__typename?: 'AuditEventTarget';
+	id?: Maybe< Scalars[ 'String' ][ 'output' ] >;
+	type?: Maybe< Scalars[ 'String' ][ 'output' ] >;
 };
 
 export type Backup = {
-  __typename?: 'Backup';
-  createdAt?: Maybe<Scalars['String']['output']>;
-  dataset?: Maybe<DbPartitioningDataset>;
-  environmentId?: Maybe<Scalars['Int']['output']>;
-  filename?: Maybe<Scalars['String']['output']>;
-  id?: Maybe<Scalars['Float']['output']>;
-  size?: Maybe<Scalars['Float']['output']>;
-  type?: Maybe<Scalars['String']['output']>;
+	__typename?: 'Backup';
+	createdAt?: Maybe< Scalars[ 'String' ][ 'output' ] >;
+	dataset?: Maybe< DbPartitioningDataset >;
+	environmentId?: Maybe< Scalars[ 'Int' ][ 'output' ] >;
+	filename?: Maybe< Scalars[ 'String' ][ 'output' ] >;
+	id?: Maybe< Scalars[ 'Float' ][ 'output' ] >;
+	size?: Maybe< Scalars[ 'Float' ][ 'output' ] >;
+	type?: Maybe< Scalars[ 'String' ][ 'output' ] >;
 };
 
 export type BackupsList = {
-  __typename?: 'BackupsList';
-  nextCursor?: Maybe<Scalars['String']['output']>;
-  nodes?: Maybe<Array<Maybe<Backup>>>;
-  total?: Maybe<Scalars['Int']['output']>;
+	__typename?: 'BackupsList';
+	nextCursor?: Maybe< Scalars[ 'String' ][ 'output' ] >;
+	nodes?: Maybe< Array< Maybe< Backup > > >;
+	total?: Maybe< Scalars[ 'Int' ][ 'output' ] >;
 };
 
 export type Build = Model & {
-  __typename?: 'Build';
-  commit_author: Scalars['String']['output'];
-  commit_sha?: Maybe<Scalars['String']['output']>;
-  commit_time: Scalars['Date']['output'];
-  finish_date?: Maybe<Scalars['Date']['output']>;
-  id?: Maybe<Scalars['Int']['output']>;
-  logs?: Maybe<Array<Maybe<Scalars['String']['output']>>>;
-  queued_date?: Maybe<Scalars['Date']['output']>;
-  start_date?: Maybe<Scalars['Date']['output']>;
-  status: BuildStatus;
-  vendor_id?: Maybe<Scalars['Int']['output']>;
+	__typename?: 'Build';
+	commit_author: Scalars[ 'String' ][ 'output' ];
+	commit_sha?: Maybe< Scalars[ 'String' ][ 'output' ] >;
+	commit_time: Scalars[ 'Date' ][ 'output' ];
+	finish_date?: Maybe< Scalars[ 'Date' ][ 'output' ] >;
+	id?: Maybe< Scalars[ 'Int' ][ 'output' ] >;
+	logs?: Maybe< Array< Maybe< Scalars[ 'String' ][ 'output' ] > > >;
+	queued_date?: Maybe< Scalars[ 'Date' ][ 'output' ] >;
+	start_date?: Maybe< Scalars[ 'Date' ][ 'output' ] >;
+	status: BuildStatus;
+	vendor_id?: Maybe< Scalars[ 'Int' ][ 'output' ] >;
 };
 
 /** Build configuration for the environment */
 export type BuildConfiguration = {
-  __typename?: 'BuildConfiguration';
-  /** Build type */
-  buildType: Scalars['String']['output'];
-  /** Node.js build environment variables */
-  nodeBuildDockerEnv: Scalars['String']['output'];
-  /** Node.js version */
-  nodeJSVersion: Scalars['String']['output'];
-  /** npm token */
-  npmToken?: Maybe<Scalars['String']['output']>;
+	__typename?: 'BuildConfiguration';
+	/** Build type */
+	buildType: Scalars[ 'String' ][ 'output' ];
+	/** Node.js build environment variables */
+	nodeBuildDockerEnv: Scalars[ 'String' ][ 'output' ];
+	/** Node.js version */
+	nodeJSVersion: Scalars[ 'String' ][ 'output' ];
+	/** npm token */
+	npmToken?: Maybe< Scalars[ 'String' ][ 'output' ] >;
 };
 
 export type BuildList = ModelList & {
-  __typename?: 'BuildList';
-  nextCursor?: Maybe<Scalars['String']['output']>;
-  nodes?: Maybe<Array<Maybe<Build>>>;
-  total?: Maybe<Scalars['Int']['output']>;
+	__typename?: 'BuildList';
+	nextCursor?: Maybe< Scalars[ 'String' ][ 'output' ] >;
+	nodes?: Maybe< Array< Maybe< Build > > >;
+	total?: Maybe< Scalars[ 'Int' ][ 'output' ] >;
 };
 
-export enum BuildStatus {
-  Failed = 'FAILED',
-  Queued = 'QUEUED',
-  Running = 'RUNNING',
-  Success = 'SUCCESS'
-}
+export type BuildStatus = 'FAILED' | 'QUEUED' | 'RUNNING' | 'SUCCESS';
 
 export type CsrDecoded = {
-  __typename?: 'CSRDecoded';
-  altNames?: Maybe<Array<Maybe<Scalars['String']['output']>>>;
-  commonName?: Maybe<Scalars['String']['output']>;
-  country?: Maybe<Scalars['String']['output']>;
-  emailAddress?: Maybe<Scalars['String']['output']>;
-  locality?: Maybe<Scalars['String']['output']>;
-  organization?: Maybe<Scalars['String']['output']>;
-  organizationUnit?: Maybe<Scalars['String']['output']>;
-  state?: Maybe<Scalars['String']['output']>;
+	__typename?: 'CSRDecoded';
+	altNames?: Maybe< Array< Maybe< Scalars[ 'String' ][ 'output' ] > > >;
+	commonName?: Maybe< Scalars[ 'String' ][ 'output' ] >;
+	country?: Maybe< Scalars[ 'String' ][ 'output' ] >;
+	emailAddress?: Maybe< Scalars[ 'String' ][ 'output' ] >;
+	locality?: Maybe< Scalars[ 'String' ][ 'output' ] >;
+	organization?: Maybe< Scalars[ 'String' ][ 'output' ] >;
+	organizationUnit?: Maybe< Scalars[ 'String' ][ 'output' ] >;
+	state?: Maybe< Scalars[ 'String' ][ 'output' ] >;
 };
 
 export type CsrInfo = {
-  altNames?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
-  commonName: Scalars['String']['input'];
-  country: Scalars['String']['input'];
-  emailAddress?: InputMaybe<Scalars['String']['input']>;
-  locality: Scalars['String']['input'];
-  organization: Scalars['String']['input'];
-  organizationUnit?: InputMaybe<Scalars['String']['input']>;
-  state: Scalars['String']['input'];
+	altNames?: InputMaybe< Array< InputMaybe< Scalars[ 'String' ][ 'input' ] > > >;
+	commonName: Scalars[ 'String' ][ 'input' ];
+	country: Scalars[ 'String' ][ 'input' ];
+	emailAddress?: InputMaybe< Scalars[ 'String' ][ 'input' ] >;
+	locality: Scalars[ 'String' ][ 'input' ];
+	organization: Scalars[ 'String' ][ 'input' ];
+	organizationUnit?: InputMaybe< Scalars[ 'String' ][ 'input' ] >;
+	state: Scalars[ 'String' ][ 'input' ];
 };
 
 export type CancelInvitationInput = {
-  invitationId?: InputMaybe<Scalars['Int']['input']>;
+	invitationId?: InputMaybe< Scalars[ 'Int' ][ 'input' ] >;
 };
 
 export type CancelInvitationPayload = {
-  __typename?: 'CancelInvitationPayload';
-  invitation?: Maybe<Invitation>;
+	__typename?: 'CancelInvitationPayload';
+	invitation?: Maybe< Invitation >;
 };
 
 /** Variables for the Cancel WP-CLI Command mutation */
 export type CancelWpcliCommandInput = {
-  /** The unique ID for the running command */
-  guid?: InputMaybe<Scalars['String']['input']>;
+	/** The unique ID for the running command */
+	guid?: InputMaybe< Scalars[ 'String' ][ 'input' ] >;
 };
 
 /** Response from the Cancel WP-CLI Command mutation */
 export type CancelWpcliCommandPayload = {
-  __typename?: 'CancelWPCLICommandPayload';
-  /** The command that was cancelled */
-  command?: Maybe<WpcliCommand>;
+	__typename?: 'CancelWPCLICommandPayload';
+	/** The command that was cancelled */
+	command?: Maybe< WpcliCommand >;
 };
 
 export type Certificate = {
-  __typename?: 'Certificate';
-  active?: Maybe<Scalars['Boolean']['output']>;
-  beginsTimestamp?: Maybe<Scalars['String']['output']>;
-  certificateId?: Maybe<Scalars['Int']['output']>;
-  /** Domain name. Ex: www.example.com */
-  commonName?: Maybe<Scalars['String']['output']>;
-  created?: Maybe<Scalars['String']['output']>;
-  /** OpenSSL generated CSR string */
-  csr?: Maybe<Scalars['String']['output']>;
-  csrDecoded?: Maybe<CsrDecoded>;
-  expiresTimestamp?: Maybe<Scalars['String']['output']>;
-  hasCertificate?: Maybe<Scalars['Boolean']['output']>;
-  issuer?: Maybe<CertificateIssuer>;
-  /** Alternative names */
-  san?: Maybe<Array<Maybe<Scalars['String']['output']>>>;
-  valid?: Maybe<Scalars['Boolean']['output']>;
+	__typename?: 'Certificate';
+	active?: Maybe< Scalars[ 'Boolean' ][ 'output' ] >;
+	beginsTimestamp?: Maybe< Scalars[ 'String' ][ 'output' ] >;
+	certificateId?: Maybe< Scalars[ 'Int' ][ 'output' ] >;
+	/** Domain name. Ex: www.example.com */
+	commonName?: Maybe< Scalars[ 'String' ][ 'output' ] >;
+	created?: Maybe< Scalars[ 'String' ][ 'output' ] >;
+	/** OpenSSL generated CSR string */
+	csr?: Maybe< Scalars[ 'String' ][ 'output' ] >;
+	csrDecoded?: Maybe< CsrDecoded >;
+	expiresTimestamp?: Maybe< Scalars[ 'String' ][ 'output' ] >;
+	hasCertificate?: Maybe< Scalars[ 'Boolean' ][ 'output' ] >;
+	issuer?: Maybe< CertificateIssuer >;
+	/** Alternative names */
+	san?: Maybe< Array< Maybe< Scalars[ 'String' ][ 'output' ] > > >;
+	valid?: Maybe< Scalars[ 'Boolean' ][ 'output' ] >;
 };
 
 export type CertificateIssuer = {
-  __typename?: 'CertificateIssuer';
-  commonName?: Maybe<Scalars['String']['output']>;
-  country?: Maybe<Scalars['String']['output']>;
-  organization?: Maybe<Scalars['String']['output']>;
+	__typename?: 'CertificateIssuer';
+	commonName?: Maybe< Scalars[ 'String' ][ 'output' ] >;
+	country?: Maybe< Scalars[ 'String' ][ 'output' ] >;
+	organization?: Maybe< Scalars[ 'String' ][ 'output' ] >;
 };
 
 export type CertificateList = {
-  __typename?: 'CertificateList';
-  nextCursor?: Maybe<Scalars['String']['output']>;
-  nodes?: Maybe<Array<Maybe<Certificate>>>;
-  total?: Maybe<Scalars['Int']['output']>;
+	__typename?: 'CertificateList';
+	nextCursor?: Maybe< Scalars[ 'String' ][ 'output' ] >;
+	nodes?: Maybe< Array< Maybe< Certificate > > >;
+	total?: Maybe< Scalars[ 'Int' ][ 'output' ] >;
 };
 
 export type CodebaseInfo = {
-  __typename?: 'CodebaseInfo';
-  plugins: CodebasePlugins;
+	__typename?: 'CodebaseInfo';
+	plugins: CodebasePlugins;
 };
 
 export type CodebasePlugins = {
-  __typename?: 'CodebasePlugins';
-  pullRequests: Array<CodebasePullRequest>;
-  tasks: Array<CodebaseTask>;
-  vulnerabilities: Array<CodebaseVulnerability>;
+	__typename?: 'CodebasePlugins';
+	pullRequests: Array< CodebasePullRequest >;
+	tasks: Array< CodebaseTask >;
+	vulnerabilities: Array< CodebaseVulnerability >;
 };
 
 export type CodebasePullRequest = {
-  __typename?: 'CodebasePullRequest';
-  link: Scalars['String']['output'];
-  modulePath: Scalars['String']['output'];
-  version: Scalars['String']['output'];
+	__typename?: 'CodebasePullRequest';
+	link: Scalars[ 'String' ][ 'output' ];
+	modulePath: Scalars[ 'String' ][ 'output' ];
+	version: Scalars[ 'String' ][ 'output' ];
 };
 
 export type CodebaseTask = {
-  __typename?: 'CodebaseTask';
-  dateUpdated: Scalars['String']['output'];
-  failureReason: Scalars['String']['output'];
-  modulePath: Scalars['String']['output'];
-  status: Scalars['String']['output'];
+	__typename?: 'CodebaseTask';
+	dateUpdated: Scalars[ 'String' ][ 'output' ];
+	failureReason: Scalars[ 'String' ][ 'output' ];
+	modulePath: Scalars[ 'String' ][ 'output' ];
+	status: Scalars[ 'String' ][ 'output' ];
 };
 
 /** Variables for the CodebaseUpdatePlugin mutation */
 export type CodebaseUpdatePluginInput = {
-  /** The unique ID of the Application */
-  appId: Scalars['Int']['input'];
-  /** The download link for the new plugin version */
-  download?: InputMaybe<Scalars['String']['input']>;
-  /** The unique ID of the Environment */
-  environmentId: Scalars['Int']['input'];
-  /** The location of the plugin in the codebase */
-  location?: InputMaybe<Scalars['String']['input']>;
-  /** The marketplace the plugin belongs too */
-  marketplace?: InputMaybe<Scalars['String']['input']>;
-  /** The name of the plugin */
-  name?: InputMaybe<Scalars['String']['input']>;
-  /** The plugin slug */
-  slug: Scalars['String']['input'];
-  /** The new version to update the plugin */
-  version?: InputMaybe<Scalars['String']['input']>;
-  /** The number of active vulns on the plugin */
-  vulnCount?: InputMaybe<Scalars['Int']['input']>;
+	/** The unique ID of the Application */
+	appId: Scalars[ 'Int' ][ 'input' ];
+	/** The download link for the new plugin version */
+	download?: InputMaybe< Scalars[ 'String' ][ 'input' ] >;
+	/** The unique ID of the Environment */
+	environmentId: Scalars[ 'Int' ][ 'input' ];
+	/** The location of the plugin in the codebase */
+	location?: InputMaybe< Scalars[ 'String' ][ 'input' ] >;
+	/** The marketplace the plugin belongs too */
+	marketplace?: InputMaybe< Scalars[ 'String' ][ 'input' ] >;
+	/** The name of the plugin */
+	name?: InputMaybe< Scalars[ 'String' ][ 'input' ] >;
+	/** The plugin slug */
+	slug: Scalars[ 'String' ][ 'input' ];
+	/** The new version to update the plugin */
+	version?: InputMaybe< Scalars[ 'String' ][ 'input' ] >;
+	/** The number of active vulns on the plugin */
+	vulnCount?: InputMaybe< Scalars[ 'Int' ][ 'input' ] >;
 };
 
 export type CodebaseUpdatePluginResult = {
-  __typename?: 'CodebaseUpdatePluginResult';
-  code: Scalars['String']['output'];
-  message: Scalars['String']['output'];
-  status: Scalars['String']['output'];
+	__typename?: 'CodebaseUpdatePluginResult';
+	code: Scalars[ 'String' ][ 'output' ];
+	message: Scalars[ 'String' ][ 'output' ];
+	status: Scalars[ 'String' ][ 'output' ];
 };
 
 export type CodebaseVulnerability = {
-  __typename?: 'CodebaseVulnerability';
-  link: Scalars['String']['output'];
-  modulePath: Scalars['String']['output'];
-  severity: Scalars['String']['output'];
-  severityScore?: Maybe<Scalars['String']['output']>;
+	__typename?: 'CodebaseVulnerability';
+	link: Scalars[ 'String' ][ 'output' ];
+	modulePath: Scalars[ 'String' ][ 'output' ];
+	severity: Scalars[ 'String' ][ 'output' ];
+	severityScore?: Maybe< Scalars[ 'String' ][ 'output' ] >;
 };
 
 export type CreateCsrInput = {
-  clientId: Scalars['Int']['input'];
-  csr: CsrInfo;
-  domainName?: InputMaybe<Scalars['String']['input']>;
+	clientId: Scalars[ 'Int' ][ 'input' ];
+	csr: CsrInfo;
+	domainName?: InputMaybe< Scalars[ 'String' ][ 'input' ] >;
 };
 
 export type CreateCsrPayload = {
-  __typename?: 'CreateCSRPayload';
-  certificateId?: Maybe<Scalars['Int']['output']>;
+	__typename?: 'CreateCSRPayload';
+	certificateId?: Maybe< Scalars[ 'Int' ][ 'output' ] >;
 };
 
 export type CreateInvitationInput = {
-  emailAddresses: Array<InputMaybe<Scalars['String']['input']>>;
-  grantedPermissions: InvitationPermissionsInput;
-  organizationId: Scalars['Int']['input'];
+	emailAddresses: Array< InputMaybe< Scalars[ 'String' ][ 'input' ] > >;
+	grantedPermissions: InvitationPermissionsInput;
+	organizationId: Scalars[ 'Int' ][ 'input' ];
 };
 
 export type CreateInvitationPayload = {
-  __typename?: 'CreateInvitationPayload';
-  invitations?: Maybe<Array<Maybe<Invitation>>>;
+	__typename?: 'CreateInvitationPayload';
+	invitations?: Maybe< Array< Maybe< Invitation > > >;
 };
 
 export type CreateUserInput = {
-  githubUsername: Scalars['String']['input'];
-  isVIP?: InputMaybe<Scalars['Boolean']['input']>;
+	githubUsername: Scalars[ 'String' ][ 'input' ];
+	isVIP?: InputMaybe< Scalars[ 'Boolean' ][ 'input' ] >;
 };
 
 export type CreateUserPayload = {
-  __typename?: 'CreateUserPayload';
-  user?: Maybe<User>;
+	__typename?: 'CreateUserPayload';
+	user?: Maybe< User >;
 };
 
 export type DbBackupCopy = Model & {
-  __typename?: 'DBBackupCopy';
-  config?: Maybe<DbBackupCopyConfig>;
-  filePath: Scalars['String']['output'];
-  /** id is not implemented by DBBackupCopy as it does not have an integer id */
-  id?: Maybe<Scalars['Int']['output']>;
+	__typename?: 'DBBackupCopy';
+	config?: Maybe< DbBackupCopyConfig >;
+	filePath: Scalars[ 'String' ][ 'output' ];
+	/** id is not implemented by DBBackupCopy as it does not have an integer id */
+	id?: Maybe< Scalars[ 'Int' ][ 'output' ] >;
 };
 
 export type DbBackupCopyConfig = {
-  __typename?: 'DBBackupCopyConfig';
-  backupLabel: Scalars['String']['output'];
-  networkSiteId?: Maybe<Scalars['Int']['output']>;
-  siteId: Scalars['Int']['output'];
-  tables: Array<Scalars['String']['output']>;
-  userId?: Maybe<Scalars['String']['output']>;
+	__typename?: 'DBBackupCopyConfig';
+	backupLabel: Scalars[ 'String' ][ 'output' ];
+	networkSiteId?: Maybe< Scalars[ 'Int' ][ 'output' ] >;
+	siteId: Scalars[ 'Int' ][ 'output' ];
+	tables: Array< Scalars[ 'String' ][ 'output' ] >;
+	userId?: Maybe< Scalars[ 'String' ][ 'output' ] >;
 };
 
 export type DbBackupCopyList = ModelList & {
-  __typename?: 'DBBackupCopyList';
-  nextCursor?: Maybe<Scalars['String']['output']>;
-  nodes: Array<DbBackupCopy>;
-  total: Scalars['Int']['output'];
+	__typename?: 'DBBackupCopyList';
+	nextCursor?: Maybe< Scalars[ 'String' ][ 'output' ] >;
+	nodes: Array< DbBackupCopy >;
+	total: Scalars[ 'Int' ][ 'output' ];
 };
 
 export type DbPartitioningDataset = {
-  __typename?: 'DBPartitioningDataset';
-  displayName?: Maybe<Scalars['String']['output']>;
-  name?: Maybe<Scalars['String']['output']>;
+	__typename?: 'DBPartitioningDataset';
+	displayName?: Maybe< Scalars[ 'String' ][ 'output' ] >;
+	name?: Maybe< Scalars[ 'String' ][ 'output' ] >;
 };
 
 export type DebugPageCacheInput = {
-  appId: Scalars['Int']['input'];
-  environmentId: Scalars['Int']['input'];
-  pop?: InputMaybe<Scalars['String']['input']>;
-  requestHeaders?: InputMaybe<Array<RequestHeader>>;
-  requestMethod?: InputMaybe<Scalars['String']['input']>;
-  url: Scalars['String']['input'];
+	appId: Scalars[ 'Int' ][ 'input' ];
+	environmentId: Scalars[ 'Int' ][ 'input' ];
+	pop?: InputMaybe< Scalars[ 'String' ][ 'input' ] >;
+	requestHeaders?: InputMaybe< Array< RequestHeader > >;
+	requestMethod?: InputMaybe< Scalars[ 'String' ][ 'input' ] >;
+	url: Scalars[ 'String' ][ 'input' ];
 };
 
 export type DebugPageCacheInsight = {
-  __typename?: 'DebugPageCacheInsight';
-  category: Scalars['String']['output'];
-  final: Scalars['Boolean']['output'];
-  html: Scalars['String']['output'];
-  name: Scalars['String']['output'];
-  type: Scalars['String']['output'];
+	__typename?: 'DebugPageCacheInsight';
+	category: Scalars[ 'String' ][ 'output' ];
+	final: Scalars[ 'Boolean' ][ 'output' ];
+	html: Scalars[ 'String' ][ 'output' ];
+	name: Scalars[ 'String' ][ 'output' ];
+	type: Scalars[ 'String' ][ 'output' ];
 };
 
 export type DebugPageCachePayload = {
-  __typename?: 'DebugPageCachePayload';
-  edge?: Maybe<ServerResponse>;
-  insights?: Maybe<Array<DebugPageCacheInsight>>;
-  origin?: Maybe<ServerResponse>;
-  success: Scalars['Boolean']['output'];
-  url: Scalars['String']['output'];
+	__typename?: 'DebugPageCachePayload';
+	edge?: Maybe< ServerResponse >;
+	insights?: Maybe< Array< DebugPageCacheInsight > >;
+	origin?: Maybe< ServerResponse >;
+	success: Scalars[ 'Boolean' ][ 'output' ];
+	url: Scalars[ 'String' ][ 'output' ];
 };
 
 export type DecodeCsrInput = {
-  csr: Scalars['String']['input'];
+	csr: Scalars[ 'String' ][ 'input' ];
 };
 
 export type DeleteCertificateInput = {
-  certificateId: Scalars['Int']['input'];
-  domainName: Scalars['String']['input'];
+	certificateId: Scalars[ 'Int' ][ 'input' ];
+	domainName: Scalars[ 'String' ][ 'input' ];
 };
 
 export type DeleteCertificatePayload = {
-  __typename?: 'DeleteCertificatePayload';
-  deleted?: Maybe<Scalars['Boolean']['output']>;
+	__typename?: 'DeleteCertificatePayload';
+	deleted?: Maybe< Scalars[ 'Boolean' ][ 'output' ] >;
 };
 
 export type DeleteNotificationRecipientInput = {
-  notificationRecipientId: Scalars['Int']['input'];
-  organizationId: Scalars['Int']['input'];
+	notificationRecipientId: Scalars[ 'Int' ][ 'input' ];
+	organizationId: Scalars[ 'Int' ][ 'input' ];
 };
 
 export type DeleteNotificationRecipientPayload = {
-  __typename?: 'DeleteNotificationRecipientPayload';
-  deleted?: Maybe<Scalars['Boolean']['output']>;
+	__typename?: 'DeleteNotificationRecipientPayload';
+	deleted?: Maybe< Scalars[ 'Boolean' ][ 'output' ] >;
 };
 
 export type DeleteNotificationSubscriptionInput = {
-  applicationId: Scalars['Int']['input'];
-  environmentId: Scalars['Int']['input'];
-  notificationRecipientId: Scalars['Int']['input'];
-  notificationSubscriptionId: Scalars['Int']['input'];
+	applicationId: Scalars[ 'Int' ][ 'input' ];
+	environmentId: Scalars[ 'Int' ][ 'input' ];
+	notificationRecipientId: Scalars[ 'Int' ][ 'input' ];
+	notificationSubscriptionId: Scalars[ 'Int' ][ 'input' ];
 };
 
 export type DeleteNotificationSubscriptionPayload = {
-  __typename?: 'DeleteNotificationSubscriptionPayload';
-  deleted?: Maybe<Scalars['Boolean']['output']>;
+	__typename?: 'DeleteNotificationSubscriptionPayload';
+	deleted?: Maybe< Scalars[ 'Boolean' ][ 'output' ] >;
 };
 
 export type Deploy = {
-  __typename?: 'Deploy';
-  branch?: Maybe<Scalars['String']['output']>;
-  commits?: Maybe<GitCommitList>;
-  deployed_at?: Maybe<Scalars['String']['output']>;
-  deployer_api_user_id?: Maybe<Scalars['Int']['output']>;
-  id?: Maybe<Scalars['Int']['output']>;
-  repo?: Maybe<Scalars['String']['output']>;
+	__typename?: 'Deploy';
+	branch?: Maybe< Scalars[ 'String' ][ 'output' ] >;
+	commits?: Maybe< GitCommitList >;
+	deployed_at?: Maybe< Scalars[ 'String' ][ 'output' ] >;
+	deployer_api_user_id?: Maybe< Scalars[ 'Int' ][ 'output' ] >;
+	id?: Maybe< Scalars[ 'Int' ][ 'output' ] >;
+	repo?: Maybe< Scalars[ 'String' ][ 'output' ] >;
 };
 
-
 export type DeployCommitsArgs = {
-  first?: InputMaybe<Scalars['Int']['input']>;
+	first?: InputMaybe< Scalars[ 'Int' ][ 'input' ] >;
 };
 
 export type DeployList = {
-  __typename?: 'DeployList';
-  edges?: Maybe<Array<Maybe<Deploy>>>;
-  nextCursor?: Maybe<Scalars['String']['output']>;
-  nodes?: Maybe<Array<Maybe<Deploy>>>;
-  total?: Maybe<Scalars['Int']['output']>;
+	__typename?: 'DeployList';
+	edges?: Maybe< Array< Maybe< Deploy > > >;
+	nextCursor?: Maybe< Scalars[ 'String' ][ 'output' ] >;
+	nodes?: Maybe< Array< Maybe< Deploy > > >;
+	total?: Maybe< Scalars[ 'Int' ][ 'output' ] >;
 };
 
 export type Deployment = Model & {
-  __typename?: 'Deployment';
-  branch: Scalars['String']['output'];
-  build?: Maybe<Build>;
-  cancelledAt?: Maybe<Scalars['Date']['output']>;
-  commit_author?: Maybe<Scalars['String']['output']>;
-  commit_description?: Maybe<Scalars['String']['output']>;
-  commit_sha: Scalars['String']['output'];
-  commit_time?: Maybe<Scalars['Date']['output']>;
-  createdAt?: Maybe<Scalars['Date']['output']>;
-  deployment_finished_at?: Maybe<Scalars['Date']['output']>;
-  deployment_status: Scalars['String']['output'];
-  deployment_triggered_at?: Maybe<Scalars['Date']['output']>;
-  id: Scalars['Int']['output'];
-  inProgress?: Maybe<Scalars['Boolean']['output']>;
-  initiatedBy?: Maybe<User>;
-  isAvailableForRollback?: Maybe<Scalars['Boolean']['output']>;
-  isError?: Maybe<Scalars['Boolean']['output']>;
-  isLatest?: Maybe<Scalars['Boolean']['output']>;
-  postDeployActionsJob?: Maybe<Scalars['String']['output']>;
-  repo: Scalars['String']['output'];
-  steps?: Maybe<Array<Maybe<DeploymentStep>>>;
+	__typename?: 'Deployment';
+	branch: Scalars[ 'String' ][ 'output' ];
+	build?: Maybe< Build >;
+	cancelledAt?: Maybe< Scalars[ 'Date' ][ 'output' ] >;
+	commit_author?: Maybe< Scalars[ 'String' ][ 'output' ] >;
+	commit_description?: Maybe< Scalars[ 'String' ][ 'output' ] >;
+	commit_sha: Scalars[ 'String' ][ 'output' ];
+	commit_time?: Maybe< Scalars[ 'Date' ][ 'output' ] >;
+	createdAt?: Maybe< Scalars[ 'Date' ][ 'output' ] >;
+	deployment_finished_at?: Maybe< Scalars[ 'Date' ][ 'output' ] >;
+	deployment_status: Scalars[ 'String' ][ 'output' ];
+	deployment_triggered_at?: Maybe< Scalars[ 'Date' ][ 'output' ] >;
+	id: Scalars[ 'Int' ][ 'output' ];
+	inProgress?: Maybe< Scalars[ 'Boolean' ][ 'output' ] >;
+	initiatedBy?: Maybe< User >;
+	isAvailableForRollback?: Maybe< Scalars[ 'Boolean' ][ 'output' ] >;
+	isError?: Maybe< Scalars[ 'Boolean' ][ 'output' ] >;
+	isLatest?: Maybe< Scalars[ 'Boolean' ][ 'output' ] >;
+	postDeployActionsJob?: Maybe< Scalars[ 'String' ][ 'output' ] >;
+	repo: Scalars[ 'String' ][ 'output' ];
+	steps?: Maybe< Array< Maybe< DeploymentStep > > >;
 };
 
 export type DeploymentList = ModelList & {
-  __typename?: 'DeploymentList';
-  nextCursor?: Maybe<Scalars['String']['output']>;
-  nodes?: Maybe<Array<Maybe<Deployment>>>;
-  total?: Maybe<Scalars['Int']['output']>;
+	__typename?: 'DeploymentList';
+	nextCursor?: Maybe< Scalars[ 'String' ][ 'output' ] >;
+	nodes?: Maybe< Array< Maybe< Deployment > > >;
+	total?: Maybe< Scalars[ 'Int' ][ 'output' ] >;
 };
 
 export type DeploymentStep = {
-  __typename?: 'DeploymentStep';
-  finishDate?: Maybe<Scalars['Date']['output']>;
-  inProgress: Scalars['Boolean']['output'];
-  isError: Scalars['Boolean']['output'];
-  isLogsAvailableForAppType?: Maybe<Scalars['Boolean']['output']>;
-  logs?: Maybe<Array<Maybe<Scalars['String']['output']>>>;
-  logsExpireAt?: Maybe<Scalars['Date']['output']>;
-  startDate?: Maybe<Scalars['Date']['output']>;
-  status: DeploymentStepStatus;
-  step: Scalars['String']['output'];
+	__typename?: 'DeploymentStep';
+	finishDate?: Maybe< Scalars[ 'Date' ][ 'output' ] >;
+	inProgress: Scalars[ 'Boolean' ][ 'output' ];
+	isError: Scalars[ 'Boolean' ][ 'output' ];
+	isLogsAvailableForAppType?: Maybe< Scalars[ 'Boolean' ][ 'output' ] >;
+	logs?: Maybe< Array< Maybe< Scalars[ 'String' ][ 'output' ] > > >;
+	logsExpireAt?: Maybe< Scalars[ 'Date' ][ 'output' ] >;
+	startDate?: Maybe< Scalars[ 'Date' ][ 'output' ] >;
+	status: DeploymentStepStatus;
+	step: Scalars[ 'String' ][ 'output' ];
 };
 
-export enum DeploymentStepStatus {
-  BuildError = 'BuildError',
-  BuildFinished = 'BuildFinished',
-  Building = 'Building',
-  Cancelled = 'Cancelled',
-  Deploying = 'Deploying',
-  Error = 'Error',
-  Finished = 'Finished',
-  Pending = 'Pending',
-  Running = 'Running',
-  Waiting = 'Waiting'
-}
+export type DeploymentStepStatus =
+	| 'BuildError'
+	| 'BuildFinished'
+	| 'Building'
+	| 'Cancelled'
+	| 'Deploying'
+	| 'Error'
+	| 'Finished'
+	| 'Pending'
+	| 'Running'
+	| 'Waiting';
 
 /** A domain for an environment */
 export type Domain = {
-  __typename?: 'Domain';
-  /** Is the domain currently active? */
-  active?: Maybe<Scalars['Boolean']['output']>;
-  /** The active certificate of the domain */
-  certificate?: Maybe<Certificate>;
-  /** The matching certificates of the domain */
-  certificates?: Maybe<CertificateList>;
-  /** The date the domain was added to the system */
-  createdAt?: Maybe<Scalars['String']['output']>;
-  /** What is the IP of the domain and does it point to VIP? */
-  dns?: Maybe<DomainDnsRecord>;
-  /** The environment this domain belongs to */
-  environment?: Maybe<AppEnvironment>;
-  /** Does this domain have a valid TLS certificate? (Note: SSL is a misnomer there; we are using TLS certificates.) */
-  hasSSL?: Maybe<Scalars['Boolean']['output']>;
-  /** The unique ID for the domain */
-  id?: Maybe<Scalars['Int']['output']>;
-  /** Is this a default domain? (*.go-vip.co / *.go-vip.net) */
-  isDefault?: Maybe<Scalars['Boolean']['output']>;
-  /** Is the domain using a Let's Encrypt certificate */
-  isLetsEncrypt?: Maybe<Scalars['Boolean']['output']>;
-  /** Is this the primary domain for the environment? */
-  isPrimary?: Maybe<Scalars['Boolean']['output']>;
-  /** What are the issues that may block LE provisioning for this domain? */
-  letsEncryptCompatibility?: Maybe<Array<Maybe<DomainLetsEncryptCompatibility>>>;
-  /** What is the status of LE provisioning? */
-  letsEncryptStatus?: Maybe<Array<Maybe<DomainLetsEncryptStatus>>>;
-  /** The domain name (i.e. something like example.com or sub.example.com) */
-  name: Scalars['String']['output'];
-  /** The wildcard value for the current domain */
-  wildcard?: Maybe<Scalars['String']['output']>;
+	__typename?: 'Domain';
+	/** Is the domain currently active? */
+	active?: Maybe< Scalars[ 'Boolean' ][ 'output' ] >;
+	/** The active certificate of the domain */
+	certificate?: Maybe< Certificate >;
+	/** The matching certificates of the domain */
+	certificates?: Maybe< CertificateList >;
+	/** The date the domain was added to the system */
+	createdAt?: Maybe< Scalars[ 'String' ][ 'output' ] >;
+	/** What is the IP of the domain and does it point to VIP? */
+	dns?: Maybe< DomainDnsRecord >;
+	/** The environment this domain belongs to */
+	environment?: Maybe< AppEnvironment >;
+	/** Does this domain have a valid TLS certificate? (Note: SSL is a misnomer there; we are using TLS certificates.) */
+	hasSSL?: Maybe< Scalars[ 'Boolean' ][ 'output' ] >;
+	/** The unique ID for the domain */
+	id?: Maybe< Scalars[ 'Int' ][ 'output' ] >;
+	/** Is this a default domain? (*.go-vip.co / *.go-vip.net) */
+	isDefault?: Maybe< Scalars[ 'Boolean' ][ 'output' ] >;
+	/** Is the domain using a Let's Encrypt certificate */
+	isLetsEncrypt?: Maybe< Scalars[ 'Boolean' ][ 'output' ] >;
+	/** Is this the primary domain for the environment? */
+	isPrimary?: Maybe< Scalars[ 'Boolean' ][ 'output' ] >;
+	/** What are the issues that may block LE provisioning for this domain? */
+	letsEncryptCompatibility?: Maybe< Array< Maybe< DomainLetsEncryptCompatibility > > >;
+	/** What is the status of LE provisioning? */
+	letsEncryptStatus?: Maybe< Array< Maybe< DomainLetsEncryptStatus > > >;
+	/** The domain name (i.e. something like example.com or sub.example.com) */
+	name: Scalars[ 'String' ][ 'output' ];
+	/** The wildcard value for the current domain */
+	wildcard?: Maybe< Scalars[ 'String' ][ 'output' ] >;
 };
-
 
 /** A domain for an environment */
 export type DomainCertificatesArgs = {
-  after?: InputMaybe<Scalars['String']['input']>;
-  first?: InputMaybe<Scalars['Int']['input']>;
+	after?: InputMaybe< Scalars[ 'String' ][ 'input' ] >;
+	first?: InputMaybe< Scalars[ 'Int' ][ 'input' ] >;
 };
 
 export type DomainDnsRecord = {
-  __typename?: 'DomainDNSRecord';
-  hasVIPHeaders?: Maybe<Scalars['Boolean']['output']>;
-  ip?: Maybe<Array<Maybe<Scalars['String']['output']>>>;
-  isVIP?: Maybe<Scalars['Boolean']['output']>;
+	__typename?: 'DomainDNSRecord';
+	hasVIPHeaders?: Maybe< Scalars[ 'Boolean' ][ 'output' ] >;
+	ip?: Maybe< Array< Maybe< Scalars[ 'String' ][ 'output' ] > > >;
+	isVIP?: Maybe< Scalars[ 'Boolean' ][ 'output' ] >;
 };
 
 export type DomainLetsEncryptCompatibility = {
-  __typename?: 'DomainLetsEncryptCompatibility';
-  actionable?: Maybe<Scalars['String']['output']>;
-  code?: Maybe<Scalars['String']['output']>;
-  domain?: Maybe<Scalars['String']['output']>;
-  explanation?: Maybe<Scalars['String']['output']>;
-  isDNSIssue?: Maybe<Scalars['Boolean']['output']>;
-  isFatal?: Maybe<Scalars['Boolean']['output']>;
-  title?: Maybe<Scalars['String']['output']>;
+	__typename?: 'DomainLetsEncryptCompatibility';
+	actionable?: Maybe< Scalars[ 'String' ][ 'output' ] >;
+	code?: Maybe< Scalars[ 'String' ][ 'output' ] >;
+	domain?: Maybe< Scalars[ 'String' ][ 'output' ] >;
+	explanation?: Maybe< Scalars[ 'String' ][ 'output' ] >;
+	isDNSIssue?: Maybe< Scalars[ 'Boolean' ][ 'output' ] >;
+	isFatal?: Maybe< Scalars[ 'Boolean' ][ 'output' ] >;
+	title?: Maybe< Scalars[ 'String' ][ 'output' ] >;
 };
 
 export type DomainLetsEncryptStatus = {
-  __typename?: 'DomainLetsEncryptStatus';
-  broken?: Maybe<Scalars['Boolean']['output']>;
-  errorMessage?: Maybe<Scalars['String']['output']>;
-  expirationDate?: Maybe<Scalars['String']['output']>;
-  failCount?: Maybe<Scalars['Int']['output']>;
-  lastErrorDateTime?: Maybe<Scalars['String']['output']>;
-  name?: Maybe<Scalars['String']['output']>;
-  retryDate?: Maybe<Scalars['String']['output']>;
+	__typename?: 'DomainLetsEncryptStatus';
+	broken?: Maybe< Scalars[ 'Boolean' ][ 'output' ] >;
+	errorMessage?: Maybe< Scalars[ 'String' ][ 'output' ] >;
+	expirationDate?: Maybe< Scalars[ 'String' ][ 'output' ] >;
+	failCount?: Maybe< Scalars[ 'Int' ][ 'output' ] >;
+	lastErrorDateTime?: Maybe< Scalars[ 'String' ][ 'output' ] >;
+	name?: Maybe< Scalars[ 'String' ][ 'output' ] >;
+	retryDate?: Maybe< Scalars[ 'String' ][ 'output' ] >;
 };
 
 export type DomainList = {
-  __typename?: 'DomainList';
-  nextCursor?: Maybe<Scalars['String']['output']>;
-  nodes?: Maybe<Array<Maybe<Domain>>>;
-  total?: Maybe<Scalars['Int']['output']>;
+	__typename?: 'DomainList';
+	nextCursor?: Maybe< Scalars[ 'String' ][ 'output' ] >;
+	nodes?: Maybe< Array< Maybe< Domain > > >;
+	total?: Maybe< Scalars[ 'Int' ][ 'output' ] >;
 };
 
 /** Customer-provided environment variable / constant */
 export type EnvironmentVariable = {
-  __typename?: 'EnvironmentVariable';
-  /** Environment variable name */
-  name: Scalars['String']['output'];
-  /** Environment variable value */
-  value?: Maybe<Scalars['String']['output']>;
+	__typename?: 'EnvironmentVariable';
+	/** Environment variable name */
+	name: Scalars[ 'String' ][ 'output' ];
+	/** Environment variable value */
+	value?: Maybe< Scalars[ 'String' ][ 'output' ] >;
 };
 
 export type EnvironmentVariableInput = {
-  /** The unique ID of the Application */
-  applicationId: Scalars['Int']['input'];
-  /** The unique ID of the environment */
-  environmentId: Scalars['Int']['input'];
-  /** Environment variable name (must consist of uppercase letters, numbers, and underscore */
-  name: Scalars['String']['input'];
-  /** Environment variable value */
-  value: Scalars['String']['input'];
+	/** The unique ID of the Application */
+	applicationId: Scalars[ 'Int' ][ 'input' ];
+	/** The unique ID of the environment */
+	environmentId: Scalars[ 'Int' ][ 'input' ];
+	/** Environment variable name (must consist of uppercase letters, numbers, and underscore */
+	name: Scalars[ 'String' ][ 'input' ];
+	/** Environment variable value */
+	value: Scalars[ 'String' ][ 'input' ];
 };
 
 /** Customer-provided environment variables / constants */
 export type EnvironmentVariablesList = {
-  __typename?: 'EnvironmentVariablesList';
-  /** The environment variables for this environment */
-  nodes?: Maybe<Array<Maybe<EnvironmentVariable>>>;
-  /** The total number of environment variables for this environment */
-  total?: Maybe<Scalars['BigInt']['output']>;
+	__typename?: 'EnvironmentVariablesList';
+	/** The environment variables for this environment */
+	nodes?: Maybe< Array< Maybe< EnvironmentVariable > > >;
+	/** The total number of environment variables for this environment */
+	total?: Maybe< Scalars[ 'BigInt' ][ 'output' ] >;
 };
 
 export type EnvironmentVariablesPayload = {
-  __typename?: 'EnvironmentVariablesPayload';
-  environmentVariables?: Maybe<EnvironmentVariablesList>;
+	__typename?: 'EnvironmentVariablesPayload';
+	environmentVariables?: Maybe< EnvironmentVariablesList >;
 };
 
 export type Feature = Model & {
-  __typename?: 'Feature';
-  active?: Maybe<Scalars['Boolean']['output']>;
-  appId?: Maybe<Scalars['Int']['output']>;
-  context?: Maybe<Scalars['String']['output']>;
-  id?: Maybe<Scalars['Int']['output']>;
-  name?: Maybe<Scalars['String']['output']>;
+	__typename?: 'Feature';
+	active?: Maybe< Scalars[ 'Boolean' ][ 'output' ] >;
+	appId?: Maybe< Scalars[ 'Int' ][ 'output' ] >;
+	context?: Maybe< Scalars[ 'String' ][ 'output' ] >;
+	id?: Maybe< Scalars[ 'Int' ][ 'output' ] >;
+	name?: Maybe< Scalars[ 'String' ][ 'output' ] >;
 };
 
 export type GitActor = {
-  __typename?: 'GitActor';
-  avatarUrl?: Maybe<Scalars['String']['output']>;
-  email?: Maybe<Scalars['String']['output']>;
-  name?: Maybe<Scalars['String']['output']>;
-  user?: Maybe<GitHubUser>;
+	__typename?: 'GitActor';
+	avatarUrl?: Maybe< Scalars[ 'String' ][ 'output' ] >;
+	email?: Maybe< Scalars[ 'String' ][ 'output' ] >;
+	name?: Maybe< Scalars[ 'String' ][ 'output' ] >;
+	user?: Maybe< GitHubUser >;
 };
 
-
 export type GitActorAvatarUrlArgs = {
-  size?: InputMaybe<Scalars['Int']['input']>;
+	size?: InputMaybe< Scalars[ 'Int' ][ 'input' ] >;
 };
 
 export type GitCommit = {
-  __typename?: 'GitCommit';
-  abbreviatedOid?: Maybe<Scalars['String']['output']>;
-  additions?: Maybe<Scalars['Int']['output']>;
-  author?: Maybe<GitActor>;
-  authoredDate?: Maybe<Scalars['String']['output']>;
-  committedDate?: Maybe<Scalars['String']['output']>;
-  deletions?: Maybe<Scalars['Int']['output']>;
-  message?: Maybe<Scalars['String']['output']>;
-  messageBody?: Maybe<Scalars['String']['output']>;
-  messageBodyHTML?: Maybe<Scalars['String']['output']>;
-  messageHeadline?: Maybe<Scalars['String']['output']>;
-  messageHeadlineHTML?: Maybe<Scalars['String']['output']>;
-  oid?: Maybe<Scalars['String']['output']>;
-  url?: Maybe<Scalars['String']['output']>;
+	__typename?: 'GitCommit';
+	abbreviatedOid?: Maybe< Scalars[ 'String' ][ 'output' ] >;
+	additions?: Maybe< Scalars[ 'Int' ][ 'output' ] >;
+	author?: Maybe< GitActor >;
+	authoredDate?: Maybe< Scalars[ 'String' ][ 'output' ] >;
+	committedDate?: Maybe< Scalars[ 'String' ][ 'output' ] >;
+	deletions?: Maybe< Scalars[ 'Int' ][ 'output' ] >;
+	message?: Maybe< Scalars[ 'String' ][ 'output' ] >;
+	messageBody?: Maybe< Scalars[ 'String' ][ 'output' ] >;
+	messageBodyHTML?: Maybe< Scalars[ 'String' ][ 'output' ] >;
+	messageHeadline?: Maybe< Scalars[ 'String' ][ 'output' ] >;
+	messageHeadlineHTML?: Maybe< Scalars[ 'String' ][ 'output' ] >;
+	oid?: Maybe< Scalars[ 'String' ][ 'output' ] >;
+	url?: Maybe< Scalars[ 'String' ][ 'output' ] >;
 };
 
 export type GitCommitList = {
-  __typename?: 'GitCommitList';
-  edges?: Maybe<Array<Maybe<GitCommit>>>;
-  nextCursor?: Maybe<Scalars['String']['output']>;
-  nodes?: Maybe<Array<Maybe<GitCommit>>>;
+	__typename?: 'GitCommitList';
+	edges?: Maybe< Array< Maybe< GitCommit > > >;
+	nextCursor?: Maybe< Scalars[ 'String' ][ 'output' ] >;
+	nodes?: Maybe< Array< Maybe< GitCommit > > >;
 };
 
 export type GitHubComment = {
-  __typename?: 'GitHubComment';
-  body?: Maybe<Scalars['String']['output']>;
-  createdAt?: Maybe<Scalars['String']['output']>;
-  htmlUrl?: Maybe<Scalars['String']['output']>;
-  id?: Maybe<Scalars['ID']['output']>;
-  issueUrl?: Maybe<Scalars['String']['output']>;
-  updatedAt?: Maybe<Scalars['String']['output']>;
-  url?: Maybe<Scalars['String']['output']>;
-  user?: Maybe<GitHubUser>;
+	__typename?: 'GitHubComment';
+	body?: Maybe< Scalars[ 'String' ][ 'output' ] >;
+	createdAt?: Maybe< Scalars[ 'String' ][ 'output' ] >;
+	htmlUrl?: Maybe< Scalars[ 'String' ][ 'output' ] >;
+	id?: Maybe< Scalars[ 'ID' ][ 'output' ] >;
+	issueUrl?: Maybe< Scalars[ 'String' ][ 'output' ] >;
+	updatedAt?: Maybe< Scalars[ 'String' ][ 'output' ] >;
+	url?: Maybe< Scalars[ 'String' ][ 'output' ] >;
+	user?: Maybe< GitHubUser >;
 };
 
 export type GitHubPullRequest = Model & {
-  __typename?: 'GitHubPullRequest';
-  assignee?: Maybe<GitHubUser>;
-  assignees?: Maybe<Array<Maybe<GitHubUser>>>;
-  body?: Maybe<Scalars['String']['output']>;
-  closedAt?: Maybe<Scalars['String']['output']>;
-  comments?: Maybe<Scalars['Int']['output']>;
-  commentsUrl?: Maybe<Scalars['String']['output']>;
-  commitsUrl?: Maybe<Scalars['String']['output']>;
-  createdAt?: Maybe<Scalars['String']['output']>;
-  eventsUrl?: Maybe<Scalars['String']['output']>;
-  id?: Maybe<Scalars['Int']['output']>;
-  initialCommit?: Maybe<Scalars['String']['output']>;
-  labels?: Maybe<Array<Maybe<Scalars['String']['output']>>>;
-  labelsUrl?: Maybe<Scalars['String']['output']>;
-  locked?: Maybe<Scalars['Boolean']['output']>;
-  number?: Maybe<Scalars['Int']['output']>;
-  repositoryUrl?: Maybe<Scalars['String']['output']>;
-  status?: Maybe<Scalars['String']['output']>;
-  title?: Maybe<Scalars['String']['output']>;
-  totalCommits?: Maybe<Scalars['Int']['output']>;
-  updatedAt?: Maybe<Scalars['String']['output']>;
-  url?: Maybe<Scalars['String']['output']>;
-  user?: Maybe<GitHubUser>;
-  vipMeta?: Maybe<VipprMeta>;
+	__typename?: 'GitHubPullRequest';
+	assignee?: Maybe< GitHubUser >;
+	assignees?: Maybe< Array< Maybe< GitHubUser > > >;
+	body?: Maybe< Scalars[ 'String' ][ 'output' ] >;
+	closedAt?: Maybe< Scalars[ 'String' ][ 'output' ] >;
+	comments?: Maybe< Scalars[ 'Int' ][ 'output' ] >;
+	commentsUrl?: Maybe< Scalars[ 'String' ][ 'output' ] >;
+	commitsUrl?: Maybe< Scalars[ 'String' ][ 'output' ] >;
+	createdAt?: Maybe< Scalars[ 'String' ][ 'output' ] >;
+	eventsUrl?: Maybe< Scalars[ 'String' ][ 'output' ] >;
+	id?: Maybe< Scalars[ 'Int' ][ 'output' ] >;
+	initialCommit?: Maybe< Scalars[ 'String' ][ 'output' ] >;
+	labels?: Maybe< Array< Maybe< Scalars[ 'String' ][ 'output' ] > > >;
+	labelsUrl?: Maybe< Scalars[ 'String' ][ 'output' ] >;
+	locked?: Maybe< Scalars[ 'Boolean' ][ 'output' ] >;
+	number?: Maybe< Scalars[ 'Int' ][ 'output' ] >;
+	repositoryUrl?: Maybe< Scalars[ 'String' ][ 'output' ] >;
+	status?: Maybe< Scalars[ 'String' ][ 'output' ] >;
+	title?: Maybe< Scalars[ 'String' ][ 'output' ] >;
+	totalCommits?: Maybe< Scalars[ 'Int' ][ 'output' ] >;
+	updatedAt?: Maybe< Scalars[ 'String' ][ 'output' ] >;
+	url?: Maybe< Scalars[ 'String' ][ 'output' ] >;
+	user?: Maybe< GitHubUser >;
+	vipMeta?: Maybe< VipprMeta >;
 };
 
 export type GitHubPullRequestList = ModelList & {
-  __typename?: 'GitHubPullRequestList';
-  edges?: Maybe<Array<Maybe<GitHubPullRequest>>>;
-  nextCursor?: Maybe<Scalars['String']['output']>;
-  nodes?: Maybe<Array<Maybe<GitHubPullRequest>>>;
-  total?: Maybe<Scalars['Int']['output']>;
+	__typename?: 'GitHubPullRequestList';
+	edges?: Maybe< Array< Maybe< GitHubPullRequest > > >;
+	nextCursor?: Maybe< Scalars[ 'String' ][ 'output' ] >;
+	nodes?: Maybe< Array< Maybe< GitHubPullRequest > > >;
+	total?: Maybe< Scalars[ 'Int' ][ 'output' ] >;
 };
 
 export type GitHubPullRequestReviewComment = {
-  __typename?: 'GitHubPullRequestReviewComment';
-  body?: Maybe<Scalars['String']['output']>;
-  commitId?: Maybe<Scalars['String']['output']>;
-  createdAt?: Maybe<Scalars['String']['output']>;
-  diffHunk?: Maybe<Scalars['String']['output']>;
-  htmlUrl?: Maybe<Scalars['String']['output']>;
-  id?: Maybe<Scalars['ID']['output']>;
-  originalCommitId?: Maybe<Scalars['String']['output']>;
-  originalPosition?: Maybe<Scalars['Int']['output']>;
-  path?: Maybe<Scalars['String']['output']>;
-  position?: Maybe<Scalars['Int']['output']>;
-  pullRequestUrl?: Maybe<Scalars['String']['output']>;
-  pullRequest_review_id?: Maybe<Scalars['Int']['output']>;
-  updatedAt?: Maybe<Scalars['String']['output']>;
-  url?: Maybe<Scalars['String']['output']>;
-  user?: Maybe<GitHubUser>;
+	__typename?: 'GitHubPullRequestReviewComment';
+	body?: Maybe< Scalars[ 'String' ][ 'output' ] >;
+	commitId?: Maybe< Scalars[ 'String' ][ 'output' ] >;
+	createdAt?: Maybe< Scalars[ 'String' ][ 'output' ] >;
+	diffHunk?: Maybe< Scalars[ 'String' ][ 'output' ] >;
+	htmlUrl?: Maybe< Scalars[ 'String' ][ 'output' ] >;
+	id?: Maybe< Scalars[ 'ID' ][ 'output' ] >;
+	originalCommitId?: Maybe< Scalars[ 'String' ][ 'output' ] >;
+	originalPosition?: Maybe< Scalars[ 'Int' ][ 'output' ] >;
+	path?: Maybe< Scalars[ 'String' ][ 'output' ] >;
+	position?: Maybe< Scalars[ 'Int' ][ 'output' ] >;
+	pullRequestUrl?: Maybe< Scalars[ 'String' ][ 'output' ] >;
+	pullRequest_review_id?: Maybe< Scalars[ 'Int' ][ 'output' ] >;
+	updatedAt?: Maybe< Scalars[ 'String' ][ 'output' ] >;
+	url?: Maybe< Scalars[ 'String' ][ 'output' ] >;
+	user?: Maybe< GitHubUser >;
 };
 
 export type GitHubReview = {
-  __typename?: 'GitHubReview';
-  body?: Maybe<Scalars['String']['output']>;
-  commitId?: Maybe<Scalars['String']['output']>;
-  htmlUrl?: Maybe<Scalars['String']['output']>;
-  id?: Maybe<Scalars['ID']['output']>;
-  pullRequestUrl?: Maybe<Scalars['String']['output']>;
-  state?: Maybe<Scalars['String']['output']>;
-  submittedAt?: Maybe<Scalars['String']['output']>;
-  user?: Maybe<GitHubUser>;
+	__typename?: 'GitHubReview';
+	body?: Maybe< Scalars[ 'String' ][ 'output' ] >;
+	commitId?: Maybe< Scalars[ 'String' ][ 'output' ] >;
+	htmlUrl?: Maybe< Scalars[ 'String' ][ 'output' ] >;
+	id?: Maybe< Scalars[ 'ID' ][ 'output' ] >;
+	pullRequestUrl?: Maybe< Scalars[ 'String' ][ 'output' ] >;
+	state?: Maybe< Scalars[ 'String' ][ 'output' ] >;
+	submittedAt?: Maybe< Scalars[ 'String' ][ 'output' ] >;
+	user?: Maybe< GitHubUser >;
 };
 
 export type GitHubUser = {
-  __typename?: 'GitHubUser';
-  avatarUrl?: Maybe<Scalars['String']['output']>;
-  eventsUrl?: Maybe<Scalars['String']['output']>;
-  followersUrl?: Maybe<Scalars['String']['output']>;
-  followingUrl?: Maybe<Scalars['String']['output']>;
-  gistsUrl?: Maybe<Scalars['String']['output']>;
-  gravatarId?: Maybe<Scalars['String']['output']>;
-  htmlUrl?: Maybe<Scalars['String']['output']>;
-  id?: Maybe<Scalars['ID']['output']>;
-  login?: Maybe<Scalars['String']['output']>;
-  organizationsUrl?: Maybe<Scalars['String']['output']>;
-  receivedEventsUrl?: Maybe<Scalars['String']['output']>;
-  reposUrl?: Maybe<Scalars['String']['output']>;
-  siteAdmin?: Maybe<Scalars['Boolean']['output']>;
-  starredUrl?: Maybe<Scalars['String']['output']>;
-  subscriptionsUrl?: Maybe<Scalars['String']['output']>;
-  type?: Maybe<Scalars['String']['output']>;
-  url?: Maybe<Scalars['String']['output']>;
+	__typename?: 'GitHubUser';
+	avatarUrl?: Maybe< Scalars[ 'String' ][ 'output' ] >;
+	eventsUrl?: Maybe< Scalars[ 'String' ][ 'output' ] >;
+	followersUrl?: Maybe< Scalars[ 'String' ][ 'output' ] >;
+	followingUrl?: Maybe< Scalars[ 'String' ][ 'output' ] >;
+	gistsUrl?: Maybe< Scalars[ 'String' ][ 'output' ] >;
+	gravatarId?: Maybe< Scalars[ 'String' ][ 'output' ] >;
+	htmlUrl?: Maybe< Scalars[ 'String' ][ 'output' ] >;
+	id?: Maybe< Scalars[ 'ID' ][ 'output' ] >;
+	login?: Maybe< Scalars[ 'String' ][ 'output' ] >;
+	organizationsUrl?: Maybe< Scalars[ 'String' ][ 'output' ] >;
+	receivedEventsUrl?: Maybe< Scalars[ 'String' ][ 'output' ] >;
+	reposUrl?: Maybe< Scalars[ 'String' ][ 'output' ] >;
+	siteAdmin?: Maybe< Scalars[ 'Boolean' ][ 'output' ] >;
+	starredUrl?: Maybe< Scalars[ 'String' ][ 'output' ] >;
+	subscriptionsUrl?: Maybe< Scalars[ 'String' ][ 'output' ] >;
+	type?: Maybe< Scalars[ 'String' ][ 'output' ] >;
+	url?: Maybe< Scalars[ 'String' ][ 'output' ] >;
 };
 
 export type GitRepository = {
-  __typename?: 'GitRepository';
-  fullName?: Maybe<Scalars['String']['output']>;
-  htmlUrl?: Maybe<Scalars['String']['output']>;
-  name?: Maybe<Scalars['String']['output']>;
-  organization?: Maybe<Scalars['String']['output']>;
-  platform?: Maybe<Scalars['String']['output']>;
+	__typename?: 'GitRepository';
+	fullName?: Maybe< Scalars[ 'String' ][ 'output' ] >;
+	htmlUrl?: Maybe< Scalars[ 'String' ][ 'output' ] >;
+	name?: Maybe< Scalars[ 'String' ][ 'output' ] >;
+	organization?: Maybe< Scalars[ 'String' ][ 'output' ] >;
+	platform?: Maybe< Scalars[ 'String' ][ 'output' ] >;
 };
 
 export type IdentityProvider = Model & {
-  __typename?: 'IdentityProvider';
-  active?: Maybe<Scalars['Boolean']['output']>;
-  certificate?: Maybe<Scalars['String']['output']>;
-  certificateExpiryDate?: Maybe<Scalars['String']['output']>;
-  createdAt?: Maybe<Scalars['String']['output']>;
-  displayName?: Maybe<Scalars['String']['output']>;
-  entryPoint?: Maybe<Scalars['String']['output']>;
-  firstSuccessfulLogin?: Maybe<Scalars['String']['output']>;
-  id?: Maybe<Scalars['Int']['output']>;
-  issuer?: Maybe<Scalars['String']['output']>;
-  organizationId?: Maybe<Scalars['Int']['output']>;
-  provider?: Maybe<Scalars['String']['output']>;
-  secondaryCertificate?: Maybe<Scalars['String']['output']>;
-  secondaryCertificateExpiryDate?: Maybe<Scalars['String']['output']>;
-  signingCertificateExpiryDate?: Maybe<Scalars['String']['output']>;
-  signingCertificatePublicKey?: Maybe<Scalars['String']['output']>;
-  slug?: Maybe<Scalars['String']['output']>;
-  updatedAt?: Maybe<Scalars['String']['output']>;
+	__typename?: 'IdentityProvider';
+	active?: Maybe< Scalars[ 'Boolean' ][ 'output' ] >;
+	certificate?: Maybe< Scalars[ 'String' ][ 'output' ] >;
+	certificateExpiryDate?: Maybe< Scalars[ 'String' ][ 'output' ] >;
+	createdAt?: Maybe< Scalars[ 'String' ][ 'output' ] >;
+	displayName?: Maybe< Scalars[ 'String' ][ 'output' ] >;
+	entryPoint?: Maybe< Scalars[ 'String' ][ 'output' ] >;
+	firstSuccessfulLogin?: Maybe< Scalars[ 'String' ][ 'output' ] >;
+	id?: Maybe< Scalars[ 'Int' ][ 'output' ] >;
+	issuer?: Maybe< Scalars[ 'String' ][ 'output' ] >;
+	organizationId?: Maybe< Scalars[ 'Int' ][ 'output' ] >;
+	provider?: Maybe< Scalars[ 'String' ][ 'output' ] >;
+	secondaryCertificate?: Maybe< Scalars[ 'String' ][ 'output' ] >;
+	secondaryCertificateExpiryDate?: Maybe< Scalars[ 'String' ][ 'output' ] >;
+	signingCertificateExpiryDate?: Maybe< Scalars[ 'String' ][ 'output' ] >;
+	signingCertificatePublicKey?: Maybe< Scalars[ 'String' ][ 'output' ] >;
+	slug?: Maybe< Scalars[ 'String' ][ 'output' ] >;
+	updatedAt?: Maybe< Scalars[ 'String' ][ 'output' ] >;
 };
 
 export type IdentityProviderList = ModelList & {
-  __typename?: 'IdentityProviderList';
-  nextCursor?: Maybe<Scalars['String']['output']>;
-  nodes?: Maybe<Array<Maybe<IdentityProvider>>>;
-  total?: Maybe<Scalars['Int']['output']>;
+	__typename?: 'IdentityProviderList';
+	nextCursor?: Maybe< Scalars[ 'String' ][ 'output' ] >;
+	nodes?: Maybe< Array< Maybe< IdentityProvider > > >;
+	total?: Maybe< Scalars[ 'Int' ][ 'output' ] >;
 };
 
 export type Invitation = Model & {
-  __typename?: 'Invitation';
-  acceptedAt?: Maybe<Scalars['String']['output']>;
-  createdAt?: Maybe<Scalars['String']['output']>;
-  emailAddress?: Maybe<Scalars['String']['output']>;
-  expiresAt?: Maybe<Scalars['String']['output']>;
-  grantedPermissions?: Maybe<InvitationPermissions>;
-  id?: Maybe<Scalars['Int']['output']>;
-  invitingUser?: Maybe<User>;
-  isCancelable?: Maybe<Scalars['Boolean']['output']>;
-  isResendable?: Maybe<Scalars['Boolean']['output']>;
-  organization?: Maybe<Organization>;
-  status?: Maybe<Scalars['String']['output']>;
+	__typename?: 'Invitation';
+	acceptedAt?: Maybe< Scalars[ 'String' ][ 'output' ] >;
+	createdAt?: Maybe< Scalars[ 'String' ][ 'output' ] >;
+	emailAddress?: Maybe< Scalars[ 'String' ][ 'output' ] >;
+	expiresAt?: Maybe< Scalars[ 'String' ][ 'output' ] >;
+	grantedPermissions?: Maybe< InvitationPermissions >;
+	id?: Maybe< Scalars[ 'Int' ][ 'output' ] >;
+	invitingUser?: Maybe< User >;
+	isCancelable?: Maybe< Scalars[ 'Boolean' ][ 'output' ] >;
+	isResendable?: Maybe< Scalars[ 'Boolean' ][ 'output' ] >;
+	organization?: Maybe< Organization >;
+	status?: Maybe< Scalars[ 'String' ][ 'output' ] >;
 };
 
 export type InvitationList = {
-  __typename?: 'InvitationList';
-  nextCursor?: Maybe<Scalars['String']['output']>;
-  nodes?: Maybe<Array<Maybe<Invitation>>>;
-  total?: Maybe<Scalars['Int']['output']>;
+	__typename?: 'InvitationList';
+	nextCursor?: Maybe< Scalars[ 'String' ][ 'output' ] >;
+	nodes?: Maybe< Array< Maybe< Invitation > > >;
+	total?: Maybe< Scalars[ 'Int' ][ 'output' ] >;
 };
 
 export type InvitationPermissions = {
-  __typename?: 'InvitationPermissions';
-  applicationRoles?: Maybe<Array<Maybe<InvitationPermissionsApplicationRole>>>;
-  organizationRoleId?: Maybe<Scalars['String']['output']>;
+	__typename?: 'InvitationPermissions';
+	applicationRoles?: Maybe< Array< Maybe< InvitationPermissionsApplicationRole > > >;
+	organizationRoleId?: Maybe< Scalars[ 'String' ][ 'output' ] >;
 };
 
 export type InvitationPermissionsApplicationRole = {
-  __typename?: 'InvitationPermissionsApplicationRole';
-  app?: Maybe<App>;
-  appId?: Maybe<Scalars['Int']['output']>;
-  role?: Maybe<ApplicationRole>;
-  roleId?: Maybe<ApplicationRoleId>;
+	__typename?: 'InvitationPermissionsApplicationRole';
+	app?: Maybe< App >;
+	appId?: Maybe< Scalars[ 'Int' ][ 'output' ] >;
+	role?: Maybe< ApplicationRole >;
+	roleId?: Maybe< ApplicationRoleId >;
 };
 
 export type InvitationPermissionsApplicationRoleInput = {
-  appId?: InputMaybe<Scalars['Int']['input']>;
-  roleId?: InputMaybe<ApplicationRoleId>;
+	appId?: InputMaybe< Scalars[ 'Int' ][ 'input' ] >;
+	roleId?: InputMaybe< ApplicationRoleId >;
 };
 
 export type InvitationPermissionsInput = {
-  applicationRoles?: InputMaybe<Array<InputMaybe<InvitationPermissionsApplicationRoleInput>>>;
-  organizationRoleId?: InputMaybe<OrgRoleId>;
+	applicationRoles?: InputMaybe< Array< InputMaybe< InvitationPermissionsApplicationRoleInput > > >;
+	organizationRoleId?: InputMaybe< OrgRoleId >;
 };
 
 export type Job = JobInterface & {
-  __typename?: 'Job';
-  completedAt?: Maybe<Scalars['String']['output']>;
-  createdAt?: Maybe<Scalars['String']['output']>;
-  id?: Maybe<Scalars['Int']['output']>;
-  inProgressLock?: Maybe<Scalars['Boolean']['output']>;
-  metadata?: Maybe<Array<Maybe<JobMetadata>>>;
-  progress?: Maybe<JobProgress>;
-  type?: Maybe<Scalars['String']['output']>;
+	__typename?: 'Job';
+	completedAt?: Maybe< Scalars[ 'String' ][ 'output' ] >;
+	createdAt?: Maybe< Scalars[ 'String' ][ 'output' ] >;
+	id?: Maybe< Scalars[ 'Int' ][ 'output' ] >;
+	inProgressLock?: Maybe< Scalars[ 'Boolean' ][ 'output' ] >;
+	metadata?: Maybe< Array< Maybe< JobMetadata > > >;
+	progress?: Maybe< JobProgress >;
+	type?: Maybe< Scalars[ 'String' ][ 'output' ] >;
 };
 
 export type JobInterface = {
-  completedAt?: Maybe<Scalars['String']['output']>;
-  createdAt?: Maybe<Scalars['String']['output']>;
-  id?: Maybe<Scalars['Int']['output']>;
-  inProgressLock?: Maybe<Scalars['Boolean']['output']>;
-  metadata?: Maybe<Array<Maybe<JobMetadata>>>;
-  progress?: Maybe<JobProgress>;
-  type?: Maybe<Scalars['String']['output']>;
+	completedAt?: Maybe< Scalars[ 'String' ][ 'output' ] >;
+	createdAt?: Maybe< Scalars[ 'String' ][ 'output' ] >;
+	id?: Maybe< Scalars[ 'Int' ][ 'output' ] >;
+	inProgressLock?: Maybe< Scalars[ 'Boolean' ][ 'output' ] >;
+	metadata?: Maybe< Array< Maybe< JobMetadata > > >;
+	progress?: Maybe< JobProgress >;
+	type?: Maybe< Scalars[ 'String' ][ 'output' ] >;
 };
 
 export type JobMetadata = {
-  __typename?: 'JobMetadata';
-  name?: Maybe<Scalars['String']['output']>;
-  value?: Maybe<Scalars['String']['output']>;
+	__typename?: 'JobMetadata';
+	name?: Maybe< Scalars[ 'String' ][ 'output' ] >;
+	value?: Maybe< Scalars[ 'String' ][ 'output' ] >;
 };
 
 export type JobProgress = {
-  __typename?: 'JobProgress';
-  status?: Maybe<Scalars['String']['output']>;
-  steps?: Maybe<Array<Maybe<JobProgressStep>>>;
+	__typename?: 'JobProgress';
+	status?: Maybe< Scalars[ 'String' ][ 'output' ] >;
+	steps?: Maybe< Array< Maybe< JobProgressStep > > >;
 };
 
 export type JobProgressStep = {
-  __typename?: 'JobProgressStep';
-  id?: Maybe<Scalars['String']['output']>;
-  name?: Maybe<Scalars['String']['output']>;
-  status?: Maybe<Scalars['String']['output']>;
-  step?: Maybe<Scalars['String']['output']>;
+	__typename?: 'JobProgressStep';
+	id?: Maybe< Scalars[ 'String' ][ 'output' ] >;
+	name?: Maybe< Scalars[ 'String' ][ 'output' ] >;
+	status?: Maybe< Scalars[ 'String' ][ 'output' ] >;
+	step?: Maybe< Scalars[ 'String' ][ 'output' ] >;
 };
 
 export type MediaExport = {
-  __typename?: 'MediaExport';
-  createdAt?: Maybe<Scalars['String']['output']>;
-  environmentId?: Maybe<Scalars['Int']['output']>;
-  error?: Maybe<MediaExportError>;
-  expiresAt?: Maybe<Scalars['String']['output']>;
-  filesProcessed?: Maybe<Scalars['Int']['output']>;
-  filesTotal?: Maybe<Scalars['Int']['output']>;
-  id?: Maybe<Scalars['Int']['output']>;
-  status?: Maybe<Scalars['String']['output']>;
-  subsite?: Maybe<WpSite>;
-  totalSizeInBytes?: Maybe<Scalars['Float']['output']>;
-  user?: Maybe<WpcliCommandUser>;
+	__typename?: 'MediaExport';
+	createdAt?: Maybe< Scalars[ 'String' ][ 'output' ] >;
+	environmentId?: Maybe< Scalars[ 'Int' ][ 'output' ] >;
+	error?: Maybe< MediaExportError >;
+	expiresAt?: Maybe< Scalars[ 'String' ][ 'output' ] >;
+	filesProcessed?: Maybe< Scalars[ 'Int' ][ 'output' ] >;
+	filesTotal?: Maybe< Scalars[ 'Int' ][ 'output' ] >;
+	id?: Maybe< Scalars[ 'Int' ][ 'output' ] >;
+	status?: Maybe< Scalars[ 'String' ][ 'output' ] >;
+	subsite?: Maybe< WpSite >;
+	totalSizeInBytes?: Maybe< Scalars[ 'Float' ][ 'output' ] >;
+	user?: Maybe< WpcliCommandUser >;
 };
 
 export type MediaExportError = {
-  __typename?: 'MediaExportError';
-  globalErrors?: Maybe<Array<Maybe<Scalars['String']['output']>>>;
-  hasFileErrors?: Maybe<Scalars['Boolean']['output']>;
+	__typename?: 'MediaExportError';
+	globalErrors?: Maybe< Array< Maybe< Scalars[ 'String' ][ 'output' ] > > >;
+	hasFileErrors?: Maybe< Scalars[ 'Boolean' ][ 'output' ] >;
 };
 
 export type MediaExportsList = {
-  __typename?: 'MediaExportsList';
-  nextCursor?: Maybe<Scalars['String']['output']>;
-  nodes?: Maybe<Array<Maybe<MediaExport>>>;
-  total?: Maybe<Scalars['Int']['output']>;
+	__typename?: 'MediaExportsList';
+	nextCursor?: Maybe< Scalars[ 'String' ][ 'output' ] >;
+	nodes?: Maybe< Array< Maybe< MediaExport > > >;
+	total?: Maybe< Scalars[ 'Int' ][ 'output' ] >;
 };
 
 export type MetricMeasurement = {
-  __typename?: 'MetricMeasurement';
-  baseline?: Maybe<Scalars['Float']['output']>;
-  timestamp: Scalars['String']['output'];
-  value: Scalars['Float']['output'];
+	__typename?: 'MetricMeasurement';
+	baseline?: Maybe< Scalars[ 'Float' ][ 'output' ] >;
+	timestamp: Scalars[ 'String' ][ 'output' ];
+	value: Scalars[ 'Float' ][ 'output' ];
 };
 
 export type Model = {
-  id?: Maybe<Scalars['Int']['output']>;
+	id?: Maybe< Scalars[ 'Int' ][ 'output' ] >;
 };
 
 export type ModelList = {
-  nextCursor?: Maybe<Scalars['String']['output']>;
-  nodes?: Maybe<Array<Maybe<Model>>>;
-  total?: Maybe<Scalars['Int']['output']>;
+	nextCursor?: Maybe< Scalars[ 'String' ][ 'output' ] >;
+	nodes?: Maybe< Array< Maybe< Model > > >;
+	total?: Maybe< Scalars[ 'Int' ][ 'output' ] >;
 };
 
 export type Mutation = {
-  __typename?: 'Mutation';
-  abortMediaImport?: Maybe<AppEnvironmentAbortMediaImportPayload>;
-  /** Accept an invitation to an organization */
-  acceptInvitation?: Maybe<AcceptInvitationPayload>;
-  activateCertificate?: Maybe<ActivateCertificatePayload>;
-  /** Activate a Let's Encrypt TLS certificate for a domain */
-  activateLetsEncryptOnDomainForAppEnvironment?: Maybe<AppEnvironmentActivateLetsEncryptOnDomainPayload>;
-  addBasicAuth?: Maybe<AppEnvironmentBasicAuthPayload>;
-  addCertificate?: Maybe<AddCertificatePayload>;
-  /** Add a domain to an environment */
-  addDomainToAppEnvironment?: Maybe<AppEnvironmentAddDomainPayload>;
-  /** Environment variables */
-  addEnvironmentVariable?: Maybe<EnvironmentVariablesPayload>;
-  /** Notifications */
-  addNotificationRecipient?: Maybe<AddNotificationRecipientPayload>;
-  addNotificationSubscription?: Maybe<AddNotificationSubscriptionPayload>;
-  /** Request stats */
-  addRequestStats?: Maybe<AppEnvironmentAddRequestStatsPayload>;
-  /** Cancel an invitation to an organization */
-  cancelInvitation?: Maybe<CancelInvitationPayload>;
-  /** Stop a running WP-CLI command */
-  cancelWPCLICommand?: Maybe<CancelWpcliCommandPayload>;
-  /** TLS Management */
-  createCSR?: Maybe<CreateCsrPayload>;
-  /** Invite a user to an organization */
-  createInvitation?: Maybe<CreateInvitationPayload>;
-  createUser?: Maybe<CreateUserPayload>;
-  /** Remove a domain from an environment */
-  deactivateDomainOnAppEnvironment?: Maybe<AppEnvironmentDeactivateDomainPayload>;
-  /** Debug page cache object */
-  debugPageCache?: Maybe<DebugPageCachePayload>;
-  decodeCSR?: Maybe<CsrDecoded>;
-  deleteBackupShippingConfig?: Maybe<AppEnvironmentBackupShippingPayload>;
-  deleteBasicAuth?: Maybe<AppEnvironmentBasicAuthPayload>;
-  deleteCertificate?: Maybe<DeleteCertificatePayload>;
-  deleteEnvironmentVariable?: Maybe<EnvironmentVariablesPayload>;
-  /** Delete one or more IPs from the IP Allow List for an environment */
-  deleteIPAllowList?: Maybe<AppEnvironmentIpAllowListPayload>;
-  deleteLogShippingConfig?: Maybe<AppEnvironmentLogShippingPayload>;
-  deleteNotificationRecipient?: Maybe<DeleteNotificationRecipientPayload>;
-  deleteNotificationSubscription?: Maybe<DeleteNotificationSubscriptionPayload>;
-  deleteOrganizationAuthDomain?: Maybe<OrganizationAuthDomainDeletePayload>;
-  disableBackupShipping?: Maybe<AppEnvironmentBackupShippingPayload>;
-  disableFeature?: Maybe<AppFeaturePayload>;
-  disableLogShipping?: Maybe<AppEnvironmentLogShippingPayload>;
-  editBasicAuth?: Maybe<AppEnvironmentBasicAuthPayload>;
-  enableBackupShipping?: Maybe<AppEnvironmentBackupShippingPayload>;
-  enableFeature?: Maybe<AppFeaturePayload>;
-  enableLaunchMode?: Maybe<AppEnvironmentEnableLaunchModePayload>;
-  enableLogShipping?: Maybe<AppEnvironmentLogShippingPayload>;
-  /** Generate a presigned download URL to a previously copied database backup */
-  generateDBBackupCopyUrl?: Maybe<AppEnvironmentGenerateDbBackupCopyUrlPayload>;
-  generateMediaExportSignedUrl?: Maybe<AppEnvironmentGenerateMediaExportSignedUrlPayload>;
-  generateUserToken?: Maybe<UserTokenGenerationPayload>;
-  launchApplication?: Maybe<AppEnvironmentLaunchedPayload>;
-  /** Purge page cache object(s) */
-  purgePageCache?: Maybe<PurgePageCachePayload>;
-  /** Remove a user from an organization (removes all roles and applications permissions) */
-  removeUserFromOrganization?: Maybe<RemoveUserFromOrganizationPayload>;
-  /** Replace all IPs in the IP Allow List for an environment */
-  replaceIPAllowList?: Maybe<AppEnvironmentIpAllowListPayload>;
-  /** Resend an invitation to an organization */
-  resendInvitation?: Maybe<ResendInvitationPayload>;
-  /** Rollback */
-  rollback?: Maybe<RollbackPayload>;
-  /** Organization Auth Domains */
-  saveOrganizationAuthDomain?: Maybe<OrganizationAuthDomainPayload>;
-  sendTestNotification?: Maybe<SendTestNotificationPayload>;
-  setUserApplicationRoles?: Maybe<SetUserApplicationRolesPayload>;
-  setUserOrganizationRole?: Maybe<UpdateUserOrganizationRolePayload>;
-  startDBBackupCopy?: Maybe<AppEnvironmentStartDbBackupCopyPayload>;
-  startImport?: Maybe<AppEnvironmentImportPayload>;
-  /** Media Exports */
-  startMediaExport?: Maybe<StartMediaExportPayload>;
-  /** Import Media into your Production Environment */
-  startMediaImport?: Maybe<AppEnvironmentMediaImportPayload>;
-  /** Switch the primary domain for an environment */
-  switchEnvironmentPrimaryDomain?: Maybe<AppEnvironmentPrimaryDomainSwitchPayload>;
-  syncEnvironment?: Maybe<AppEnvironmentSyncPayload>;
-  toggleVIPStatus?: Maybe<ToggleUserVipStatusPayload>;
-  triggerDatabaseBackup?: Maybe<AppEnvironmentTriggerDbBackupPayload>;
-  /** Execute a WP-CLI command on an environment */
-  triggerWPCLICommandOnAppEnvironment?: Maybe<AppEnvironmentTriggerWpcliCommandPayload>;
-  updateBackupShippingConfig?: Maybe<AppEnvironmentBackupShippingPayload>;
-  updateCertificate?: Maybe<UpdateCertificatePayload>;
-  /** Network Sites */
-  updateEnvironmentSubsiteDomain?: Maybe<AppEnvironmentUpdateSubsiteDomainPayload>;
-  updateEnvironmentVariable?: Maybe<EnvironmentVariablesPayload>;
-  /** HSTS Settings */
-  updateHSTSSettings?: Maybe<AppEnvironmentHstsSettingsPayload>;
-  /** Add one or more IPs to the IP Allow List for an environment */
-  updateIPAllowList?: Maybe<AppEnvironmentIpAllowListPayload>;
-  updateLogShippingConfig?: Maybe<AppEnvironmentLogShippingPayload>;
-  updateNotificationRecipient?: Maybe<UpdateNotificationRecipientPayload>;
-  updateNotificationSubscription?: Maybe<UpdateNotificationSubscriptionPayload>;
-  /** Plugin Update */
-  updatePlugin?: Maybe<CodebaseUpdatePluginResult>;
-  /** Software Settings */
-  updateSoftwareSettings?: Maybe<AppEnvironmentSoftwareSettings>;
-  updateWPSiteLaunchStatus?: Maybe<WpSiteLaunchStatusPayload>;
-  validateLogShippingConfig?: Maybe<AppEnvironmentLogShippingValidationPayload>;
+	__typename?: 'Mutation';
+	abortMediaImport?: Maybe< AppEnvironmentAbortMediaImportPayload >;
+	/** Accept an invitation to an organization */
+	acceptInvitation?: Maybe< AcceptInvitationPayload >;
+	activateCertificate?: Maybe< ActivateCertificatePayload >;
+	/** Activate a Let's Encrypt TLS certificate for a domain */
+	activateLetsEncryptOnDomainForAppEnvironment?: Maybe< AppEnvironmentActivateLetsEncryptOnDomainPayload >;
+	addBasicAuth?: Maybe< AppEnvironmentBasicAuthPayload >;
+	addCertificate?: Maybe< AddCertificatePayload >;
+	/** Add a domain to an environment */
+	addDomainToAppEnvironment?: Maybe< AppEnvironmentAddDomainPayload >;
+	/** Environment variables */
+	addEnvironmentVariable?: Maybe< EnvironmentVariablesPayload >;
+	/** Notifications */
+	addNotificationRecipient?: Maybe< AddNotificationRecipientPayload >;
+	addNotificationSubscription?: Maybe< AddNotificationSubscriptionPayload >;
+	/** Request stats */
+	addRequestStats?: Maybe< AppEnvironmentAddRequestStatsPayload >;
+	/** Cancel an invitation to an organization */
+	cancelInvitation?: Maybe< CancelInvitationPayload >;
+	/** Stop a running WP-CLI command */
+	cancelWPCLICommand?: Maybe< CancelWpcliCommandPayload >;
+	/** TLS Management */
+	createCSR?: Maybe< CreateCsrPayload >;
+	/** Invite a user to an organization */
+	createInvitation?: Maybe< CreateInvitationPayload >;
+	createUser?: Maybe< CreateUserPayload >;
+	/** Remove a domain from an environment */
+	deactivateDomainOnAppEnvironment?: Maybe< AppEnvironmentDeactivateDomainPayload >;
+	/** Debug page cache object */
+	debugPageCache?: Maybe< DebugPageCachePayload >;
+	decodeCSR?: Maybe< CsrDecoded >;
+	deleteBackupShippingConfig?: Maybe< AppEnvironmentBackupShippingPayload >;
+	deleteBasicAuth?: Maybe< AppEnvironmentBasicAuthPayload >;
+	deleteCertificate?: Maybe< DeleteCertificatePayload >;
+	deleteEnvironmentVariable?: Maybe< EnvironmentVariablesPayload >;
+	/** Delete one or more IPs from the IP Allow List for an environment */
+	deleteIPAllowList?: Maybe< AppEnvironmentIpAllowListPayload >;
+	deleteLogShippingConfig?: Maybe< AppEnvironmentLogShippingPayload >;
+	deleteNotificationRecipient?: Maybe< DeleteNotificationRecipientPayload >;
+	deleteNotificationSubscription?: Maybe< DeleteNotificationSubscriptionPayload >;
+	deleteOrganizationAuthDomain?: Maybe< OrganizationAuthDomainDeletePayload >;
+	disableBackupShipping?: Maybe< AppEnvironmentBackupShippingPayload >;
+	disableFeature?: Maybe< AppFeaturePayload >;
+	disableLogShipping?: Maybe< AppEnvironmentLogShippingPayload >;
+	editBasicAuth?: Maybe< AppEnvironmentBasicAuthPayload >;
+	enableBackupShipping?: Maybe< AppEnvironmentBackupShippingPayload >;
+	enableFeature?: Maybe< AppFeaturePayload >;
+	enableLaunchMode?: Maybe< AppEnvironmentEnableLaunchModePayload >;
+	enableLogShipping?: Maybe< AppEnvironmentLogShippingPayload >;
+	/** Generate a presigned download URL to a previously copied database backup */
+	generateDBBackupCopyUrl?: Maybe< AppEnvironmentGenerateDbBackupCopyUrlPayload >;
+	generateMediaExportSignedUrl?: Maybe< AppEnvironmentGenerateMediaExportSignedUrlPayload >;
+	generateUserToken?: Maybe< UserTokenGenerationPayload >;
+	launchApplication?: Maybe< AppEnvironmentLaunchedPayload >;
+	/** Purge page cache object(s) */
+	purgePageCache?: Maybe< PurgePageCachePayload >;
+	/** Remove a user from an organization (removes all roles and applications permissions) */
+	removeUserFromOrganization?: Maybe< RemoveUserFromOrganizationPayload >;
+	/** Replace all IPs in the IP Allow List for an environment */
+	replaceIPAllowList?: Maybe< AppEnvironmentIpAllowListPayload >;
+	/** Resend an invitation to an organization */
+	resendInvitation?: Maybe< ResendInvitationPayload >;
+	/** Rollback */
+	rollback?: Maybe< RollbackPayload >;
+	/** Organization Auth Domains */
+	saveOrganizationAuthDomain?: Maybe< OrganizationAuthDomainPayload >;
+	sendTestNotification?: Maybe< SendTestNotificationPayload >;
+	setUserApplicationRoles?: Maybe< SetUserApplicationRolesPayload >;
+	setUserOrganizationRole?: Maybe< UpdateUserOrganizationRolePayload >;
+	startDBBackupCopy?: Maybe< AppEnvironmentStartDbBackupCopyPayload >;
+	startImport?: Maybe< AppEnvironmentImportPayload >;
+	/** Media Exports */
+	startMediaExport?: Maybe< StartMediaExportPayload >;
+	/** Import Media into your Production Environment */
+	startMediaImport?: Maybe< AppEnvironmentMediaImportPayload >;
+	/** Switch the primary domain for an environment */
+	switchEnvironmentPrimaryDomain?: Maybe< AppEnvironmentPrimaryDomainSwitchPayload >;
+	syncEnvironment?: Maybe< AppEnvironmentSyncPayload >;
+	toggleVIPStatus?: Maybe< ToggleUserVipStatusPayload >;
+	triggerDatabaseBackup?: Maybe< AppEnvironmentTriggerDbBackupPayload >;
+	/** Execute a WP-CLI command on an environment */
+	triggerWPCLICommandOnAppEnvironment?: Maybe< AppEnvironmentTriggerWpcliCommandPayload >;
+	updateBackupShippingConfig?: Maybe< AppEnvironmentBackupShippingPayload >;
+	updateCertificate?: Maybe< UpdateCertificatePayload >;
+	/** Network Sites */
+	updateEnvironmentSubsiteDomain?: Maybe< AppEnvironmentUpdateSubsiteDomainPayload >;
+	updateEnvironmentVariable?: Maybe< EnvironmentVariablesPayload >;
+	/** HSTS Settings */
+	updateHSTSSettings?: Maybe< AppEnvironmentHstsSettingsPayload >;
+	/** Add one or more IPs to the IP Allow List for an environment */
+	updateIPAllowList?: Maybe< AppEnvironmentIpAllowListPayload >;
+	updateLogShippingConfig?: Maybe< AppEnvironmentLogShippingPayload >;
+	updateNotificationRecipient?: Maybe< UpdateNotificationRecipientPayload >;
+	updateNotificationSubscription?: Maybe< UpdateNotificationSubscriptionPayload >;
+	/** Plugin Update */
+	updatePlugin?: Maybe< CodebaseUpdatePluginResult >;
+	/** Software Settings */
+	updateSoftwareSettings?: Maybe< AppEnvironmentSoftwareSettings >;
+	updateWPSiteLaunchStatus?: Maybe< WpSiteLaunchStatusPayload >;
+	validateLogShippingConfig?: Maybe< AppEnvironmentLogShippingValidationPayload >;
 };
-
 
 export type MutationAbortMediaImportArgs = {
-  input?: InputMaybe<AppEnvironmentAbortMediaImportInput>;
+	input?: InputMaybe< AppEnvironmentAbortMediaImportInput >;
 };
-
 
 export type MutationAcceptInvitationArgs = {
-  input?: InputMaybe<AcceptInvitationInput>;
+	input?: InputMaybe< AcceptInvitationInput >;
 };
-
 
 export type MutationActivateCertificateArgs = {
-  input?: InputMaybe<ActivateCertificateInput>;
+	input?: InputMaybe< ActivateCertificateInput >;
 };
-
 
 export type MutationActivateLetsEncryptOnDomainForAppEnvironmentArgs = {
-  input?: InputMaybe<AppEnvironmentActivateLetsEncryptOnDomainInput>;
+	input?: InputMaybe< AppEnvironmentActivateLetsEncryptOnDomainInput >;
 };
-
 
 export type MutationAddBasicAuthArgs = {
-  input?: InputMaybe<AppEnvironmentBasicAuthInput>;
+	input?: InputMaybe< AppEnvironmentBasicAuthInput >;
 };
-
 
 export type MutationAddCertificateArgs = {
-  input?: InputMaybe<AddCertificateInput>;
+	input?: InputMaybe< AddCertificateInput >;
 };
-
 
 export type MutationAddDomainToAppEnvironmentArgs = {
-  input?: InputMaybe<AppEnvironmentAddDomainInput>;
+	input?: InputMaybe< AppEnvironmentAddDomainInput >;
 };
-
 
 export type MutationAddEnvironmentVariableArgs = {
-  input?: InputMaybe<EnvironmentVariableInput>;
+	input?: InputMaybe< EnvironmentVariableInput >;
 };
-
 
 export type MutationAddNotificationRecipientArgs = {
-  input?: InputMaybe<AddNotificationRecipientInput>;
+	input?: InputMaybe< AddNotificationRecipientInput >;
 };
-
 
 export type MutationAddNotificationSubscriptionArgs = {
-  input?: InputMaybe<AddNotificationSubscriptionInput>;
+	input?: InputMaybe< AddNotificationSubscriptionInput >;
 };
-
 
 export type MutationAddRequestStatsArgs = {
-  input?: InputMaybe<AppEnvironmentAddRequestStatsInput>;
+	input?: InputMaybe< AppEnvironmentAddRequestStatsInput >;
 };
-
 
 export type MutationCancelInvitationArgs = {
-  input?: InputMaybe<CancelInvitationInput>;
+	input?: InputMaybe< CancelInvitationInput >;
 };
-
 
 export type MutationCancelWpcliCommandArgs = {
-  input?: InputMaybe<CancelWpcliCommandInput>;
+	input?: InputMaybe< CancelWpcliCommandInput >;
 };
-
 
 export type MutationCreateCsrArgs = {
-  input?: InputMaybe<CreateCsrInput>;
+	input?: InputMaybe< CreateCsrInput >;
 };
-
 
 export type MutationCreateInvitationArgs = {
-  input?: InputMaybe<CreateInvitationInput>;
+	input?: InputMaybe< CreateInvitationInput >;
 };
-
 
 export type MutationCreateUserArgs = {
-  input?: InputMaybe<CreateUserInput>;
+	input?: InputMaybe< CreateUserInput >;
 };
-
 
 export type MutationDeactivateDomainOnAppEnvironmentArgs = {
-  input?: InputMaybe<AppEnvironmentDeactivateDomainInput>;
+	input?: InputMaybe< AppEnvironmentDeactivateDomainInput >;
 };
-
 
 export type MutationDebugPageCacheArgs = {
-  input?: InputMaybe<DebugPageCacheInput>;
+	input?: InputMaybe< DebugPageCacheInput >;
 };
-
 
 export type MutationDecodeCsrArgs = {
-  input?: InputMaybe<DecodeCsrInput>;
+	input?: InputMaybe< DecodeCsrInput >;
 };
-
 
 export type MutationDeleteBackupShippingConfigArgs = {
-  input?: InputMaybe<AppEnvironmentBackupShippingInput>;
+	input?: InputMaybe< AppEnvironmentBackupShippingInput >;
 };
-
 
 export type MutationDeleteBasicAuthArgs = {
-  input?: InputMaybe<AppEnvironmentBasicAuthDeleteInput>;
+	input?: InputMaybe< AppEnvironmentBasicAuthDeleteInput >;
 };
-
 
 export type MutationDeleteCertificateArgs = {
-  input?: InputMaybe<DeleteCertificateInput>;
+	input?: InputMaybe< DeleteCertificateInput >;
 };
-
 
 export type MutationDeleteEnvironmentVariableArgs = {
-  input?: InputMaybe<EnvironmentVariableInput>;
+	input?: InputMaybe< EnvironmentVariableInput >;
 };
-
 
 export type MutationDeleteIpAllowListArgs = {
-  input?: InputMaybe<AppEnvironmentIpAllowListInput>;
+	input?: InputMaybe< AppEnvironmentIpAllowListInput >;
 };
-
 
 export type MutationDeleteLogShippingConfigArgs = {
-  input?: InputMaybe<AppEnvironmentLogShippingInput>;
+	input?: InputMaybe< AppEnvironmentLogShippingInput >;
 };
-
 
 export type MutationDeleteNotificationRecipientArgs = {
-  input?: InputMaybe<DeleteNotificationRecipientInput>;
+	input?: InputMaybe< DeleteNotificationRecipientInput >;
 };
-
 
 export type MutationDeleteNotificationSubscriptionArgs = {
-  input?: InputMaybe<DeleteNotificationSubscriptionInput>;
+	input?: InputMaybe< DeleteNotificationSubscriptionInput >;
 };
-
 
 export type MutationDeleteOrganizationAuthDomainArgs = {
-  input?: InputMaybe<OrganizationAuthDomainDeleteInput>;
+	input?: InputMaybe< OrganizationAuthDomainDeleteInput >;
 };
-
 
 export type MutationDisableBackupShippingArgs = {
-  input?: InputMaybe<AppEnvironmentBackupShippingInput>;
+	input?: InputMaybe< AppEnvironmentBackupShippingInput >;
 };
-
 
 export type MutationDisableFeatureArgs = {
-  input?: InputMaybe<AppFeatureInput>;
+	input?: InputMaybe< AppFeatureInput >;
 };
-
 
 export type MutationDisableLogShippingArgs = {
-  input?: InputMaybe<AppEnvironmentLogShippingInput>;
+	input?: InputMaybe< AppEnvironmentLogShippingInput >;
 };
-
 
 export type MutationEditBasicAuthArgs = {
-  input?: InputMaybe<AppEnvironmentBasicAuthInput>;
+	input?: InputMaybe< AppEnvironmentBasicAuthInput >;
 };
-
 
 export type MutationEnableBackupShippingArgs = {
-  input?: InputMaybe<AppEnvironmentBackupShippingInput>;
+	input?: InputMaybe< AppEnvironmentBackupShippingInput >;
 };
-
 
 export type MutationEnableFeatureArgs = {
-  input?: InputMaybe<AppFeatureInput>;
+	input?: InputMaybe< AppFeatureInput >;
 };
-
 
 export type MutationEnableLaunchModeArgs = {
-  input?: InputMaybe<AppEnvironmentEnableLaunchModeInput>;
+	input?: InputMaybe< AppEnvironmentEnableLaunchModeInput >;
 };
-
 
 export type MutationEnableLogShippingArgs = {
-  input?: InputMaybe<AppEnvironmentLogShippingInput>;
+	input?: InputMaybe< AppEnvironmentLogShippingInput >;
 };
-
 
 export type MutationGenerateDbBackupCopyUrlArgs = {
-  input?: InputMaybe<AppEnvironmentGenerateDbBackupCopyUrlInput>;
+	input?: InputMaybe< AppEnvironmentGenerateDbBackupCopyUrlInput >;
 };
-
 
 export type MutationGenerateMediaExportSignedUrlArgs = {
-  input?: InputMaybe<AppEnvironmentGenerateMediaExportSignedUrlInput>;
+	input?: InputMaybe< AppEnvironmentGenerateMediaExportSignedUrlInput >;
 };
-
 
 export type MutationGenerateUserTokenArgs = {
-  input?: InputMaybe<UserTokenGenerationInput>;
+	input?: InputMaybe< UserTokenGenerationInput >;
 };
-
 
 export type MutationLaunchApplicationArgs = {
-  input?: InputMaybe<AppEnvironmentLaunchedInput>;
+	input?: InputMaybe< AppEnvironmentLaunchedInput >;
 };
-
 
 export type MutationPurgePageCacheArgs = {
-  input?: InputMaybe<PurgePageCacheInput>;
+	input?: InputMaybe< PurgePageCacheInput >;
 };
-
 
 export type MutationRemoveUserFromOrganizationArgs = {
-  input?: InputMaybe<RemoveUserFromOrganizationInput>;
+	input?: InputMaybe< RemoveUserFromOrganizationInput >;
 };
-
 
 export type MutationReplaceIpAllowListArgs = {
-  input?: InputMaybe<AppEnvironmentIpAllowListInput>;
+	input?: InputMaybe< AppEnvironmentIpAllowListInput >;
 };
-
 
 export type MutationResendInvitationArgs = {
-  input?: InputMaybe<ResendInvitationInput>;
+	input?: InputMaybe< ResendInvitationInput >;
 };
-
 
 export type MutationRollbackArgs = {
-  input?: InputMaybe<RollbackInput>;
+	input?: InputMaybe< RollbackInput >;
 };
-
 
 export type MutationSaveOrganizationAuthDomainArgs = {
-  input?: InputMaybe<OrganizationAuthDomainCreateInput>;
+	input?: InputMaybe< OrganizationAuthDomainCreateInput >;
 };
-
 
 export type MutationSendTestNotificationArgs = {
-  input?: InputMaybe<SendTestNotificationInput>;
+	input?: InputMaybe< SendTestNotificationInput >;
 };
-
 
 export type MutationSetUserApplicationRolesArgs = {
-  input?: InputMaybe<SetUserApplicationRolesInput>;
+	input?: InputMaybe< SetUserApplicationRolesInput >;
 };
-
 
 export type MutationSetUserOrganizationRoleArgs = {
-  input?: InputMaybe<UpdateUserOrganizationRoleInput>;
+	input?: InputMaybe< UpdateUserOrganizationRoleInput >;
 };
-
 
 export type MutationStartDbBackupCopyArgs = {
-  input?: InputMaybe<AppEnvironmentStartDbBackupCopyInput>;
+	input?: InputMaybe< AppEnvironmentStartDbBackupCopyInput >;
 };
-
 
 export type MutationStartImportArgs = {
-  input?: InputMaybe<AppEnvironmentImportInput>;
+	input?: InputMaybe< AppEnvironmentImportInput >;
 };
-
 
 export type MutationStartMediaExportArgs = {
-  input?: InputMaybe<StartMediaExportInput>;
+	input?: InputMaybe< StartMediaExportInput >;
 };
-
 
 export type MutationStartMediaImportArgs = {
-  input?: InputMaybe<AppEnvironmentStartMediaImportInput>;
+	input?: InputMaybe< AppEnvironmentStartMediaImportInput >;
 };
-
 
 export type MutationSwitchEnvironmentPrimaryDomainArgs = {
-  input?: InputMaybe<AppEnvironmentPrimaryDomainSwitchInput>;
+	input?: InputMaybe< AppEnvironmentPrimaryDomainSwitchInput >;
 };
-
 
 export type MutationSyncEnvironmentArgs = {
-  input?: InputMaybe<AppEnvironmentSyncInput>;
+	input?: InputMaybe< AppEnvironmentSyncInput >;
 };
-
 
 export type MutationToggleVipStatusArgs = {
-  input?: InputMaybe<ToggleUserVipStatusInput>;
+	input?: InputMaybe< ToggleUserVipStatusInput >;
 };
-
 
 export type MutationTriggerDatabaseBackupArgs = {
-  input?: InputMaybe<AppEnvironmentTriggerDbBackupInput>;
+	input?: InputMaybe< AppEnvironmentTriggerDbBackupInput >;
 };
-
 
 export type MutationTriggerWpcliCommandOnAppEnvironmentArgs = {
-  input?: InputMaybe<AppEnvironmentTriggerWpcliCommandInput>;
+	input?: InputMaybe< AppEnvironmentTriggerWpcliCommandInput >;
 };
-
 
 export type MutationUpdateBackupShippingConfigArgs = {
-  input?: InputMaybe<AppEnvironmentBackupShippingInput>;
+	input?: InputMaybe< AppEnvironmentBackupShippingInput >;
 };
-
 
 export type MutationUpdateCertificateArgs = {
-  input?: InputMaybe<UpdateCertificateInput>;
+	input?: InputMaybe< UpdateCertificateInput >;
 };
-
 
 export type MutationUpdateEnvironmentSubsiteDomainArgs = {
-  input?: InputMaybe<AppEnvironmentUpdateSubsiteDomainInput>;
+	input?: InputMaybe< AppEnvironmentUpdateSubsiteDomainInput >;
 };
-
 
 export type MutationUpdateEnvironmentVariableArgs = {
-  input?: InputMaybe<EnvironmentVariableInput>;
+	input?: InputMaybe< EnvironmentVariableInput >;
 };
-
 
 export type MutationUpdateHstsSettingsArgs = {
-  input?: InputMaybe<AppEnvironmentHstsSettingsInput>;
+	input?: InputMaybe< AppEnvironmentHstsSettingsInput >;
 };
-
 
 export type MutationUpdateIpAllowListArgs = {
-  input?: InputMaybe<AppEnvironmentIpAllowListInput>;
+	input?: InputMaybe< AppEnvironmentIpAllowListInput >;
 };
-
 
 export type MutationUpdateLogShippingConfigArgs = {
-  input?: InputMaybe<AppEnvironmentLogShippingInput>;
+	input?: InputMaybe< AppEnvironmentLogShippingInput >;
 };
-
 
 export type MutationUpdateNotificationRecipientArgs = {
-  input?: InputMaybe<UpdateNotificationRecipientInput>;
+	input?: InputMaybe< UpdateNotificationRecipientInput >;
 };
-
 
 export type MutationUpdateNotificationSubscriptionArgs = {
-  input?: InputMaybe<UpdateNotificationSubscriptionInput>;
+	input?: InputMaybe< UpdateNotificationSubscriptionInput >;
 };
-
 
 export type MutationUpdatePluginArgs = {
-  input?: InputMaybe<CodebaseUpdatePluginInput>;
+	input?: InputMaybe< CodebaseUpdatePluginInput >;
 };
-
 
 export type MutationUpdateSoftwareSettingsArgs = {
-  input?: InputMaybe<AppEnvironmentSoftwareSettingsInput>;
+	input?: InputMaybe< AppEnvironmentSoftwareSettingsInput >;
 };
-
 
 export type MutationUpdateWpSiteLaunchStatusArgs = {
-  input?: InputMaybe<WpSiteLaunchStatusInput>;
+	input?: InputMaybe< WpSiteLaunchStatusInput >;
 };
 
-
 export type MutationValidateLogShippingConfigArgs = {
-  input?: InputMaybe<AppEnvironmentLogShippingInput>;
+	input?: InputMaybe< AppEnvironmentLogShippingInput >;
 };
 
 export type NewDomain = {
-  name: Scalars['String']['input'];
+	name: Scalars[ 'String' ][ 'input' ];
 };
 
 export type NotificationRecipient = {
-  __typename?: 'NotificationRecipient';
-  createdAt?: Maybe<Scalars['Date']['output']>;
-  description?: Maybe<Scalars['String']['output']>;
-  id: Scalars['Int']['output'];
-  meta?: Maybe<Scalars['String']['output']>;
-  name?: Maybe<Scalars['String']['output']>;
-  organizationId: Scalars['Int']['output'];
-  recipientType?: Maybe<NotificationRecipientType>;
-  recipientValue?: Maybe<Scalars['String']['output']>;
-  updatedAt?: Maybe<Scalars['Date']['output']>;
+	__typename?: 'NotificationRecipient';
+	createdAt?: Maybe< Scalars[ 'Date' ][ 'output' ] >;
+	description?: Maybe< Scalars[ 'String' ][ 'output' ] >;
+	id: Scalars[ 'Int' ][ 'output' ];
+	meta?: Maybe< Scalars[ 'String' ][ 'output' ] >;
+	name?: Maybe< Scalars[ 'String' ][ 'output' ] >;
+	organizationId: Scalars[ 'Int' ][ 'output' ];
+	recipientType?: Maybe< NotificationRecipientType >;
+	recipientValue?: Maybe< Scalars[ 'String' ][ 'output' ] >;
+	updatedAt?: Maybe< Scalars[ 'Date' ][ 'output' ] >;
 };
 
 export type NotificationRecipientList = {
-  __typename?: 'NotificationRecipientList';
-  nodes?: Maybe<Array<Maybe<NotificationRecipient>>>;
-  total?: Maybe<Scalars['BigInt']['output']>;
+	__typename?: 'NotificationRecipientList';
+	nodes?: Maybe< Array< Maybe< NotificationRecipient > > >;
+	total?: Maybe< Scalars[ 'BigInt' ][ 'output' ] >;
 };
 
-export enum NotificationRecipientType {
-  Email = 'EMAIL',
-  Slack = 'SLACK',
-  Webhook = 'WEBHOOK'
-}
+export type NotificationRecipientType = 'EMAIL' | 'SLACK' | 'WEBHOOK';
 
 export type NotificationSubscription = {
-  __typename?: 'NotificationSubscription';
-  active?: Maybe<Scalars['Boolean']['output']>;
-  createdAt?: Maybe<Scalars['Date']['output']>;
-  description?: Maybe<Scalars['String']['output']>;
-  entityType?: Maybe<Scalars['String']['output']>;
-  entityValue?: Maybe<Scalars['String']['output']>;
-  id: Scalars['Int']['output'];
-  meta?: Maybe<Scalars['String']['output']>;
-  notificationRecipient?: Maybe<NotificationRecipient>;
-  updatedAt?: Maybe<Scalars['Date']['output']>;
+	__typename?: 'NotificationSubscription';
+	active?: Maybe< Scalars[ 'Boolean' ][ 'output' ] >;
+	createdAt?: Maybe< Scalars[ 'Date' ][ 'output' ] >;
+	description?: Maybe< Scalars[ 'String' ][ 'output' ] >;
+	entityType?: Maybe< Scalars[ 'String' ][ 'output' ] >;
+	entityValue?: Maybe< Scalars[ 'String' ][ 'output' ] >;
+	id: Scalars[ 'Int' ][ 'output' ];
+	meta?: Maybe< Scalars[ 'String' ][ 'output' ] >;
+	notificationRecipient?: Maybe< NotificationRecipient >;
+	updatedAt?: Maybe< Scalars[ 'Date' ][ 'output' ] >;
 };
 
 export type NotificationSubscriptionList = {
-  __typename?: 'NotificationSubscriptionList';
-  nodes?: Maybe<Array<Maybe<NotificationSubscription>>>;
-  total?: Maybe<Scalars['BigInt']['output']>;
+	__typename?: 'NotificationSubscriptionList';
+	nodes?: Maybe< Array< Maybe< NotificationSubscription > > >;
+	total?: Maybe< Scalars[ 'BigInt' ][ 'output' ] >;
 };
 
 export type OrgList = ModelList & {
-  __typename?: 'OrgList';
-  edges?: Maybe<Array<Maybe<Organization>>>;
-  nextCursor?: Maybe<Scalars['String']['output']>;
-  nodes?: Maybe<Array<Maybe<Organization>>>;
-  total?: Maybe<Scalars['Int']['output']>;
+	__typename?: 'OrgList';
+	edges?: Maybe< Array< Maybe< Organization > > >;
+	nextCursor?: Maybe< Scalars[ 'String' ][ 'output' ] >;
+	nodes?: Maybe< Array< Maybe< Organization > > >;
+	total?: Maybe< Scalars[ 'Int' ][ 'output' ] >;
 };
 
 export type OrgRole = {
-  __typename?: 'OrgRole';
-  extends?: Maybe<Scalars['String']['output']>;
-  name?: Maybe<Scalars['String']['output']>;
+	__typename?: 'OrgRole';
+	extends?: Maybe< Scalars[ 'String' ][ 'output' ] >;
+	name?: Maybe< Scalars[ 'String' ][ 'output' ] >;
 };
 
-export enum OrgRoleId {
-  Admin = 'admin',
-  Member = 'member',
-  Viewer = 'viewer'
-}
+export type OrgRoleId = 'admin' | 'member' | 'viewer';
 
 export type Organization = Model & {
-  __typename?: 'Organization';
-  apps?: Maybe<AppList>;
-  authDomains?: Maybe<OrganizationAuthDomainList>;
-  contacts?: Maybe<OrganizationContacts>;
-  events?: Maybe<AuditEventList>;
-  id?: Maybe<Scalars['Int']['output']>;
-  identityProviders?: Maybe<IdentityProviderList>;
-  invitations?: Maybe<InvitationList>;
-  letsEncryptDisallowed?: Maybe<Scalars['Boolean']['output']>;
-  name?: Maybe<Scalars['String']['output']>;
-  notificationRecipients?: Maybe<NotificationRecipientList>;
-  pageviews?: Maybe<Pageviews>;
-  permissions?: Maybe<Array<Maybe<PermissionResult>>>;
-  plan?: Maybe<OrganizationPlan>;
-  serviceStatus?: Maybe<Scalars['String']['output']>;
-  slug?: Maybe<Scalars['String']['output']>;
-  supportPackage?: Maybe<Scalars['String']['output']>;
-  users?: Maybe<UserList>;
+	__typename?: 'Organization';
+	apps?: Maybe< AppList >;
+	authDomains?: Maybe< OrganizationAuthDomainList >;
+	contacts?: Maybe< OrganizationContacts >;
+	events?: Maybe< AuditEventList >;
+	id?: Maybe< Scalars[ 'Int' ][ 'output' ] >;
+	identityProviders?: Maybe< IdentityProviderList >;
+	invitations?: Maybe< InvitationList >;
+	letsEncryptDisallowed?: Maybe< Scalars[ 'Boolean' ][ 'output' ] >;
+	name?: Maybe< Scalars[ 'String' ][ 'output' ] >;
+	notificationRecipients?: Maybe< NotificationRecipientList >;
+	pageviews?: Maybe< Pageviews >;
+	permissions?: Maybe< Array< Maybe< PermissionResult > > >;
+	plan?: Maybe< OrganizationPlan >;
+	serviceStatus?: Maybe< Scalars[ 'String' ][ 'output' ] >;
+	slug?: Maybe< Scalars[ 'String' ][ 'output' ] >;
+	supportPackage?: Maybe< Scalars[ 'String' ][ 'output' ] >;
+	users?: Maybe< UserList >;
 };
 
 export type OrganizationAppsArgs = {
-  active?: InputMaybe<Scalars['String']['input']>;
-  after?: InputMaybe<Scalars['String']['input']>;
-  first?: InputMaybe<Scalars['Int']['input']>;
-  matching?: InputMaybe<Scalars['String']['input']>;
+	active?: InputMaybe< Scalars[ 'String' ][ 'input' ] >;
+	after?: InputMaybe< Scalars[ 'String' ][ 'input' ] >;
+	first?: InputMaybe< Scalars[ 'Int' ][ 'input' ] >;
+	matching?: InputMaybe< Scalars[ 'String' ][ 'input' ] >;
 };
 
 export type OrganizationAuthDomainsArgs = {
-  domain?: InputMaybe<Scalars['String']['input']>;
+	domain?: InputMaybe< Scalars[ 'String' ][ 'input' ] >;
 };
 
 export type OrganizationEventsArgs = {
-  after?: InputMaybe<Scalars['String']['input']>;
-  first?: InputMaybe<Scalars['Int']['input']>;
-  order?: InputMaybe<Scalars['String']['input']>;
+	after?: InputMaybe< Scalars[ 'String' ][ 'input' ] >;
+	first?: InputMaybe< Scalars[ 'Int' ][ 'input' ] >;
+	order?: InputMaybe< Scalars[ 'String' ][ 'input' ] >;
 };
 
 export type OrganizationIdentityProvidersArgs = {
-  id?: InputMaybe<Scalars['Int']['input']>;
+	id?: InputMaybe< Scalars[ 'Int' ][ 'input' ] >;
 };
 
 export type OrganizationInvitationsArgs = {
-  after?: InputMaybe<Scalars['String']['input']>;
-  first?: InputMaybe<Scalars['Int']['input']>;
-  matching?: InputMaybe<Scalars['String']['input']>;
-  status?: InputMaybe<Scalars['String']['input']>;
+	after?: InputMaybe< Scalars[ 'String' ][ 'input' ] >;
+	first?: InputMaybe< Scalars[ 'Int' ][ 'input' ] >;
+	matching?: InputMaybe< Scalars[ 'String' ][ 'input' ] >;
+	status?: InputMaybe< Scalars[ 'String' ][ 'input' ] >;
 };
 
 export type OrganizationNotificationRecipientsArgs = {
-  appId?: InputMaybe<Scalars['Int']['input']>;
+	appId?: InputMaybe< Scalars[ 'Int' ][ 'input' ] >;
 };
 
 export type OrganizationPermissionsArgs = {
-  permissions?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+	permissions?: InputMaybe< Array< InputMaybe< Scalars[ 'String' ][ 'input' ] > > >;
 };
 
 export type OrganizationUsersArgs = {
-  after?: InputMaybe<Scalars['String']['input']>;
-  first?: InputMaybe<Scalars['Int']['input']>;
-  id?: InputMaybe<Scalars['Int']['input']>;
-  isVIP?: InputMaybe<Scalars['Boolean']['input']>;
+	after?: InputMaybe< Scalars[ 'String' ][ 'input' ] >;
+	first?: InputMaybe< Scalars[ 'Int' ][ 'input' ] >;
+	id?: InputMaybe< Scalars[ 'Int' ][ 'input' ] >;
+	isVIP?: InputMaybe< Scalars[ 'Boolean' ][ 'input' ] >;
 };
 
 export type OrganizationAuthDomain = Model & {
-  __typename?: 'OrganizationAuthDomain';
-  active?: Maybe<Scalars['Boolean']['output']>;
-  createdAt?: Maybe<Scalars['String']['output']>;
-  domain?: Maybe<Scalars['String']['output']>;
-  id?: Maybe<Scalars['Int']['output']>;
-  organizationId?: Maybe<Scalars['Int']['output']>;
+	__typename?: 'OrganizationAuthDomain';
+	active?: Maybe< Scalars[ 'Boolean' ][ 'output' ] >;
+	createdAt?: Maybe< Scalars[ 'String' ][ 'output' ] >;
+	domain?: Maybe< Scalars[ 'String' ][ 'output' ] >;
+	id?: Maybe< Scalars[ 'Int' ][ 'output' ] >;
+	organizationId?: Maybe< Scalars[ 'Int' ][ 'output' ] >;
 };
 
 export type OrganizationAuthDomainCreateInput = {
-  active?: InputMaybe<Scalars['Boolean']['input']>;
-  domain?: InputMaybe<Scalars['String']['input']>;
-  id?: InputMaybe<Scalars['Int']['input']>;
-  organizationId?: InputMaybe<Scalars['Int']['input']>;
+	active?: InputMaybe< Scalars[ 'Boolean' ][ 'input' ] >;
+	domain?: InputMaybe< Scalars[ 'String' ][ 'input' ] >;
+	id?: InputMaybe< Scalars[ 'Int' ][ 'input' ] >;
+	organizationId?: InputMaybe< Scalars[ 'Int' ][ 'input' ] >;
 };
 
 export type OrganizationAuthDomainDeleteInput = {
-  id?: InputMaybe<Scalars['Int']['input']>;
+	id?: InputMaybe< Scalars[ 'Int' ][ 'input' ] >;
 };
 
 export type OrganizationAuthDomainDeletePayload = {
-  __typename?: 'OrganizationAuthDomainDeletePayload';
-  deleted?: Maybe<Scalars['Boolean']['output']>;
+	__typename?: 'OrganizationAuthDomainDeletePayload';
+	deleted?: Maybe< Scalars[ 'Boolean' ][ 'output' ] >;
 };
 
 export type OrganizationAuthDomainList = ModelList & {
-  __typename?: 'OrganizationAuthDomainList';
-  nextCursor?: Maybe<Scalars['String']['output']>;
-  nodes?: Maybe<Array<Maybe<OrganizationAuthDomain>>>;
-  total?: Maybe<Scalars['Int']['output']>;
+	__typename?: 'OrganizationAuthDomainList';
+	nextCursor?: Maybe< Scalars[ 'String' ][ 'output' ] >;
+	nodes?: Maybe< Array< Maybe< OrganizationAuthDomain > > >;
+	total?: Maybe< Scalars[ 'Int' ][ 'output' ] >;
 };
 
 export type OrganizationAuthDomainPayload = {
-  __typename?: 'OrganizationAuthDomainPayload';
-  authDomain?: Maybe<OrganizationAuthDomain>;
+	__typename?: 'OrganizationAuthDomainPayload';
+	authDomain?: Maybe< OrganizationAuthDomain >;
 };
 
 export type OrganizationContacts = {
-  __typename?: 'OrganizationContacts';
-  accountOwners?: Maybe<SalesforceContactList>;
-  supportContacts?: Maybe<SalesforceContactList>;
-  technicalContacts?: Maybe<SalesforceContactList>;
-  vipLaunchTAM?: Maybe<SalesforceContact>;
-  vipRelationshipManager?: Maybe<SalesforceContact>;
-  vipTechnicalAccountManager?: Maybe<SalesforceContact>;
+	__typename?: 'OrganizationContacts';
+	accountOwners?: Maybe< SalesforceContactList >;
+	supportContacts?: Maybe< SalesforceContactList >;
+	technicalContacts?: Maybe< SalesforceContactList >;
+	vipLaunchTAM?: Maybe< SalesforceContact >;
+	vipRelationshipManager?: Maybe< SalesforceContact >;
+	vipTechnicalAccountManager?: Maybe< SalesforceContact >;
 };
 
 export type OrganizationPlan = {
-  __typename?: 'OrganizationPlan';
-  addOns?: Maybe<Array<Maybe<Scalars['String']['output']>>>;
-  codeReviewLevel?: Maybe<Scalars['String']['output']>;
-  numberOfAllowedApplications?: Maybe<Scalars['Int']['output']>;
-  planEndDate?: Maybe<Scalars['String']['output']>;
-  planIncludedRequests?: Maybe<Scalars['Int']['output']>;
-  planName?: Maybe<Scalars['String']['output']>;
-  planStartDate?: Maybe<Scalars['String']['output']>;
-  ticketSLA?: Maybe<Scalars['String']['output']>;
-  uptimeSLA?: Maybe<Scalars['String']['output']>;
+	__typename?: 'OrganizationPlan';
+	addOns?: Maybe< Array< Maybe< Scalars[ 'String' ][ 'output' ] > > >;
+	codeReviewLevel?: Maybe< Scalars[ 'String' ][ 'output' ] >;
+	numberOfAllowedApplications?: Maybe< Scalars[ 'Int' ][ 'output' ] >;
+	planEndDate?: Maybe< Scalars[ 'String' ][ 'output' ] >;
+	planIncludedRequests?: Maybe< Scalars[ 'Int' ][ 'output' ] >;
+	planName?: Maybe< Scalars[ 'String' ][ 'output' ] >;
+	planStartDate?: Maybe< Scalars[ 'String' ][ 'output' ] >;
+	ticketSLA?: Maybe< Scalars[ 'String' ][ 'output' ] >;
+	uptimeSLA?: Maybe< Scalars[ 'String' ][ 'output' ] >;
 };
 
 export type PageviewDetails = {
-  __typename?: 'PageviewDetails';
-  apiRequests?: Maybe<Scalars['Int']['output']>;
-  appRequests?: Maybe<Scalars['Int']['output']>;
-  endDate?: Maybe<Scalars['String']['output']>;
-  startDate?: Maybe<Scalars['String']['output']>;
-  staticRequests?: Maybe<Scalars['Int']['output']>;
-  total?: Maybe<Scalars['Int']['output']>;
+	__typename?: 'PageviewDetails';
+	apiRequests?: Maybe< Scalars[ 'Int' ][ 'output' ] >;
+	appRequests?: Maybe< Scalars[ 'Int' ][ 'output' ] >;
+	endDate?: Maybe< Scalars[ 'String' ][ 'output' ] >;
+	startDate?: Maybe< Scalars[ 'String' ][ 'output' ] >;
+	staticRequests?: Maybe< Scalars[ 'Int' ][ 'output' ] >;
+	total?: Maybe< Scalars[ 'Int' ][ 'output' ] >;
 };
 
 export type Pageviews = {
-  __typename?: 'Pageviews';
-  apiRequests?: Maybe<Scalars['BigInt']['output']>;
-  appRequests?: Maybe<Scalars['BigInt']['output']>;
-  details?: Maybe<Array<Maybe<PageviewDetails>>>;
-  endDate?: Maybe<Scalars['String']['output']>;
-  startDate?: Maybe<Scalars['String']['output']>;
-  staticRequests?: Maybe<Scalars['BigInt']['output']>;
-  total?: Maybe<Scalars['BigInt']['output']>;
+	__typename?: 'Pageviews';
+	apiRequests?: Maybe< Scalars[ 'BigInt' ][ 'output' ] >;
+	appRequests?: Maybe< Scalars[ 'BigInt' ][ 'output' ] >;
+	details?: Maybe< Array< Maybe< PageviewDetails > > >;
+	endDate?: Maybe< Scalars[ 'String' ][ 'output' ] >;
+	startDate?: Maybe< Scalars[ 'String' ][ 'output' ] >;
+	staticRequests?: Maybe< Scalars[ 'BigInt' ][ 'output' ] >;
+	total?: Maybe< Scalars[ 'BigInt' ][ 'output' ] >;
 };
 
 export type PermissionResult = {
-  __typename?: 'PermissionResult';
-  isAllowed?: Maybe<Scalars['Boolean']['output']>;
-  permission?: Maybe<Scalars['String']['output']>;
+	__typename?: 'PermissionResult';
+	isAllowed?: Maybe< Scalars[ 'Boolean' ][ 'output' ] >;
+	permission?: Maybe< Scalars[ 'String' ][ 'output' ] >;
 };
 
 export type PrimaryDomainSwitchJob = JobInterface & {
-  __typename?: 'PrimaryDomainSwitchJob';
-  completedAt?: Maybe<Scalars['String']['output']>;
-  createdAt?: Maybe<Scalars['String']['output']>;
-  id?: Maybe<Scalars['Int']['output']>;
-  inProgressLock?: Maybe<Scalars['Boolean']['output']>;
-  metadata?: Maybe<Array<Maybe<JobMetadata>>>;
-  newDomain?: Maybe<Domain>;
-  progress?: Maybe<JobProgress>;
-  type?: Maybe<Scalars['String']['output']>;
+	__typename?: 'PrimaryDomainSwitchJob';
+	completedAt?: Maybe< Scalars[ 'String' ][ 'output' ] >;
+	createdAt?: Maybe< Scalars[ 'String' ][ 'output' ] >;
+	id?: Maybe< Scalars[ 'Int' ][ 'output' ] >;
+	inProgressLock?: Maybe< Scalars[ 'Boolean' ][ 'output' ] >;
+	metadata?: Maybe< Array< Maybe< JobMetadata > > >;
+	newDomain?: Maybe< Domain >;
+	progress?: Maybe< JobProgress >;
+	type?: Maybe< Scalars[ 'String' ][ 'output' ] >;
 };
 
 export type PurgePageCacheInput = {
-  appId: Scalars['Int']['input'];
-  environmentId: Scalars['Int']['input'];
-  urls: Array<Scalars['String']['input']>;
+	appId: Scalars[ 'Int' ][ 'input' ];
+	environmentId: Scalars[ 'Int' ][ 'input' ];
+	urls: Array< Scalars[ 'String' ][ 'input' ] >;
 };
 
 export type PurgePageCachePayload = {
-  __typename?: 'PurgePageCachePayload';
-  success: Scalars['Boolean']['output'];
-  urls: Array<Scalars['String']['output']>;
+	__typename?: 'PurgePageCachePayload';
+	success: Scalars[ 'Boolean' ][ 'output' ];
+	urls: Array< Scalars[ 'String' ][ 'output' ] >;
 };
 
 export type Query = {
-  __typename?: 'Query';
-  app?: Maybe<App>;
-  apps?: Maybe<AppList>;
-  certificate?: Maybe<Certificate>;
-  dbBackupCopies?: Maybe<DbBackupCopyList>;
-  domain?: Maybe<Domain>;
-  domains?: Maybe<DomainList>;
-  me?: Maybe<User>;
-  organization?: Maybe<Organization>;
-  organizations?: Maybe<OrgList>;
-  repo?: Maybe<Repo>;
-  user?: Maybe<User>;
-  users?: Maybe<UserList>;
+	__typename?: 'Query';
+	app?: Maybe< App >;
+	apps?: Maybe< AppList >;
+	certificate?: Maybe< Certificate >;
+	dbBackupCopies?: Maybe< DbBackupCopyList >;
+	domain?: Maybe< Domain >;
+	domains?: Maybe< DomainList >;
+	me?: Maybe< User >;
+	organization?: Maybe< Organization >;
+	organizations?: Maybe< OrgList >;
+	repo?: Maybe< Repo >;
+	user?: Maybe< User >;
+	users?: Maybe< UserList >;
 };
 
 export type QueryAppArgs = {
-  id?: InputMaybe<Scalars['Int']['input']>;
+	id?: InputMaybe< Scalars[ 'Int' ][ 'input' ] >;
 };
 
 export type QueryAppsArgs = {
-  after?: InputMaybe<Scalars['String']['input']>;
-  first?: InputMaybe<Scalars['Int']['input']>;
-  ids?: InputMaybe<Array<InputMaybe<Scalars['Int']['input']>>>;
-  matching?: InputMaybe<Scalars['String']['input']>;
-  name?: InputMaybe<Scalars['String']['input']>;
+	after?: InputMaybe< Scalars[ 'String' ][ 'input' ] >;
+	first?: InputMaybe< Scalars[ 'Int' ][ 'input' ] >;
+	ids?: InputMaybe< Array< InputMaybe< Scalars[ 'Int' ][ 'input' ] > > >;
+	matching?: InputMaybe< Scalars[ 'String' ][ 'input' ] >;
+	name?: InputMaybe< Scalars[ 'String' ][ 'input' ] >;
 };
 
 export type QueryCertificateArgs = {
-  certificateId?: InputMaybe<Scalars['Int']['input']>;
-  clientId?: InputMaybe<Scalars['Int']['input']>;
+	certificateId?: InputMaybe< Scalars[ 'Int' ][ 'input' ] >;
+	clientId?: InputMaybe< Scalars[ 'Int' ][ 'input' ] >;
 };
 
 export type QueryDbBackupCopiesArgs = {
-  environmentId?: InputMaybe<Scalars['Int']['input']>;
-  fileNames?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+	environmentId?: InputMaybe< Scalars[ 'Int' ][ 'input' ] >;
+	fileNames?: InputMaybe< Array< InputMaybe< Scalars[ 'String' ][ 'input' ] > > >;
 };
 
 export type QueryDomainArgs = {
-  id?: InputMaybe<Scalars['Int']['input']>;
-  name?: InputMaybe<Scalars['String']['input']>;
+	id?: InputMaybe< Scalars[ 'Int' ][ 'input' ] >;
+	name?: InputMaybe< Scalars[ 'String' ][ 'input' ] >;
 };
 
 export type QueryDomainsArgs = {
-  after?: InputMaybe<Scalars['String']['input']>;
-  first?: InputMaybe<Scalars['Int']['input']>;
-  wildcards?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+	after?: InputMaybe< Scalars[ 'String' ][ 'input' ] >;
+	first?: InputMaybe< Scalars[ 'Int' ][ 'input' ] >;
+	wildcards?: InputMaybe< Array< InputMaybe< Scalars[ 'String' ][ 'input' ] > > >;
 };
 
 export type QueryOrganizationArgs = {
-  id?: InputMaybe<Scalars['Int']['input']>;
+	id?: InputMaybe< Scalars[ 'Int' ][ 'input' ] >;
 };
 
 export type QueryOrganizationsArgs = {
-  after?: InputMaybe<Scalars['String']['input']>;
-  first?: InputMaybe<Scalars['Int']['input']>;
-  id?: InputMaybe<Scalars['Int']['input']>;
-  matching?: InputMaybe<Scalars['String']['input']>;
-  name?: InputMaybe<Scalars['String']['input']>;
+	after?: InputMaybe< Scalars[ 'String' ][ 'input' ] >;
+	first?: InputMaybe< Scalars[ 'Int' ][ 'input' ] >;
+	id?: InputMaybe< Scalars[ 'Int' ][ 'input' ] >;
+	matching?: InputMaybe< Scalars[ 'String' ][ 'input' ] >;
+	name?: InputMaybe< Scalars[ 'String' ][ 'input' ] >;
 };
 
 export type QueryRepoArgs = {
-  name?: InputMaybe<Scalars['String']['input']>;
+	name?: InputMaybe< Scalars[ 'String' ][ 'input' ] >;
 };
 
 export type QueryUserArgs = {
-  githubUsername?: InputMaybe<Scalars['String']['input']>;
-  id?: InputMaybe<Scalars['Int']['input']>;
+	githubUsername?: InputMaybe< Scalars[ 'String' ][ 'input' ] >;
+	id?: InputMaybe< Scalars[ 'Int' ][ 'input' ] >;
 };
 
 export type QueryUsersArgs = {
-  after?: InputMaybe<Scalars['String']['input']>;
-  first?: InputMaybe<Scalars['Int']['input']>;
-  isVIP?: InputMaybe<Scalars['Boolean']['input']>;
-  matching?: InputMaybe<Scalars['String']['input']>;
-  organizationId?: InputMaybe<Scalars['Int']['input']>;
+	after?: InputMaybe< Scalars[ 'String' ][ 'input' ] >;
+	first?: InputMaybe< Scalars[ 'Int' ][ 'input' ] >;
+	isVIP?: InputMaybe< Scalars[ 'Boolean' ][ 'input' ] >;
+	matching?: InputMaybe< Scalars[ 'String' ][ 'input' ] >;
+	organizationId?: InputMaybe< Scalars[ 'Int' ][ 'input' ] >;
 };
 
 export type RemoveUserFromOrganizationInput = {
-  organizationId: Scalars['Int']['input'];
-  userId: Scalars['Int']['input'];
+	organizationId: Scalars[ 'Int' ][ 'input' ];
+	userId: Scalars[ 'Int' ][ 'input' ];
 };
 
 export type RemoveUserFromOrganizationPayload = {
-  __typename?: 'RemoveUserFromOrganizationPayload';
-  user?: Maybe<User>;
+	__typename?: 'RemoveUserFromOrganizationPayload';
+	user?: Maybe< User >;
 };
 
 export type Repo = Model & {
-  __typename?: 'Repo';
-  apps?: Maybe<AppList>;
-  branch?: Maybe<Scalars['String']['output']>;
-  id?: Maybe<Scalars['Int']['output']>;
-  name?: Maybe<Scalars['String']['output']>;
+	__typename?: 'Repo';
+	apps?: Maybe< AppList >;
+	branch?: Maybe< Scalars[ 'String' ][ 'output' ] >;
+	id?: Maybe< Scalars[ 'Int' ][ 'output' ] >;
+	name?: Maybe< Scalars[ 'String' ][ 'output' ] >;
 };
 
 export type RequestHeader = {
-  name: Scalars['String']['input'];
-  value: Scalars['String']['input'];
+	name: Scalars[ 'String' ][ 'input' ];
+	value: Scalars[ 'String' ][ 'input' ];
 };
 
 export type RequestStats = {
-  __typename?: 'RequestStats';
-  apiA8cCached?: Maybe<Scalars['BigInt']['output']>;
-  apiA8cUncached?: Maybe<Scalars['BigInt']['output']>;
-  apiCached?: Maybe<Scalars['BigInt']['output']>;
-  apiUncached?: Maybe<Scalars['BigInt']['output']>;
-  appA8cCached?: Maybe<Scalars['BigInt']['output']>;
-  appA8cUncached?: Maybe<Scalars['BigInt']['output']>;
-  appCached?: Maybe<Scalars['BigInt']['output']>;
-  appUncached?: Maybe<Scalars['BigInt']['output']>;
-  createdAt?: Maybe<Scalars['String']['output']>;
-  date?: Maybe<Scalars['String']['output']>;
-  environmentId?: Maybe<Scalars['Int']['output']>;
-  id?: Maybe<Scalars['Int']['output']>;
-  staticA8cCached?: Maybe<Scalars['BigInt']['output']>;
-  staticA8cUncached?: Maybe<Scalars['BigInt']['output']>;
-  staticCached?: Maybe<Scalars['BigInt']['output']>;
-  staticUncached?: Maybe<Scalars['BigInt']['output']>;
+	__typename?: 'RequestStats';
+	apiA8cCached?: Maybe< Scalars[ 'BigInt' ][ 'output' ] >;
+	apiA8cUncached?: Maybe< Scalars[ 'BigInt' ][ 'output' ] >;
+	apiCached?: Maybe< Scalars[ 'BigInt' ][ 'output' ] >;
+	apiUncached?: Maybe< Scalars[ 'BigInt' ][ 'output' ] >;
+	appA8cCached?: Maybe< Scalars[ 'BigInt' ][ 'output' ] >;
+	appA8cUncached?: Maybe< Scalars[ 'BigInt' ][ 'output' ] >;
+	appCached?: Maybe< Scalars[ 'BigInt' ][ 'output' ] >;
+	appUncached?: Maybe< Scalars[ 'BigInt' ][ 'output' ] >;
+	createdAt?: Maybe< Scalars[ 'String' ][ 'output' ] >;
+	date?: Maybe< Scalars[ 'String' ][ 'output' ] >;
+	environmentId?: Maybe< Scalars[ 'Int' ][ 'output' ] >;
+	id?: Maybe< Scalars[ 'Int' ][ 'output' ] >;
+	staticA8cCached?: Maybe< Scalars[ 'BigInt' ][ 'output' ] >;
+	staticA8cUncached?: Maybe< Scalars[ 'BigInt' ][ 'output' ] >;
+	staticCached?: Maybe< Scalars[ 'BigInt' ][ 'output' ] >;
+	staticUncached?: Maybe< Scalars[ 'BigInt' ][ 'output' ] >;
 };
 
 export type RequestStatsList = {
-  __typename?: 'RequestStatsList';
-  nodes?: Maybe<Array<Maybe<RequestStats>>>;
-  total?: Maybe<Scalars['Int']['output']>;
+	__typename?: 'RequestStatsList';
+	nodes?: Maybe< Array< Maybe< RequestStats > > >;
+	total?: Maybe< Scalars[ 'Int' ][ 'output' ] >;
 };
 
 export type ResendInvitationInput = {
-  invitationId?: InputMaybe<Scalars['Int']['input']>;
+	invitationId?: InputMaybe< Scalars[ 'Int' ][ 'input' ] >;
 };
 
 export type ResendInvitationPayload = {
-  __typename?: 'ResendInvitationPayload';
-  invitation?: Maybe<Invitation>;
+	__typename?: 'ResendInvitationPayload';
+	invitation?: Maybe< Invitation >;
 };
 
 export type ResponseHeader = {
-  __typename?: 'ResponseHeader';
-  name: Scalars['String']['output'];
-  value: Scalars['String']['output'];
+	__typename?: 'ResponseHeader';
+	name: Scalars[ 'String' ][ 'output' ];
+	value: Scalars[ 'String' ][ 'output' ];
 };
 
 export type ReviewQueue = {
-  __typename?: 'ReviewQueue';
-  repos?: Maybe<Array<Maybe<Repo>>>;
+	__typename?: 'ReviewQueue';
+	repos?: Maybe< Array< Maybe< Repo > > >;
 };
 
 export type RollbackInput = {
-  appId?: InputMaybe<Scalars['Int']['input']>;
-  environmentId?: InputMaybe<Scalars['Int']['input']>;
-  toDeploymentId?: InputMaybe<Scalars['Int']['input']>;
+	appId?: InputMaybe< Scalars[ 'Int' ][ 'input' ] >;
+	environmentId?: InputMaybe< Scalars[ 'Int' ][ 'input' ] >;
+	toDeploymentId?: InputMaybe< Scalars[ 'Int' ][ 'input' ] >;
 };
 
 export type RollbackPayload = {
-  __typename?: 'RollbackPayload';
-  newDeployment?: Maybe<Deployment>;
+	__typename?: 'RollbackPayload';
+	newDeployment?: Maybe< Deployment >;
 };
 
 export type SalesforceContact = {
-  __typename?: 'SalesforceContact';
-  email?: Maybe<Scalars['String']['output']>;
-  name?: Maybe<Scalars['String']['output']>;
-  title?: Maybe<Scalars['String']['output']>;
-  type?: Maybe<Scalars['String']['output']>;
+	__typename?: 'SalesforceContact';
+	email?: Maybe< Scalars[ 'String' ][ 'output' ] >;
+	name?: Maybe< Scalars[ 'String' ][ 'output' ] >;
+	title?: Maybe< Scalars[ 'String' ][ 'output' ] >;
+	type?: Maybe< Scalars[ 'String' ][ 'output' ] >;
 };
 
 export type SalesforceContactList = {
-  __typename?: 'SalesforceContactList';
-  nodes?: Maybe<Array<Maybe<SalesforceContact>>>;
-  total?: Maybe<Scalars['Int']['output']>;
+	__typename?: 'SalesforceContactList';
+	nodes?: Maybe< Array< Maybe< SalesforceContact > > >;
+	total?: Maybe< Scalars[ 'Int' ][ 'output' ] >;
 };
 
 export type SendTestNotificationInput = {
-  body?: InputMaybe<Scalars['String']['input']>;
-  header?: InputMaybe<Scalars['String']['input']>;
-  notificationRecipientId: Scalars['Int']['input'];
-  organizationId: Scalars['Int']['input'];
+	body?: InputMaybe< Scalars[ 'String' ][ 'input' ] >;
+	header?: InputMaybe< Scalars[ 'String' ][ 'input' ] >;
+	notificationRecipientId: Scalars[ 'Int' ][ 'input' ];
+	organizationId: Scalars[ 'Int' ][ 'input' ];
 };
 
 export type SendTestNotificationPayload = {
-  __typename?: 'SendTestNotificationPayload';
-  sent?: Maybe<Scalars['Boolean']['output']>;
+	__typename?: 'SendTestNotificationPayload';
+	sent?: Maybe< Scalars[ 'Boolean' ][ 'output' ] >;
 };
 
 export type ServerResponse = {
-  __typename?: 'ServerResponse';
-  headers: Array<ResponseHeader>;
-  statusCode: Scalars['Int']['output'];
+	__typename?: 'ServerResponse';
+	headers: Array< ResponseHeader >;
+	statusCode: Scalars[ 'Int' ][ 'output' ];
 };
 
 export type SetUserApplicationRolesInput = {
-  applicationRoles: Array<InputMaybe<UserApplicationRoleInput>>;
+	applicationRoles: Array< InputMaybe< UserApplicationRoleInput > >;
 };
 
 export type SetUserApplicationRolesPayload = {
-  __typename?: 'SetUserApplicationRolesPayload';
-  applicationRoles?: Maybe<Array<Maybe<UserApplicationRole>>>;
+	__typename?: 'SetUserApplicationRolesPayload';
+	applicationRoles?: Maybe< Array< Maybe< UserApplicationRole > > >;
 };
 
 export type StartMediaExportConfigOptions = {
-  regex?: InputMaybe<Scalars['String']['input']>;
-  subsiteId?: InputMaybe<Scalars['Int']['input']>;
+	regex?: InputMaybe< Scalars[ 'String' ][ 'input' ] >;
+	subsiteId?: InputMaybe< Scalars[ 'Int' ][ 'input' ] >;
 };
 
 export type StartMediaExportInput = {
-  appId?: InputMaybe<Scalars['Int']['input']>;
-  config?: InputMaybe<StartMediaExportConfigOptions>;
-  environmentId?: InputMaybe<Scalars['Int']['input']>;
+	appId?: InputMaybe< Scalars[ 'Int' ][ 'input' ] >;
+	config?: InputMaybe< StartMediaExportConfigOptions >;
+	environmentId?: InputMaybe< Scalars[ 'Int' ][ 'input' ] >;
 };
 
 export type StartMediaExportPayload = {
-  __typename?: 'StartMediaExportPayload';
-  mediaExport?: Maybe<MediaExport>;
-  message?: Maybe<Scalars['String']['output']>;
-  success?: Maybe<Scalars['Boolean']['output']>;
+	__typename?: 'StartMediaExportPayload';
+	mediaExport?: Maybe< MediaExport >;
+	message?: Maybe< Scalars[ 'String' ][ 'output' ] >;
+	success?: Maybe< Scalars[ 'Boolean' ][ 'output' ] >;
 };
 
 export type ToggleUserVipStatusInput = {
-  githubUsername: Scalars['String']['input'];
-  isVIP?: InputMaybe<Scalars['Boolean']['input']>;
+	githubUsername: Scalars[ 'String' ][ 'input' ];
+	isVIP?: InputMaybe< Scalars[ 'Boolean' ][ 'input' ] >;
 };
 
 export type ToggleUserVipStatusPayload = {
-  __typename?: 'ToggleUserVIPStatusPayload';
-  user?: Maybe<User>;
+	__typename?: 'ToggleUserVIPStatusPayload';
+	user?: Maybe< User >;
 };
 
 export type Token = Model & {
-  __typename?: 'Token';
-  active?: Maybe<Scalars['Boolean']['output']>;
-  exp?: Maybe<Scalars['Int']['output']>;
-  id?: Maybe<Scalars['Int']['output']>;
-  userId?: Maybe<Scalars['Int']['output']>;
+	__typename?: 'Token';
+	active?: Maybe< Scalars[ 'Boolean' ][ 'output' ] >;
+	exp?: Maybe< Scalars[ 'Int' ][ 'output' ] >;
+	id?: Maybe< Scalars[ 'Int' ][ 'output' ] >;
+	userId?: Maybe< Scalars[ 'Int' ][ 'output' ] >;
 };
 
 export type UpdateCertificateInput = {
-  certificate: Scalars['String']['input'];
-  certificateId: Scalars['Int']['input'];
-  clientId: Scalars['Int']['input'];
-  domainName?: InputMaybe<Scalars['String']['input']>;
-  trustedCertificate?: InputMaybe<Scalars['String']['input']>;
+	certificate: Scalars[ 'String' ][ 'input' ];
+	certificateId: Scalars[ 'Int' ][ 'input' ];
+	clientId: Scalars[ 'Int' ][ 'input' ];
+	domainName?: InputMaybe< Scalars[ 'String' ][ 'input' ] >;
+	trustedCertificate?: InputMaybe< Scalars[ 'String' ][ 'input' ] >;
 };
 
 export type UpdateCertificatePayload = {
-  __typename?: 'UpdateCertificatePayload';
-  certificate?: Maybe<Certificate>;
+	__typename?: 'UpdateCertificatePayload';
+	certificate?: Maybe< Certificate >;
 };
 
 export type UpdateNotificationRecipientInput = {
-  active?: InputMaybe<Scalars['Boolean']['input']>;
-  description?: InputMaybe<Scalars['String']['input']>;
-  id: Scalars['Int']['input'];
-  meta?: InputMaybe<Scalars['String']['input']>;
-  name?: InputMaybe<Scalars['String']['input']>;
-  organizationId: Scalars['Int']['input'];
-  recipientType?: InputMaybe<NotificationRecipientType>;
-  recipientValue?: InputMaybe<Scalars['String']['input']>;
+	active?: InputMaybe< Scalars[ 'Boolean' ][ 'input' ] >;
+	description?: InputMaybe< Scalars[ 'String' ][ 'input' ] >;
+	id: Scalars[ 'Int' ][ 'input' ];
+	meta?: InputMaybe< Scalars[ 'String' ][ 'input' ] >;
+	name?: InputMaybe< Scalars[ 'String' ][ 'input' ] >;
+	organizationId: Scalars[ 'Int' ][ 'input' ];
+	recipientType?: InputMaybe< NotificationRecipientType >;
+	recipientValue?: InputMaybe< Scalars[ 'String' ][ 'input' ] >;
 };
 
 export type UpdateNotificationRecipientPayload = {
-  __typename?: 'UpdateNotificationRecipientPayload';
-  notificationRecipient?: Maybe<NotificationRecipient>;
+	__typename?: 'UpdateNotificationRecipientPayload';
+	notificationRecipient?: Maybe< NotificationRecipient >;
 };
 
 export type UpdateNotificationSubscriptionInput = {
-  active?: InputMaybe<Scalars['Boolean']['input']>;
-  applicationId: Scalars['Int']['input'];
-  description: Scalars['String']['input'];
-  environmentId: Scalars['Int']['input'];
-  meta?: InputMaybe<Scalars['String']['input']>;
-  notificationRecipientId: Scalars['Int']['input'];
-  notificationSubscriptionId: Scalars['Int']['input'];
+	active?: InputMaybe< Scalars[ 'Boolean' ][ 'input' ] >;
+	applicationId: Scalars[ 'Int' ][ 'input' ];
+	description: Scalars[ 'String' ][ 'input' ];
+	environmentId: Scalars[ 'Int' ][ 'input' ];
+	meta?: InputMaybe< Scalars[ 'String' ][ 'input' ] >;
+	notificationRecipientId: Scalars[ 'Int' ][ 'input' ];
+	notificationSubscriptionId: Scalars[ 'Int' ][ 'input' ];
 };
 
 export type UpdateNotificationSubscriptionPayload = {
-  __typename?: 'UpdateNotificationSubscriptionPayload';
-  notificationSubscription?: Maybe<NotificationSubscription>;
+	__typename?: 'UpdateNotificationSubscriptionPayload';
+	notificationSubscription?: Maybe< NotificationSubscription >;
 };
 
 export type UpdateUserOrganizationRoleInput = {
-  organizationId: Scalars['Int']['input'];
-  role?: InputMaybe<Scalars['String']['input']>;
-  userId: Scalars['Int']['input'];
+	organizationId: Scalars[ 'Int' ][ 'input' ];
+	role?: InputMaybe< Scalars[ 'String' ][ 'input' ] >;
+	userId: Scalars[ 'Int' ][ 'input' ];
 };
 
 export type UpdateUserOrganizationRolePayload = {
-  __typename?: 'UpdateUserOrganizationRolePayload';
-  organizationRole?: Maybe<UserOrganizationRole>;
-  user?: Maybe<User>;
+	__typename?: 'UpdateUserOrganizationRolePayload';
+	organizationRole?: Maybe< UserOrganizationRole >;
+	user?: Maybe< User >;
 };
 
 export type User = Model & {
-  __typename?: 'User';
-  applicationRoles?: Maybe<UserApplicationRoleList>;
-  auth0Id?: Maybe<Scalars['String']['output']>;
-  displayName?: Maybe<Scalars['String']['output']>;
-  emailAddress?: Maybe<Scalars['String']['output']>;
-  githubUsername?: Maybe<Scalars['String']['output']>;
-  id?: Maybe<Scalars['Int']['output']>;
-  isVIP?: Maybe<Scalars['Boolean']['output']>;
-  organizationRoles?: Maybe<UserOrganizationRoleList>;
-  tokens?: Maybe<Array<Maybe<Token>>>;
-  wpcomUsername?: Maybe<Scalars['String']['output']>;
+	__typename?: 'User';
+	applicationRoles?: Maybe< UserApplicationRoleList >;
+	auth0Id?: Maybe< Scalars[ 'String' ][ 'output' ] >;
+	displayName?: Maybe< Scalars[ 'String' ][ 'output' ] >;
+	emailAddress?: Maybe< Scalars[ 'String' ][ 'output' ] >;
+	githubUsername?: Maybe< Scalars[ 'String' ][ 'output' ] >;
+	id?: Maybe< Scalars[ 'Int' ][ 'output' ] >;
+	isVIP?: Maybe< Scalars[ 'Boolean' ][ 'output' ] >;
+	organizationRoles?: Maybe< UserOrganizationRoleList >;
+	tokens?: Maybe< Array< Maybe< Token > > >;
+	wpcomUsername?: Maybe< Scalars[ 'String' ][ 'output' ] >;
 };
 
 export type UserApplicationRolesArgs = {
-  appId?: InputMaybe<Scalars['Int']['input']>;
+	appId?: InputMaybe< Scalars[ 'Int' ][ 'input' ] >;
 };
 
 export type UserApplicationRole = Model & {
-  __typename?: 'UserApplicationRole';
-  app?: Maybe<App>;
-  appId?: Maybe<Scalars['Int']['output']>;
-  id?: Maybe<Scalars['Int']['output']>;
-  role?: Maybe<ApplicationRole>;
-  roleId?: Maybe<ApplicationRoleId>;
-  source?: Maybe<Scalars['String']['output']>;
-  userId?: Maybe<Scalars['Int']['output']>;
+	__typename?: 'UserApplicationRole';
+	app?: Maybe< App >;
+	appId?: Maybe< Scalars[ 'Int' ][ 'output' ] >;
+	id?: Maybe< Scalars[ 'Int' ][ 'output' ] >;
+	role?: Maybe< ApplicationRole >;
+	roleId?: Maybe< ApplicationRoleId >;
+	source?: Maybe< Scalars[ 'String' ][ 'output' ] >;
+	userId?: Maybe< Scalars[ 'Int' ][ 'output' ] >;
 };
 
 export type UserApplicationRoleInput = {
-  appId: Scalars['Int']['input'];
-  roleId?: InputMaybe<ApplicationRoleId>;
-  userId: Scalars['Int']['input'];
+	appId: Scalars[ 'Int' ][ 'input' ];
+	roleId?: InputMaybe< ApplicationRoleId >;
+	userId: Scalars[ 'Int' ][ 'input' ];
 };
 
 export type UserApplicationRoleList = ModelList & {
-  __typename?: 'UserApplicationRoleList';
-  edges?: Maybe<Array<Maybe<UserApplicationRole>>>;
-  nextCursor?: Maybe<Scalars['String']['output']>;
-  nodes?: Maybe<Array<Maybe<UserApplicationRole>>>;
-  total?: Maybe<Scalars['Int']['output']>;
+	__typename?: 'UserApplicationRoleList';
+	edges?: Maybe< Array< Maybe< UserApplicationRole > > >;
+	nextCursor?: Maybe< Scalars[ 'String' ][ 'output' ] >;
+	nodes?: Maybe< Array< Maybe< UserApplicationRole > > >;
+	total?: Maybe< Scalars[ 'Int' ][ 'output' ] >;
 };
 
 export type UserList = ModelList & {
-  __typename?: 'UserList';
-  edges?: Maybe<Array<Maybe<User>>>;
-  nextCursor?: Maybe<Scalars['String']['output']>;
-  nodes?: Maybe<Array<Maybe<User>>>;
-  total?: Maybe<Scalars['Int']['output']>;
+	__typename?: 'UserList';
+	edges?: Maybe< Array< Maybe< User > > >;
+	nextCursor?: Maybe< Scalars[ 'String' ][ 'output' ] >;
+	nodes?: Maybe< Array< Maybe< User > > >;
+	total?: Maybe< Scalars[ 'Int' ][ 'output' ] >;
 };
 
 export type UserOrganizationRole = Model & {
-  __typename?: 'UserOrganizationRole';
-  id?: Maybe<Scalars['Int']['output']>;
-  organization?: Maybe<Organization>;
-  organizationId?: Maybe<Scalars['Int']['output']>;
-  role?: Maybe<OrgRole>;
-  roleId?: Maybe<OrgRoleId>;
-  source?: Maybe<Scalars['String']['output']>;
-  userId?: Maybe<Scalars['Int']['output']>;
+	__typename?: 'UserOrganizationRole';
+	id?: Maybe< Scalars[ 'Int' ][ 'output' ] >;
+	organization?: Maybe< Organization >;
+	organizationId?: Maybe< Scalars[ 'Int' ][ 'output' ] >;
+	role?: Maybe< OrgRole >;
+	roleId?: Maybe< OrgRoleId >;
+	source?: Maybe< Scalars[ 'String' ][ 'output' ] >;
+	userId?: Maybe< Scalars[ 'Int' ][ 'output' ] >;
 };
 
 export type UserOrganizationRoleList = ModelList & {
-  __typename?: 'UserOrganizationRoleList';
-  edges?: Maybe<Array<Maybe<UserOrganizationRole>>>;
-  nextCursor?: Maybe<Scalars['String']['output']>;
-  nodes?: Maybe<Array<Maybe<UserOrganizationRole>>>;
-  total?: Maybe<Scalars['Int']['output']>;
+	__typename?: 'UserOrganizationRoleList';
+	edges?: Maybe< Array< Maybe< UserOrganizationRole > > >;
+	nextCursor?: Maybe< Scalars[ 'String' ][ 'output' ] >;
+	nodes?: Maybe< Array< Maybe< UserOrganizationRole > > >;
+	total?: Maybe< Scalars[ 'Int' ][ 'output' ] >;
 };
 
 export type UserTokenGenerationInput = {
-  lifetime?: InputMaybe<Scalars['String']['input']>;
+	lifetime?: InputMaybe< Scalars[ 'String' ][ 'input' ] >;
 };
 
 export type UserTokenGenerationPayload = {
-  __typename?: 'UserTokenGenerationPayload';
-  jwt?: Maybe<Scalars['String']['output']>;
+	__typename?: 'UserTokenGenerationPayload';
+	jwt?: Maybe< Scalars[ 'String' ][ 'output' ] >;
 };
 
 export type VipprMeta = {
-  __typename?: 'VIPPRMeta';
-  comments?: Maybe<Array<Maybe<GitHubComment>>>;
-  reviewComments?: Maybe<Array<Maybe<GitHubPullRequestReviewComment>>>;
-  reviews?: Maybe<Array<Maybe<GitHubReview>>>;
+	__typename?: 'VIPPRMeta';
+	comments?: Maybe< Array< Maybe< GitHubComment > > >;
+	reviewComments?: Maybe< Array< Maybe< GitHubPullRequestReviewComment > > >;
+	reviews?: Maybe< Array< Maybe< GitHubReview > > >;
 };
 
 export type WpcliCommand = {
-  __typename?: 'WPCLICommand';
-  command?: Maybe<Scalars['String']['output']>;
-  createdAt?: Maybe<Scalars['String']['output']>;
-  endedAt?: Maybe<Scalars['String']['output']>;
-  environmentId?: Maybe<Scalars['Int']['output']>;
-  guid?: Maybe<Scalars['String']['output']>;
-  id?: Maybe<Scalars['Int']['output']>;
-  startedAt?: Maybe<Scalars['String']['output']>;
-  status?: Maybe<Scalars['String']['output']>;
-  user?: Maybe<WpcliCommandUser>;
-  userId?: Maybe<Scalars['Int']['output']>;
+	__typename?: 'WPCLICommand';
+	command?: Maybe< Scalars[ 'String' ][ 'output' ] >;
+	createdAt?: Maybe< Scalars[ 'String' ][ 'output' ] >;
+	endedAt?: Maybe< Scalars[ 'String' ][ 'output' ] >;
+	environmentId?: Maybe< Scalars[ 'Int' ][ 'output' ] >;
+	guid?: Maybe< Scalars[ 'String' ][ 'output' ] >;
+	id?: Maybe< Scalars[ 'Int' ][ 'output' ] >;
+	startedAt?: Maybe< Scalars[ 'String' ][ 'output' ] >;
+	status?: Maybe< Scalars[ 'String' ][ 'output' ] >;
+	user?: Maybe< WpcliCommandUser >;
+	userId?: Maybe< Scalars[ 'Int' ][ 'output' ] >;
 };
 
 export type WpcliCommandList = {
-  __typename?: 'WPCLICommandList';
-  nextCursor?: Maybe<Scalars['String']['output']>;
-  nodes?: Maybe<Array<Maybe<WpcliCommand>>>;
-  total?: Maybe<Scalars['Int']['output']>;
+	__typename?: 'WPCLICommandList';
+	nextCursor?: Maybe< Scalars[ 'String' ][ 'output' ] >;
+	nodes?: Maybe< Array< Maybe< WpcliCommand > > >;
+	total?: Maybe< Scalars[ 'Int' ][ 'output' ] >;
 };
 
 export type WpcliCommandUser = {
-  __typename?: 'WPCLICommandUser';
-  displayName?: Maybe<Scalars['String']['output']>;
-  githubUsername?: Maybe<Scalars['String']['output']>;
-  id?: Maybe<Scalars['Int']['output']>;
-  isVIP?: Maybe<Scalars['Boolean']['output']>;
-  wpcomUsername?: Maybe<Scalars['String']['output']>;
+	__typename?: 'WPCLICommandUser';
+	displayName?: Maybe< Scalars[ 'String' ][ 'output' ] >;
+	githubUsername?: Maybe< Scalars[ 'String' ][ 'output' ] >;
+	id?: Maybe< Scalars[ 'Int' ][ 'output' ] >;
+	isVIP?: Maybe< Scalars[ 'Boolean' ][ 'output' ] >;
+	wpcomUsername?: Maybe< Scalars[ 'String' ][ 'output' ] >;
 };
 
 export type WpInstallation = {
-  __typename?: 'WPInstallation';
-  /** Core WordPress Site Installation Details */
-  core?: Maybe<WpInstallationCoreDetails>;
-  /** App Environment Name */
-  environmentName?: Maybe<Scalars['String']['output']>;
-  /** Details about Jetpack */
-  jetpack?: Maybe<WpInstallationJetpackDetails>;
-  /** Details about all plugins installed */
-  plugins?: Maybe<Array<WpInstallationPluginDetails>>;
-  /** App Environment / GOOP Site ID */
-  siteId?: Maybe<Scalars['Int']['output']>;
-  /** Last updated timestamp of the Site Installation Details */
-  timestamp?: Maybe<Scalars['BigInt']['output']>;
+	__typename?: 'WPInstallation';
+	/** Core WordPress Site Installation Details */
+	core?: Maybe< WpInstallationCoreDetails >;
+	/** App Environment Name */
+	environmentName?: Maybe< Scalars[ 'String' ][ 'output' ] >;
+	/** Details about Jetpack */
+	jetpack?: Maybe< WpInstallationJetpackDetails >;
+	/** Details about all plugins installed */
+	plugins?: Maybe< Array< WpInstallationPluginDetails > >;
+	/** App Environment / GOOP Site ID */
+	siteId?: Maybe< Scalars[ 'Int' ][ 'output' ] >;
+	/** Last updated timestamp of the Site Installation Details */
+	timestamp?: Maybe< Scalars[ 'BigInt' ][ 'output' ] >;
 };
 
 export type WpInstallationCoreDetails = {
-  __typename?: 'WPInstallationCoreDetails';
-  /** Is WordPress Multisite Installation */
-  isMultisite?: Maybe<Scalars['Boolean']['output']>;
-  /** WordPress Installation PHP Version */
-  phpVersion?: Maybe<Scalars['String']['output']>;
-  /** WordPress Installation Version */
-  wpVersion?: Maybe<Scalars['String']['output']>;
+	__typename?: 'WPInstallationCoreDetails';
+	/** Is WordPress Multisite Installation */
+	isMultisite?: Maybe< Scalars[ 'Boolean' ][ 'output' ] >;
+	/** WordPress Installation PHP Version */
+	phpVersion?: Maybe< Scalars[ 'String' ][ 'output' ] >;
+	/** WordPress Installation Version */
+	wpVersion?: Maybe< Scalars[ 'String' ][ 'output' ] >;
 };
 
 export type WpInstallationJetpackDetails = {
-  __typename?: 'WPInstallationJetpackDetails';
-  /** Is Jetpack available on WordPress Installation */
-  available?: Maybe<Scalars['Boolean']['output']>;
-  /** Jetpack Version */
-  version?: Maybe<Scalars['String']['output']>;
-  /** VIP Jetpack Version */
-  vipVersion?: Maybe<Scalars['String']['output']>;
+	__typename?: 'WPInstallationJetpackDetails';
+	/** Is Jetpack available on WordPress Installation */
+	available?: Maybe< Scalars[ 'Boolean' ][ 'output' ] >;
+	/** Jetpack Version */
+	version?: Maybe< Scalars[ 'String' ][ 'output' ] >;
+	/** VIP Jetpack Version */
+	vipVersion?: Maybe< Scalars[ 'String' ][ 'output' ] >;
 };
 
 export type WpInstallationPluginDetails = {
-  __typename?: 'WPInstallationPluginDetails';
-  /** WordPress Plugin activated by */
-  activatedBy?: Maybe<Scalars['String']['output']>;
-  /** Is WordPress Plugin active */
-  active: Scalars['Boolean']['output'];
-  /** WordPress Plugin update download link */
-  downloadLink?: Maybe<Scalars['String']['output']>;
-  /** WordPress Plugin available update version */
-  hasUpdate?: Maybe<Scalars['String']['output']>;
-  /** WordPress Plugin marketplace */
-  marketplace?: Maybe<Scalars['String']['output']>;
-  /** WordPress Plugin name */
-  name: Scalars['String']['output'];
-  /** WordPress Plugin path */
-  path: Scalars['String']['output'];
-  /** WordPress Plugin slug */
-  slug?: Maybe<Scalars['String']['output']>;
-  /** WordPress Plugin version */
-  version: Scalars['String']['output'];
+	__typename?: 'WPInstallationPluginDetails';
+	/** WordPress Plugin activated by */
+	activatedBy?: Maybe< Scalars[ 'String' ][ 'output' ] >;
+	/** Is WordPress Plugin active */
+	active: Scalars[ 'Boolean' ][ 'output' ];
+	/** WordPress Plugin update download link */
+	downloadLink?: Maybe< Scalars[ 'String' ][ 'output' ] >;
+	/** WordPress Plugin available update version */
+	hasUpdate?: Maybe< Scalars[ 'String' ][ 'output' ] >;
+	/** WordPress Plugin marketplace */
+	marketplace?: Maybe< Scalars[ 'String' ][ 'output' ] >;
+	/** WordPress Plugin name */
+	name: Scalars[ 'String' ][ 'output' ];
+	/** WordPress Plugin path */
+	path: Scalars[ 'String' ][ 'output' ];
+	/** WordPress Plugin slug */
+	slug?: Maybe< Scalars[ 'String' ][ 'output' ] >;
+	/** WordPress Plugin version */
+	version: Scalars[ 'String' ][ 'output' ];
 };
 
 export type WpSite = {
-  __typename?: 'WPSite';
-  /** WordPress Site/Blog ID */
-  blogId?: Maybe<Scalars['Int']['output']>;
-  /** List of WordPress PHP defines/constants used in the blog */
-  constants?: Maybe<Array<Maybe<WpSitePhpConstants>>>;
-  /** WordPress Home URL option */
-  homeUrl?: Maybe<Scalars['String']['output']>;
-  /** [DEPRECATING SOON] Alias for blogId */
-  id?: Maybe<Scalars['Int']['output']>;
-  /** WP Site Installation Details */
-  installation?: Maybe<WpInstallation>;
-  /** [DEPRECATING SOON] Is blog active */
-  isActive?: Maybe<Scalars['Boolean']['output']>;
-  /** Jetpack Details */
-  jetpack?: Maybe<WpSiteJetpackDetails>;
-  /** [DEPRECATING SOON] Alias for jetpack */
-  jetpackDetails?: Maybe<WpSiteJetpackDetails>;
-  /** Launched status of the subsite */
-  launchStatus?: Maybe<WpSiteLaunchStatus>;
-  /** Details about Parse.ly plugin (wp-parsely) usage */
-  parsely?: Maybe<WpSiteParselyDetails>;
-  /** List of enabled plugins on the blog */
-  plugins?: Maybe<Array<Maybe<Scalars['String']['output']>>>;
-  /** WordPress Site URL option */
-  siteUrl?: Maybe<Scalars['String']['output']>;
-  /** Last updated timestamp of the Site Details */
-  timestamp?: Maybe<Scalars['BigInt']['output']>;
+	__typename?: 'WPSite';
+	/** WordPress Site/Blog ID */
+	blogId?: Maybe< Scalars[ 'Int' ][ 'output' ] >;
+	/** List of WordPress PHP defines/constants used in the blog */
+	constants?: Maybe< Array< Maybe< WpSitePhpConstants > > >;
+	/** WordPress Home URL option */
+	homeUrl?: Maybe< Scalars[ 'String' ][ 'output' ] >;
+	/** [DEPRECATING SOON] Alias for blogId */
+	id?: Maybe< Scalars[ 'Int' ][ 'output' ] >;
+	/** WP Site Installation Details */
+	installation?: Maybe< WpInstallation >;
+	/** [DEPRECATING SOON] Is blog active */
+	isActive?: Maybe< Scalars[ 'Boolean' ][ 'output' ] >;
+	/** Jetpack Details */
+	jetpack?: Maybe< WpSiteJetpackDetails >;
+	/** [DEPRECATING SOON] Alias for jetpack */
+	jetpackDetails?: Maybe< WpSiteJetpackDetails >;
+	/** Launched status of the subsite */
+	launchStatus?: Maybe< WpSiteLaunchStatus >;
+	/** Details about Parse.ly plugin (wp-parsely) usage */
+	parsely?: Maybe< WpSiteParselyDetails >;
+	/** List of enabled plugins on the blog */
+	plugins?: Maybe< Array< Maybe< Scalars[ 'String' ][ 'output' ] > > >;
+	/** WordPress Site URL option */
+	siteUrl?: Maybe< Scalars[ 'String' ][ 'output' ] >;
+	/** Last updated timestamp of the Site Details */
+	timestamp?: Maybe< Scalars[ 'BigInt' ][ 'output' ] >;
 };
 
 export type WpSiteJetpackDetails = {
-  __typename?: 'WPSiteJetpackDetails';
-  /** Is Jetpack Active */
-  active?: Maybe<Scalars['Boolean']['output']>;
-  /** [DEPRECATING SOON] Jetpack Cache Site ID */
-  cacheSiteId?: Maybe<Scalars['Int']['output']>;
-  /** Jetpack Cache Site ID */
-  id?: Maybe<Scalars['String']['output']>;
-  /** Enabled Jetpack modules */
-  modules?: Maybe<Array<Maybe<Scalars['String']['output']>>>;
+	__typename?: 'WPSiteJetpackDetails';
+	/** Is Jetpack Active */
+	active?: Maybe< Scalars[ 'Boolean' ][ 'output' ] >;
+	/** [DEPRECATING SOON] Jetpack Cache Site ID */
+	cacheSiteId?: Maybe< Scalars[ 'Int' ][ 'output' ] >;
+	/** Jetpack Cache Site ID */
+	id?: Maybe< Scalars[ 'String' ][ 'output' ] >;
+	/** Enabled Jetpack modules */
+	modules?: Maybe< Array< Maybe< Scalars[ 'String' ][ 'output' ] > > >;
 };
 
-export enum WpSiteLaunchStatus {
-  Launched = 'LAUNCHED',
-  Launching = 'LAUNCHING',
-  NotLaunched = 'NOT_LAUNCHED',
-  Unknown = 'UNKNOWN'
-}
+export type WpSiteLaunchStatus = 'LAUNCHED' | 'LAUNCHING' | 'NOT_LAUNCHED' | 'UNKNOWN';
 
 /** Variables for the UpdateWPSiteLaunchStatus mutation */
 export type WpSiteLaunchStatusInput = {
-  /** Unique ID of the application */
-  appId: Scalars['Int']['input'];
-  /** Unique ID of the environment */
-  environmentId: Scalars['Int']['input'];
-  /** Updated launch status of the network site */
-  launchStatus: WpSiteLaunchStatus;
-  /** ID of the network site (subsite) being updated */
-  networkSiteId: Scalars['Int']['input'];
+	/** Unique ID of the application */
+	appId: Scalars[ 'Int' ][ 'input' ];
+	/** Unique ID of the environment */
+	environmentId: Scalars[ 'Int' ][ 'input' ];
+	/** Updated launch status of the network site */
+	launchStatus: WpSiteLaunchStatus;
+	/** ID of the network site (subsite) being updated */
+	networkSiteId: Scalars[ 'Int' ][ 'input' ];
 };
 
 /** Variables for the UpdateWPSiteLaunchStatus mutation */
 export type WpSiteLaunchStatusPayload = {
-  __typename?: 'WPSiteLaunchStatusPayload';
-  app?: Maybe<App>;
-  environment?: Maybe<AppEnvironment>;
-  launchStatus?: Maybe<Scalars['String']['output']>;
-  /** ID of the network site (subsite) being updated */
-  networkSiteId?: Maybe<Scalars['Int']['output']>;
-  /** Updated launch status of the network site */
-  updated?: Maybe<Scalars['Boolean']['output']>;
+	__typename?: 'WPSiteLaunchStatusPayload';
+	app?: Maybe< App >;
+	environment?: Maybe< AppEnvironment >;
+	launchStatus?: Maybe< Scalars[ 'String' ][ 'output' ] >;
+	/** ID of the network site (subsite) being updated */
+	networkSiteId?: Maybe< Scalars[ 'Int' ][ 'output' ] >;
+	/** Updated launch status of the network site */
+	updated?: Maybe< Scalars[ 'Boolean' ][ 'output' ] >;
 };
 
 export type WpSiteList = {
-  __typename?: 'WPSiteList';
-  nextCursor?: Maybe<Scalars['String']['output']>;
-  nodes?: Maybe<Array<Maybe<WpSite>>>;
-  total?: Maybe<Scalars['Int']['output']>;
+	__typename?: 'WPSiteList';
+	nextCursor?: Maybe< Scalars[ 'String' ][ 'output' ] >;
+	nodes?: Maybe< Array< Maybe< WpSite > > >;
+	total?: Maybe< Scalars[ 'Int' ][ 'output' ] >;
 };
 
 export type WpSiteParselyConfigs = {
-  __typename?: 'WPSiteParselyConfigs';
-  /** Does the site have a Parse.ly API Secret configured? */
-  haveApiSecret?: Maybe<Scalars['Boolean']['output']>;
-  /** Is autotrack disabled (to allow Dynamic Tracking to be used)? */
-  isAutotrackingDisabled?: Maybe<Scalars['Boolean']['output']>;
-  /** Is JavaScript Tracking disabled? */
-  isJavascriptDisabled?: Maybe<Scalars['Boolean']['output']>;
-  /** Is the site pinned to the specific plugin version? */
-  isPinnedVersion?: Maybe<Scalars['Boolean']['output']>;
-  /** Is JavaScript tracking enabled for logged in users? */
-  shouldTrackLoggedInUsers?: Maybe<Scalars['Boolean']['output']>;
-  /** Parse.ly Site ID (aka apikey) */
-  siteId?: Maybe<Scalars['String']['output']>;
-  /** Details about tracked post types */
-  trackedPostTypes?: Maybe<Array<Maybe<WpSiteParselyTrackedPostTypesConfig>>>;
+	__typename?: 'WPSiteParselyConfigs';
+	/** Does the site have a Parse.ly API Secret configured? */
+	haveApiSecret?: Maybe< Scalars[ 'Boolean' ][ 'output' ] >;
+	/** Is autotrack disabled (to allow Dynamic Tracking to be used)? */
+	isAutotrackingDisabled?: Maybe< Scalars[ 'Boolean' ][ 'output' ] >;
+	/** Is JavaScript Tracking disabled? */
+	isJavascriptDisabled?: Maybe< Scalars[ 'Boolean' ][ 'output' ] >;
+	/** Is the site pinned to the specific plugin version? */
+	isPinnedVersion?: Maybe< Scalars[ 'Boolean' ][ 'output' ] >;
+	/** Is JavaScript tracking enabled for logged in users? */
+	shouldTrackLoggedInUsers?: Maybe< Scalars[ 'Boolean' ][ 'output' ] >;
+	/** Parse.ly Site ID (aka apikey) */
+	siteId?: Maybe< Scalars[ 'String' ][ 'output' ] >;
+	/** Details about tracked post types */
+	trackedPostTypes?: Maybe< Array< Maybe< WpSiteParselyTrackedPostTypesConfig > > >;
 };
 
 export type WpSiteParselyDetails = {
-  __typename?: 'WPSiteParselyDetails';
-  /** Is wp-parsely active? */
-  active?: Maybe<Scalars['Boolean']['output']>;
-  /** Details about how the plugin is configured on site */
-  configs?: Maybe<WpSiteParselyConfigs>;
-  /** How wp-parsely is activated (if active) */
-  integrationType?: Maybe<Scalars['String']['output']>;
-  /** Version for the wp-parsely plugin */
-  version?: Maybe<Scalars['String']['output']>;
+	__typename?: 'WPSiteParselyDetails';
+	/** Is wp-parsely active? */
+	active?: Maybe< Scalars[ 'Boolean' ][ 'output' ] >;
+	/** Details about how the plugin is configured on site */
+	configs?: Maybe< WpSiteParselyConfigs >;
+	/** How wp-parsely is activated (if active) */
+	integrationType?: Maybe< Scalars[ 'String' ][ 'output' ] >;
+	/** Version for the wp-parsely plugin */
+	version?: Maybe< Scalars[ 'String' ][ 'output' ] >;
 };
 
 export type WpSiteParselyTrackedPostTypesConfig = {
-  __typename?: 'WPSiteParselyTrackedPostTypesConfig';
-  /** The slug for the post type */
-  name?: Maybe<Scalars['String']['output']>;
-  /** How is the post type tracked within Parse.ly? (post, non-post, or do-not-track) */
-  trackType?: Maybe<Scalars['String']['output']>;
+	__typename?: 'WPSiteParselyTrackedPostTypesConfig';
+	/** The slug for the post type */
+	name?: Maybe< Scalars[ 'String' ][ 'output' ] >;
+	/** How is the post type tracked within Parse.ly? (post, non-post, or do-not-track) */
+	trackType?: Maybe< Scalars[ 'String' ][ 'output' ] >;
 };
 
 export type WpSitePhpConstants = {
-  __typename?: 'WPSitePhpConstants';
-  /** WordPress PHP Define/Constant key */
-  name?: Maybe<Scalars['String']['output']>;
-  /** WordPress PHP Define/Constant value */
-  value?: Maybe<Scalars['String']['output']>;
+	__typename?: 'WPSitePhpConstants';
+	/** WordPress PHP Define/Constant key */
+	name?: Maybe< Scalars[ 'String' ][ 'output' ] >;
+	/** WordPress PHP Define/Constant value */
+	value?: Maybe< Scalars[ 'String' ][ 'output' ] >;
 };

--- a/src/lib/api/cache-purge.generated.d.ts
+++ b/src/lib/api/cache-purge.generated.d.ts
@@ -1,16 +1,16 @@
 import * as Types from '../../graphqlTypes';
 
-export type PurgePageCacheMutationMutationVariables = Types.Exact<{
-	appId: Types.Scalars['Int']['input'];
-	envId: Types.Scalars['Int']['input'];
-	urls: Array<Types.Scalars['String']['input']> | Types.Scalars['String']['input'];
-}>;
+export type PurgePageCacheMutationMutationVariables = Types.Exact< {
+	appId: Types.Scalars[ 'Int' ][ 'input' ];
+	envId: Types.Scalars[ 'Int' ][ 'input' ];
+	urls: Array< Types.Scalars[ 'String' ][ 'input' ] > | Types.Scalars[ 'String' ][ 'input' ];
+} >;
 
 export type PurgePageCacheMutationMutation = {
-	__typename?: 'Mutation',
+	__typename?: 'Mutation';
 	purgePageCache?: {
-		__typename?: 'PurgePageCachePayload',
-		success: boolean,
-		urls: Array<string>
-	} | null
+		__typename?: 'PurgePageCachePayload';
+		success: boolean;
+		urls: Array< string >;
+	} | null;
 };

--- a/src/lib/api/feature-flags.generated.d.ts
+++ b/src/lib/api/feature-flags.generated.d.ts
@@ -1,8 +1,8 @@
 import * as Types from '../../graphqlTypes';
 
-export type IsVipQueryVariables = Types.Exact<{ [ key: string ]: never; }>;
+export type IsVipQueryVariables = Types.Exact< { [ key: string ]: never } >;
 
 export type IsVipQuery = {
-	__typename?: 'Query',
-	me?: { __typename?: 'User', isVIP?: boolean | null } | null
+	__typename?: 'Query';
+	me?: { __typename?: 'User'; isVIP?: boolean | null } | null;
 };

--- a/src/lib/api/user.generated.d.ts
+++ b/src/lib/api/user.generated.d.ts
@@ -1,21 +1,21 @@
 import * as Types from '../../graphqlTypes';
 
-export type MeQueryVariables = Types.Exact<{ [ key: string ]: never; }>;
+export type MeQueryVariables = Types.Exact< { [ key: string ]: never } >;
 
 export type MeQuery = {
-	__typename?: 'Query',
+	__typename?: 'Query';
 	me?: {
-		__typename?: 'User',
-		id?: number | null,
-		displayName?: string | null,
-		isVIP?: boolean | null,
+		__typename?: 'User';
+		id?: number | null;
+		displayName?: string | null;
+		isVIP?: boolean | null;
 		organizationRoles?: {
-			__typename?: 'UserOrganizationRoleList',
-			nodes?: Array<{
-				__typename?: 'UserOrganizationRole',
-				organizationId?: number | null,
-				roleId?: Types.OrgRoleId | null
-			} | null> | null
-		} | null
-	} | null
+			__typename?: 'UserOrganizationRoleList';
+			nodes?: Array< {
+				__typename?: 'UserOrganizationRole';
+				organizationId?: number | null;
+				roleId?: Types.OrgRoleId | null;
+			} | null > | null;
+		} | null;
+	} | null;
 };

--- a/src/lib/app-logs/app-logs.generated.d.ts
+++ b/src/lib/app-logs/app-logs.generated.d.ts
@@ -1,30 +1,30 @@
 import * as Types from '../../graphqlTypes';
 
-export type GetAppLogsQueryVariables = Types.Exact<{
-	appId?: Types.InputMaybe<Types.Scalars['Int']['input']>;
-	envId?: Types.InputMaybe<Types.Scalars['Int']['input']>;
-	type?: Types.InputMaybe<Types.AppEnvironmentLogType>;
-	limit?: Types.InputMaybe<Types.Scalars['Int']['input']>;
-	after?: Types.InputMaybe<Types.Scalars['String']['input']>;
-}>;
+export type GetAppLogsQueryVariables = Types.Exact< {
+	appId?: Types.InputMaybe< Types.Scalars[ 'Int' ][ 'input' ] >;
+	envId?: Types.InputMaybe< Types.Scalars[ 'Int' ][ 'input' ] >;
+	type?: Types.InputMaybe< Types.AppEnvironmentLogType >;
+	limit?: Types.InputMaybe< Types.Scalars[ 'Int' ][ 'input' ] >;
+	after?: Types.InputMaybe< Types.Scalars[ 'String' ][ 'input' ] >;
+} >;
 
 export type GetAppLogsQuery = {
-	__typename?: 'Query',
+	__typename?: 'Query';
 	app?: {
-		__typename?: 'App',
-		environments?: Array<{
-			__typename?: 'AppEnvironment',
-			id?: number | null,
+		__typename?: 'App';
+		environments?: Array< {
+			__typename?: 'AppEnvironment';
+			id?: number | null;
 			logs?: {
-				__typename?: 'AppEnvironmentLogsList',
-				nextCursor?: string | null,
-				pollingDelaySeconds: number,
-				nodes?: Array<{
-					__typename?: 'AppEnvironmentLog',
-					timestamp?: string | null,
-					message?: string | null
-				} | null> | null
-			} | null
-		} | null> | null
-	} | null
+				__typename?: 'AppEnvironmentLogsList';
+				nextCursor?: string | null;
+				pollingDelaySeconds: number;
+				nodes?: Array< {
+					__typename?: 'AppEnvironmentLog';
+					timestamp?: string | null;
+					message?: string | null;
+				} | null > | null;
+			} | null;
+		} | null > | null;
+	} | null;
 };

--- a/src/lib/config/software.generated.d.ts
+++ b/src/lib/config/software.generated.d.ts
@@ -1,67 +1,71 @@
 import * as Types from '../../graphqlTypes';
 
-export type UpdateSoftwareSettingsMutationVariables = Types.Exact<{
-  appId: Types.Scalars['Int']['input'];
-  envId: Types.Scalars['Int']['input'];
-  component: Types.Scalars['String']['input'];
-  version: Types.Scalars['String']['input'];
-}>;
+export type UpdateSoftwareSettingsMutationVariables = Types.Exact< {
+	appId: Types.Scalars[ 'Int' ][ 'input' ];
+	envId: Types.Scalars[ 'Int' ][ 'input' ];
+	component: Types.Scalars[ 'String' ][ 'input' ];
+	version: Types.Scalars[ 'String' ][ 'input' ];
+} >;
 
 export type UpdateSoftwareSettingsMutation = {
-  __typename?: 'Mutation',
-  updateSoftwareSettings?: {
-    __typename?: 'AppEnvironmentSoftwareSettings',
-    php?: { __typename?: 'AppEnvironmentSoftwareSettingsSoftware' } | null,
-    wordpress?: { __typename?: 'AppEnvironmentSoftwareSettingsSoftware' } | null,
-    muplugins?: { __typename?: 'AppEnvironmentSoftwareSettingsSoftware' } | null,
-    nodejs?: { __typename?: 'AppEnvironmentSoftwareSettingsSoftware' } | null
-  } | null
+	__typename?: 'Mutation';
+	updateSoftwareSettings?: {
+		__typename?: 'AppEnvironmentSoftwareSettings';
+		php?: { __typename?: 'AppEnvironmentSoftwareSettingsSoftware' } | null;
+		wordpress?: { __typename?: 'AppEnvironmentSoftwareSettingsSoftware' } | null;
+		muplugins?: { __typename?: 'AppEnvironmentSoftwareSettingsSoftware' } | null;
+		nodejs?: { __typename?: 'AppEnvironmentSoftwareSettingsSoftware' } | null;
+	} | null;
 };
 
-export type UpdateJobQueryVariables = Types.Exact<{
-  appId: Types.Scalars['Int']['input'];
-  envId: Types.Scalars['Int']['input'];
-}>;
+export type UpdateJobQueryVariables = Types.Exact< {
+	appId: Types.Scalars[ 'Int' ][ 'input' ];
+	envId: Types.Scalars[ 'Int' ][ 'input' ];
+} >;
 
 export type UpdateJobQuery = {
-  __typename?: 'Query',
-  app?: {
-    __typename?: 'App',
-    environments?: Array<{
-      __typename?: 'AppEnvironment',
-      jobs?: Array<{
-        __typename?: 'Job',
-        type?: string | null,
-        completedAt?: string | null,
-        createdAt?: string | null,
-        inProgressLock?: boolean | null,
-        progress?: {
-          __typename?: 'JobProgress',
-          status?: string | null,
-          steps?: Array<{
-            __typename?: 'JobProgressStep',
-            step?: string | null,
-            name?: string | null,
-            status?: string | null
-          } | null> | null
-        } | null
-      } | {
-        __typename?: 'PrimaryDomainSwitchJob',
-        type?: string | null,
-        completedAt?: string | null,
-        createdAt?: string | null,
-        inProgressLock?: boolean | null,
-        progress?: {
-          __typename?: 'JobProgress',
-          status?: string | null,
-          steps?: Array<{
-            __typename?: 'JobProgressStep',
-            step?: string | null,
-            name?: string | null,
-            status?: string | null
-          } | null> | null
-        } | null
-      } | null> | null
-    } | null> | null
-  } | null
+	__typename?: 'Query';
+	app?: {
+		__typename?: 'App';
+		environments?: Array< {
+			__typename?: 'AppEnvironment';
+			jobs?: Array<
+				| {
+						__typename?: 'Job';
+						type?: string | null;
+						completedAt?: string | null;
+						createdAt?: string | null;
+						inProgressLock?: boolean | null;
+						progress?: {
+							__typename?: 'JobProgress';
+							status?: string | null;
+							steps?: Array< {
+								__typename?: 'JobProgressStep';
+								step?: string | null;
+								name?: string | null;
+								status?: string | null;
+							} | null > | null;
+						} | null;
+				  }
+				| {
+						__typename?: 'PrimaryDomainSwitchJob';
+						type?: string | null;
+						completedAt?: string | null;
+						createdAt?: string | null;
+						inProgressLock?: boolean | null;
+						progress?: {
+							__typename?: 'JobProgress';
+							status?: string | null;
+							steps?: Array< {
+								__typename?: 'JobProgressStep';
+								step?: string | null;
+								name?: string | null;
+								status?: string | null;
+							} | null > | null;
+						} | null;
+				  }
+				| null
+			> | null;
+		} | null > | null;
+	} | null;
 };

--- a/src/lib/envvar/api-delete.generated.d.ts
+++ b/src/lib/envvar/api-delete.generated.d.ts
@@ -1,19 +1,19 @@
 import * as Types from '../../graphqlTypes';
 
-export type DeleteEnvironmentVariableMutationVariables = Types.Exact<{
-  appId: Types.Scalars['Int']['input'];
-  envId: Types.Scalars['Int']['input'];
-  name: Types.Scalars['String']['input'];
-}>;
+export type DeleteEnvironmentVariableMutationVariables = Types.Exact< {
+	appId: Types.Scalars[ 'Int' ][ 'input' ];
+	envId: Types.Scalars[ 'Int' ][ 'input' ];
+	name: Types.Scalars[ 'String' ][ 'input' ];
+} >;
 
 export type DeleteEnvironmentVariableMutation = {
-  __typename?: 'Mutation',
-  deleteEnvironmentVariable?: {
-    __typename?: 'EnvironmentVariablesPayload',
-    environmentVariables?: {
-      __typename?: 'EnvironmentVariablesList',
-      total?: any | null,
-      nodes?: Array<{ __typename?: 'EnvironmentVariable', name: string } | null> | null
-    } | null
-  } | null
+	__typename?: 'Mutation';
+	deleteEnvironmentVariable?: {
+		__typename?: 'EnvironmentVariablesPayload';
+		environmentVariables?: {
+			__typename?: 'EnvironmentVariablesList';
+			total?: any | null;
+			nodes?: Array< { __typename?: 'EnvironmentVariable'; name: string } | null > | null;
+		} | null;
+	} | null;
 };

--- a/src/lib/envvar/api-get-all.generated.d.ts
+++ b/src/lib/envvar/api-get-all.generated.d.ts
@@ -1,27 +1,27 @@
 import * as Types from '../../graphqlTypes';
 
-export type GetEnvironmentVariablesWithValuesQueryVariables = Types.Exact<{
-	appId: Types.Scalars['Int']['input'];
-	envId: Types.Scalars['Int']['input'];
-}>;
+export type GetEnvironmentVariablesWithValuesQueryVariables = Types.Exact< {
+	appId: Types.Scalars[ 'Int' ][ 'input' ];
+	envId: Types.Scalars[ 'Int' ][ 'input' ];
+} >;
 
 export type GetEnvironmentVariablesWithValuesQuery = {
-	__typename?: 'Query',
+	__typename?: 'Query';
 	app?: {
-		__typename?: 'App',
-		id?: number | null,
-		environments?: Array<{
-			__typename?: 'AppEnvironment',
-			id?: number | null,
+		__typename?: 'App';
+		id?: number | null;
+		environments?: Array< {
+			__typename?: 'AppEnvironment';
+			id?: number | null;
 			environmentVariables?: {
-				__typename?: 'EnvironmentVariablesList',
-				total?: any | null,
-				nodes?: Array<{
-					__typename?: 'EnvironmentVariable',
-					name: string,
-					value?: string | null
-				} | null> | null
-			} | null
-		} | null> | null
-	} | null
+				__typename?: 'EnvironmentVariablesList';
+				total?: any | null;
+				nodes?: Array< {
+					__typename?: 'EnvironmentVariable';
+					name: string;
+					value?: string | null;
+				} | null > | null;
+			} | null;
+		} | null > | null;
+	} | null;
 };

--- a/src/lib/envvar/api-list.generated.d.ts
+++ b/src/lib/envvar/api-list.generated.d.ts
@@ -1,23 +1,23 @@
 import * as Types from '../../graphqlTypes';
 
-export type GetEnvironmentVariablesQueryVariables = Types.Exact<{
-	appId: Types.Scalars['Int']['input'];
-	envId: Types.Scalars['Int']['input'];
-}>;
+export type GetEnvironmentVariablesQueryVariables = Types.Exact< {
+	appId: Types.Scalars[ 'Int' ][ 'input' ];
+	envId: Types.Scalars[ 'Int' ][ 'input' ];
+} >;
 
 export type GetEnvironmentVariablesQuery = {
-	__typename?: 'Query',
+	__typename?: 'Query';
 	app?: {
-		__typename?: 'App',
-		id?: number | null,
-		environments?: Array<{
-			__typename?: 'AppEnvironment',
-			id?: number | null,
+		__typename?: 'App';
+		id?: number | null;
+		environments?: Array< {
+			__typename?: 'AppEnvironment';
+			id?: number | null;
 			environmentVariables?: {
-				__typename?: 'EnvironmentVariablesList',
-				total?: any | null,
-				nodes?: Array<{ __typename?: 'EnvironmentVariable', name: string } | null> | null
-			} | null
-		} | null> | null
-	} | null
+				__typename?: 'EnvironmentVariablesList';
+				total?: any | null;
+				nodes?: Array< { __typename?: 'EnvironmentVariable'; name: string } | null > | null;
+			} | null;
+		} | null > | null;
+	} | null;
 };

--- a/src/lib/envvar/api-set.generated.d.ts
+++ b/src/lib/envvar/api-set.generated.d.ts
@@ -1,20 +1,20 @@
 import * as Types from '../../graphqlTypes';
 
-export type AddEnvironmentVariableMutationVariables = Types.Exact<{
-  appId: Types.Scalars['Int']['input'];
-  envId: Types.Scalars['Int']['input'];
-  name: Types.Scalars['String']['input'];
-  value: Types.Scalars['String']['input'];
-}>;
+export type AddEnvironmentVariableMutationVariables = Types.Exact< {
+	appId: Types.Scalars[ 'Int' ][ 'input' ];
+	envId: Types.Scalars[ 'Int' ][ 'input' ];
+	name: Types.Scalars[ 'String' ][ 'input' ];
+	value: Types.Scalars[ 'String' ][ 'input' ];
+} >;
 
 export type AddEnvironmentVariableMutation = {
-  __typename?: 'Mutation',
-  addEnvironmentVariable?: {
-    __typename?: 'EnvironmentVariablesPayload',
-    environmentVariables?: {
-      __typename?: 'EnvironmentVariablesList',
-      total?: any | null,
-      nodes?: Array<{ __typename?: 'EnvironmentVariable', name: string } | null> | null
-    } | null
-  } | null
+	__typename?: 'Mutation';
+	addEnvironmentVariable?: {
+		__typename?: 'EnvironmentVariablesPayload';
+		environmentVariables?: {
+			__typename?: 'EnvironmentVariablesList';
+			total?: any | null;
+			nodes?: Array< { __typename?: 'EnvironmentVariable'; name: string } | null > | null;
+		} | null;
+	} | null;
 };

--- a/src/lib/media-import/status.generated.d.ts
+++ b/src/lib/media-import/status.generated.d.ts
@@ -1,38 +1,38 @@
 import * as Types from '../../graphqlTypes';
 
-export type AppQueryVariables = Types.Exact<{
-  appId?: Types.InputMaybe<Types.Scalars['Int']['input']>;
-  envId?: Types.InputMaybe<Types.Scalars['Int']['input']>;
-}>;
+export type AppQueryVariables = Types.Exact< {
+	appId?: Types.InputMaybe< Types.Scalars[ 'Int' ][ 'input' ] >;
+	envId?: Types.InputMaybe< Types.Scalars[ 'Int' ][ 'input' ] >;
+} >;
 
 export type AppQuery = {
-  __typename?: 'Query',
-  app?: {
-    __typename?: 'App',
-    environments?: Array<{
-      __typename?: 'AppEnvironment',
-      id?: number | null,
-      name?: string | null,
-      type?: string | null,
-      repo?: string | null,
-      mediaImportStatus?: {
-        __typename?: 'AppEnvironmentMediaImportStatus',
-        importId?: number | null,
-        siteId?: number | null,
-        status?: string | null,
-        filesTotal?: number | null,
-        filesProcessed?: number | null,
-        failureDetails?: {
-          __typename?: 'AppEnvironmentMediaImportStatusFailureDetails',
-          previousStatus?: string | null,
-          globalErrors?: Array<string | null> | null,
-          fileErrors?: Array<{
-            __typename?: 'AppEnvironmentMediaImportStatusFailureDetailsFileErrors',
-            fileName?: string | null,
-            errors?: Array<string | null> | null
-          } | null> | null
-        } | null
-      } | null
-    } | null> | null
-  } | null
+	__typename?: 'Query';
+	app?: {
+		__typename?: 'App';
+		environments?: Array< {
+			__typename?: 'AppEnvironment';
+			id?: number | null;
+			name?: string | null;
+			type?: string | null;
+			repo?: string | null;
+			mediaImportStatus?: {
+				__typename?: 'AppEnvironmentMediaImportStatus';
+				importId?: number | null;
+				siteId?: number | null;
+				status?: string | null;
+				filesTotal?: number | null;
+				filesProcessed?: number | null;
+				failureDetails?: {
+					__typename?: 'AppEnvironmentMediaImportStatusFailureDetails';
+					previousStatus?: string | null;
+					globalErrors?: Array< string | null > | null;
+					fileErrors?: Array< {
+						__typename?: 'AppEnvironmentMediaImportStatusFailureDetailsFileErrors';
+						fileName?: string | null;
+						errors?: Array< string | null > | null;
+					} | null > | null;
+				} | null;
+			} | null;
+		} | null > | null;
+	} | null;
 };

--- a/src/lib/site-import/status.generated.d.ts
+++ b/src/lib/site-import/status.generated.d.ts
@@ -1,68 +1,74 @@
 import * as Types from '../../graphqlTypes';
 
-export type AppQueryVariables = Types.Exact<{
-	appId?: Types.InputMaybe<Types.Scalars['Int']['input']>;
-	envId?: Types.InputMaybe<Types.Scalars['Int']['input']>;
-}>;
+export type AppQueryVariables = Types.Exact< {
+	appId?: Types.InputMaybe< Types.Scalars[ 'Int' ][ 'input' ] >;
+	envId?: Types.InputMaybe< Types.Scalars[ 'Int' ][ 'input' ] >;
+} >;
 
 export type AppQuery = {
-	__typename?: 'Query', app?: {
-		__typename?: 'App', environments?: Array<{
-			__typename?: 'AppEnvironment',
-			id?: number | null,
-			isK8sResident?: boolean | null,
-			launched?: boolean | null,
-			jobs?: Array<{
-				__typename?: 'Job',
-				id?: number | null,
-				type?: string | null,
-				completedAt?: string | null,
-				createdAt?: string | null,
-				progress?: {
-					__typename?: 'JobProgress',
-					status?: string | null,
-					steps?: Array<{
-						__typename?: 'JobProgressStep',
-						id?: string | null,
-						name?: string | null,
-						status?: string | null
-					} | null> | null
-				} | null
-			} | {
-				__typename?: 'PrimaryDomainSwitchJob',
-				id?: number | null,
-				type?: string | null,
-				completedAt?: string | null,
-				createdAt?: string | null,
-				progress?: {
-					__typename?: 'JobProgress',
-					status?: string | null,
-					steps?: Array<{
-						__typename?: 'JobProgressStep',
-						id?: string | null,
-						name?: string | null,
-						status?: string | null
-					} | null> | null
-				} | null
-			} | null> | null,
+	__typename?: 'Query';
+	app?: {
+		__typename?: 'App';
+		environments?: Array< {
+			__typename?: 'AppEnvironment';
+			id?: number | null;
+			isK8sResident?: boolean | null;
+			launched?: boolean | null;
+			jobs?: Array<
+				| {
+						__typename?: 'Job';
+						id?: number | null;
+						type?: string | null;
+						completedAt?: string | null;
+						createdAt?: string | null;
+						progress?: {
+							__typename?: 'JobProgress';
+							status?: string | null;
+							steps?: Array< {
+								__typename?: 'JobProgressStep';
+								id?: string | null;
+								name?: string | null;
+								status?: string | null;
+							} | null > | null;
+						} | null;
+				  }
+				| {
+						__typename?: 'PrimaryDomainSwitchJob';
+						id?: number | null;
+						type?: string | null;
+						completedAt?: string | null;
+						createdAt?: string | null;
+						progress?: {
+							__typename?: 'JobProgress';
+							status?: string | null;
+							steps?: Array< {
+								__typename?: 'JobProgressStep';
+								id?: string | null;
+								name?: string | null;
+								status?: string | null;
+							} | null > | null;
+						} | null;
+				  }
+				| null
+			> | null;
 			importStatus?: {
-				__typename?: 'AppEnvironmentImportStatus',
-				dbOperationInProgress?: boolean | null,
-				importInProgress?: boolean | null,
+				__typename?: 'AppEnvironmentImportStatus';
+				dbOperationInProgress?: boolean | null;
+				importInProgress?: boolean | null;
 				progress?: {
-					__typename?: 'AppEnvironmentStatusProgress',
-					started_at?: number | null,
-					finished_at?: number | null,
-					steps?: Array<{
-						__typename?: 'AppEnvironmentStatusProgressStep',
-						name?: string | null,
-						started_at?: number | null,
-						finished_at?: number | null,
-						result?: string | null,
-						output?: Array<string | null> | null
-					} | null> | null
-				} | null
-			} | null
-		} | null> | null
-	} | null
+					__typename?: 'AppEnvironmentStatusProgress';
+					started_at?: number | null;
+					finished_at?: number | null;
+					steps?: Array< {
+						__typename?: 'AppEnvironmentStatusProgressStep';
+						name?: string | null;
+						started_at?: number | null;
+						finished_at?: number | null;
+						result?: string | null;
+						output?: Array< string | null > | null;
+					} | null > | null;
+				} | null;
+			} | null;
+		} | null > | null;
+	} | null;
 };

--- a/src/lib/validations/is-multi-site.generated.d.ts
+++ b/src/lib/validations/is-multi-site.generated.d.ts
@@ -1,25 +1,25 @@
 import * as Types from '../../graphqlTypes';
 
-export type AppMultiSiteCheckQueryVariables = Types.Exact<{
-  appId?: Types.InputMaybe<Types.Scalars['Int']['input']>;
-  envId?: Types.InputMaybe<Types.Scalars['Int']['input']>;
-}>;
+export type AppMultiSiteCheckQueryVariables = Types.Exact< {
+	appId?: Types.InputMaybe< Types.Scalars[ 'Int' ][ 'input' ] >;
+	envId?: Types.InputMaybe< Types.Scalars[ 'Int' ][ 'input' ] >;
+} >;
 
 export type AppMultiSiteCheckQuery = {
-  __typename?: 'Query',
-  app?: {
-    __typename?: 'App',
-    id?: number | null,
-    name?: string | null,
-    repo?: string | null,
-    environments?: Array<{
-      __typename?: 'AppEnvironment',
-      id?: number | null,
-      appId?: number | null,
-      name?: string | null,
-      type?: string | null,
-      isMultisite?: boolean | null,
-      isSubdirectoryMultisite?: boolean | null
-    } | null> | null
-  } | null
+	__typename?: 'Query';
+	app?: {
+		__typename?: 'App';
+		id?: number | null;
+		name?: string | null;
+		repo?: string | null;
+		environments?: Array< {
+			__typename?: 'AppEnvironment';
+			id?: number | null;
+			appId?: number | null;
+			name?: string | null;
+			type?: string | null;
+			isMultisite?: boolean | null;
+			isSubdirectoryMultisite?: boolean | null;
+		} | null > | null;
+	} | null;
 };

--- a/src/lib/validations/is-multisite-domain-mapped.generated.d.ts
+++ b/src/lib/validations/is-multisite-domain-mapped.generated.d.ts
@@ -1,28 +1,28 @@
 import * as Types from '../../graphqlTypes';
 
-export type AppMappedDomainsQueryVariables = Types.Exact<{
-  appId?: Types.InputMaybe<Types.Scalars['Int']['input']>;
-  envId?: Types.InputMaybe<Types.Scalars['Int']['input']>;
-}>;
+export type AppMappedDomainsQueryVariables = Types.Exact< {
+	appId?: Types.InputMaybe< Types.Scalars[ 'Int' ][ 'input' ] >;
+	envId?: Types.InputMaybe< Types.Scalars[ 'Int' ][ 'input' ] >;
+} >;
 
 export type AppMappedDomainsQuery = {
-  __typename?: 'Query',
-  app?: {
-    __typename?: 'App',
-    id?: number | null,
-    name?: string | null,
-    environments?: Array<{
-      __typename?: 'AppEnvironment',
-      uniqueLabel?: string | null,
-      isMultisite?: boolean | null,
-      domains?: {
-        __typename?: 'DomainList',
-        nodes?: Array<{
-          __typename?: 'Domain',
-          name: string,
-          isPrimary?: boolean | null
-        } | null> | null
-      } | null
-    } | null> | null
-  } | null
+	__typename?: 'Query';
+	app?: {
+		__typename?: 'App';
+		id?: number | null;
+		name?: string | null;
+		environments?: Array< {
+			__typename?: 'AppEnvironment';
+			uniqueLabel?: string | null;
+			isMultisite?: boolean | null;
+			domains?: {
+				__typename?: 'DomainList';
+				nodes?: Array< {
+					__typename?: 'Domain';
+					name: string;
+					isPrimary?: boolean | null;
+				} | null > | null;
+			} | null;
+		} | null > | null;
+	} | null;
 };


### PR DESCRIPTION
## Description

Looks like prettier didn't run during the last PR because the generated files was ignored by prettier.

So I'm re-enabling it here.

We also remove enums from this PR because enums are actual objects in TypeScript - not just a type. So someone importing the enum i.e. `SomeEnum.SOME_VALUE` would get an undefined error, since we put it in a `.d.ts` instead of a `.ts` as we definitely don't want to increase our bundle size!

Hopefully this is the last of it. The formatting looks good now (spaces everywhere).

We missed this because the tests rightfully also ignore these files.

We can review this by ignoring all `.d.ts` files generated - but pick one to verify the formatting is good.

## Steps to Test

Similar to the previous PR.

1. Check out PR.
1. Get a hold of `schema.gql` and paste it in project root - this is the schema of the endpoint that
   we communicate with.
1. Run `npm run typescript:codegen:install-dependencies` - this will install the codegen
   dependencies without updating `package.json`
1. Run `npm run typescript:codegen:generate` - this will regenerate the types.
1. There shouldn't be any new files to commit (which means prettier ran through graphql-codegen)
1. Verify that the generated files conform to the style generated in non-generated files.
