### PR TITLE
BB8-10502: Fix SQL import command

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -22,6 +22,7 @@
         "debug": "4.3.4",
         "ejs": "^3.1.8",
         "enquirer": "2.3.6",
+        "fetch-retry": "^5.0.6",
         "graphql": "15.5.1",
         "graphql-tag": "2.12.5",
         "https-proxy-agent": "^5.0.1",
@@ -7251,6 +7252,11 @@
       "dependencies": {
         "bser": "2.1.1"
       }
+    },
+    "node_modules/fetch-retry": {
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/fetch-retry/-/fetch-retry-5.0.6.tgz",
+      "integrity": "sha512-3yurQZ2hD9VISAhJJP9bpYFNQrHHBXE2JxxjY5aLEcDi46RmAzJE2OC9FAde0yis5ElW0jTTzs0zfg/Cca4XqQ=="
     },
     "node_modules/figlet": {
       "version": "1.5.2",
@@ -18831,6 +18837,11 @@
       "requires": {
         "bser": "2.1.1"
       }
+    },
+    "fetch-retry": {
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/fetch-retry/-/fetch-retry-5.0.6.tgz",
+      "integrity": "sha512-3yurQZ2hD9VISAhJJP9bpYFNQrHHBXE2JxxjY5aLEcDi46RmAzJE2OC9FAde0yis5ElW0jTTzs0zfg/Cca4XqQ=="
     },
     "figlet": {
       "version": "1.5.2",

--- a/package.json
+++ b/package.json
@@ -152,6 +152,7 @@
     "debug": "4.3.4",
     "ejs": "^3.1.8",
     "enquirer": "2.3.6",
+    "fetch-retry": "^5.0.6",
     "graphql": "15.5.1",
     "graphql-tag": "2.12.5",
     "https-proxy-agent": "^5.0.1",

--- a/src/lib/client-file-uploader.ts
+++ b/src/lib/client-file-uploader.ts
@@ -28,9 +28,9 @@ const fetchWithRetry: ( input: RequestInfo | URL, init?: RequestInit ) => Promis
 	// eslint-disable-next-line @typescript-eslint/no-unsafe-call
 	require( 'fetch-retry' )( fetch, {
 		// Set default retry options
-		retries: 5,
+		retries: 3,
 		retryDelay: ( attempt: number, error: Error, response: Response ) => {
-			return Math.pow( 2, attempt ) * 500; // 500, 1000, 2000
+			return Math.pow( 2, attempt ) * 1000; // 1000, 2000, 4000
 		},
 	} );
 

--- a/src/lib/client-file-uploader.ts
+++ b/src/lib/client-file-uploader.ts
@@ -425,6 +425,8 @@ export async function detectCompressedMimeType( fileName: string ): Promise< str
 	const { buffer } = await file.read( Buffer.alloc( 4 ), 0, 4, 0 );
 	const fileHeader = buffer.toString( 'hex' );
 
+	await file.close();
+
 	if ( ZIP_MAGIC_NUMBER === fileHeader.slice( 0, ZIP_MAGIC_NUMBER.length ) ) {
 		return 'application/zip';
 	}

--- a/src/lib/client-file-uploader.ts
+++ b/src/lib/client-file-uploader.ts
@@ -90,6 +90,8 @@ export const getFileMD5Hash = async ( fileName: string ): Promise< string > => {
 		return dst.digest().toString( 'hex' );
 	} catch ( err ) {
 		throw new Error( `could not generate file hash: ${ ( err as Error ).message }` );
+	} finally {
+		await src.close();
 	}
 };
 

--- a/src/lib/client-file-uploader.ts
+++ b/src/lib/client-file-uploader.ts
@@ -29,7 +29,9 @@ const fetchWithRetry: ( input: RequestInfo | URL, init?: RequestInit ) => Promis
 	require( 'fetch-retry' )( fetch, {
 		// Set default retry options
 		retries: 5,
-		retryDelay: 1000,
+		retryDelay: ( attempt: number, error: Error, response: Response ) => {
+			return Math.pow( 2, attempt ) * 500; // 500, 1000, 2000
+		},
 	} );
 
 const debug = debugLib( 'vip:lib/client-file-uploader' );

--- a/src/lib/client-file-uploader.ts
+++ b/src/lib/client-file-uploader.ts
@@ -7,7 +7,7 @@ import { constants, createReadStream, createWriteStream, type ReadStream } from 
 import { access, mkdtemp, open, stat } from 'node:fs/promises';
 import os from 'os';
 import path from 'path';
-import fetch, { HeaderInit, RequestInit, Response } from 'node-fetch';
+import fetch, { HeaderInit, RequestInfo, RequestInit, Response } from 'node-fetch';
 import chalk from 'chalk';
 import { createGunzip, createGzip } from 'zlib';
 import { createHash } from 'crypto';
@@ -15,7 +15,6 @@ import { pipeline } from 'node:stream/promises';
 import { PassThrough } from 'stream';
 import { Parser as XmlParser } from 'xml2js';
 import debugLib from 'debug';
-import fetchRetry from 'fetch-retry';
 
 /**
  * Internal dependencies


### PR DESCRIPTION
## Description

This PR adds retry logic to the `fetch` requests that uploads the import files in `vip import sql` command. Retry logic courtesy of the `fetch-retry` NPM module.

This PR also removes the warnings the user sees when running the import SQL command due to an open file descriptor that wasn't explicitly closed:
```
(node:52659) Warning: Closing file descriptor 26 on garbage collection
(Use `node --trace-warnings ...` to show where the warning was created)
(node:52659) [DEP0137] DeprecationWarning: Closing a FileHandle object on garbage collection is deprecated. Please close FileHandle objects explicitly using FileHandle.prototype.close(). In the future, an error will be thrown if a file descriptor is closed during garbage collection.
```

## Steps to Test

1. Prepare a test site and a test SQL file.
1. Check out PR.
1. Run `npm install`
1. Run `npm run build`
1. Run `node ./dist/bin/vip-import-sql @{target test site} {test file}.sql`
1. Verify that the import was successful and no warning messages were displayed.
