### PR TITLE
chore(dev-deps): update TypeScript-related packages

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -1,12 +1,12 @@
 {
   "name": "@automattic/vip",
-  "version": "2.32.1",
+  "version": "2.32.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@automattic/vip",
-      "version": "2.32.1",
+      "version": "2.32.2",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
@@ -12768,9 +12768,9 @@
       }
     },
     "node_modules/typescript": {
-      "version": "5.1.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.1.3.tgz",
-      "integrity": "sha512-XH627E9vkeqhlZFQuL+UsyAXEnibT0kWR2FWONlr4sTjvxyJYnyefgrkyECLzM5NenmKzRAy2rR/OlYLA1HkZw==",
+      "version": "5.1.6",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.1.6.tgz",
+      "integrity": "sha512-zaWCozRZ6DLEWAWFrVDz1H6FVXzUSfTy5FUMWsQlU8Ym5JP9eO4xkTIROFCQvhQf61z6O/G6ugw3SgAnvvm+HA==",
       "dev": true,
       "bin": {
         "tsc": "bin/tsc",
@@ -22900,9 +22900,9 @@
       }
     },
     "typescript": {
-      "version": "5.1.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.1.3.tgz",
-      "integrity": "sha512-XH627E9vkeqhlZFQuL+UsyAXEnibT0kWR2FWONlr4sTjvxyJYnyefgrkyECLzM5NenmKzRAy2rR/OlYLA1HkZw==",
+      "version": "5.1.6",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.1.6.tgz",
+      "integrity": "sha512-zaWCozRZ6DLEWAWFrVDz1H6FVXzUSfTy5FUMWsQlU8Ym5JP9eO4xkTIROFCQvhQf61z6O/G6ugw3SgAnvvm+HA==",
       "dev": true
     },
     "typical": {

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -105,7 +105,7 @@
         "@babel/preset-typescript": "7.22.5",
         "@jest/globals": "^29.5.0",
         "@jest/test-sequencer": "^29.5.0",
-        "@tsconfig/node16": "^1.0.4",
+        "@tsconfig/node16": "^16.1.0",
         "@types/args": "5.0.0",
         "@types/cli-table": "0.3.1",
         "@types/configstore": "5.0.1",
@@ -3512,9 +3512,9 @@
       }
     },
     "node_modules/@tsconfig/node16": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/@tsconfig/node16/-/node16-1.0.4.tgz",
-      "integrity": "sha512-vxhUy4J8lyeyinH7Azl1pdd43GJhZH/tP2weN8TntQblOY+A0XbT8DJk1/oCPuOOyg/Ja757rG0CgHcWC8OfMA==",
+      "version": "16.1.0",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node16/-/node16-16.1.0.tgz",
+      "integrity": "sha512-cfwhqrdZEKS+Iqu1OPDwmKsOV/eo7q4sPhWzOXc1rU77nnPFV3+77yPg8uKQ2e8eir6mERCvrKnd+EGa4qo4bQ==",
       "dev": true
     },
     "node_modules/@types/args": {
@@ -16021,9 +16021,9 @@
       }
     },
     "@tsconfig/node16": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/@tsconfig/node16/-/node16-1.0.4.tgz",
-      "integrity": "sha512-vxhUy4J8lyeyinH7Azl1pdd43GJhZH/tP2weN8TntQblOY+A0XbT8DJk1/oCPuOOyg/Ja757rG0CgHcWC8OfMA==",
+      "version": "16.1.0",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node16/-/node16-16.1.0.tgz",
+      "integrity": "sha512-cfwhqrdZEKS+Iqu1OPDwmKsOV/eo7q4sPhWzOXc1rU77nnPFV3+77yPg8uKQ2e8eir6mERCvrKnd+EGa4qo4bQ==",
       "dev": true
     },
     "@types/args": {

--- a/package.json
+++ b/package.json
@@ -108,7 +108,7 @@
     "@babel/preset-typescript": "7.22.5",
     "@jest/globals": "^29.5.0",
     "@jest/test-sequencer": "^29.5.0",
-    "@tsconfig/node16": "^1.0.4",
+    "@tsconfig/node16": "^16.1.0",
     "@types/args": "5.0.0",
     "@types/cli-table": "0.3.1",
     "@types/configstore": "5.0.1",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -24,7 +24,9 @@
       ]
     },
     // It's worth enabling this, I promise!
-    "noImplicitAny": true
+    "noImplicitAny": true,
+    // We have to use this because we're using Babel
+    "moduleResolution": "node"
   },
   "include": [
     "src",


### PR DESCRIPTION
## Description

This PR updates:
* `typescript` from 5.1.3 to 5.1.6;
* `@tsconfig/node16` from 1.0.4 to 16.1.0 (~no breaking changes, they switched to a different versioning scheme~ had to update module resolution to `node`)

## Steps to Test

CI should pass.
