### PR TITLE
On-demand Database Backup: Use a less error-prone way of detecting if we're rate limited

### DIFF
--- a/src/commands/backup-db.ts
+++ b/src/commands/backup-db.ts
@@ -28,8 +28,6 @@ import { App, AppEnvironment, Job } from '../graphqlTypes';
 
 const DB_BACKUP_PROGRESS_POLL_INTERVAL = 1000;
 
-// type Job = AppBackupJobStatusQuery['app']
-
 export const CREATE_DB_BACKUP_JOB_MUTATION = gql`
 	mutation TriggerDatabaseBackup($input: AppEnvironmentTriggerDBBackupInput) {
 		triggerDatabaseBackup(input: $input) {

--- a/src/lib/types/graphql/rate-limit-exceeded-error.ts
+++ b/src/lib/types/graphql/rate-limit-exceeded-error.ts
@@ -1,0 +1,10 @@
+import { GraphQLFormattedError } from 'graphql';
+
+interface RateLimitExceededErrorExtension {
+	errorHttpCode: 429;
+	retryAfter: string;
+	errorCode: string;
+}
+
+export interface RateLimitExceededError
+	extends GraphQLFormattedError< RateLimitExceededErrorExtension > {}


### PR DESCRIPTION
## Description

A slight refactor on how we detect if we're rate limited. Makes things look nicer, and if the error message changes later, no change is needed on our side.

~~This is still awaiting changes from the server side though.~~

## Steps to Test

Outline the steps to test and verify the PR here.

Example:

1. Check out PR.
1. Run `npm run build`
1. Run `node ./dist/bin/vip-export-sql.js --generate-backup` **twice**. The second one should be an error.
