### PR TITLE
BB8-10453: Fix DB engine validation regex

### DIFF
--- a/src/lib/validations/sql.ts
+++ b/src/lib/validations/sql.ts
@@ -337,7 +337,7 @@ const checks: Checks = {
 		recommendation: "Use search-replace to change environment's domain",
 	},
 	engineInnoDB: {
-		matcher: / ENGINE=(?!(InnoDB))/i,
+		matcher: / ENGINE\s?=(?!(\s?InnoDB))/i,
 		matchHandler: lineNumber => ( { lineNumber } ),
 		outputFormatter: lineNumberCheckFormatter,
 		results: [],

--- a/src/lib/validations/sql.ts
+++ b/src/lib/validations/sql.ts
@@ -337,7 +337,7 @@ const checks: Checks = {
 		recommendation: "Use search-replace to change environment's domain",
 	},
 	engineInnoDB: {
-		matcher: / ENGINE\s?=(?!(\s?InnoDB))/i,
+		matcher: /\sENGINE\s?=(?!(\s?InnoDB))/i,
 		matchHandler: lineNumber => ( { lineNumber } ),
 		outputFormatter: lineNumberCheckFormatter,
 		results: [],

--- a/src/lib/validations/sql.ts
+++ b/src/lib/validations/sql.ts
@@ -348,6 +348,7 @@ const checks: Checks = {
 			"We suggest you search for all 'ENGINE=X' entries and replace them with 'ENGINE=InnoDB'!",
 	},
 };
+
 const DEV_ENV_SPECIFIC_CHECKS = [ 'useStatement', 'siteHomeUrlLando' ];
 
 function findDuplicates< T >( arr: T[], where: Set< T > ) {


### PR DESCRIPTION
Change regex to take into account spaces before and after the `=`

## Description

This PR fixes an issue with the SQL validation logic where the `ENGINE` type not being `InnoDB` is not caught by the validator due to spaces in the target SQL file. E.g.:
```
ENGINE = MyISAM // missed
ENGINE=MyISAM // caught
```
The regex has been updated to take the optional spaces into account.

## Steps to Test

1. Get a SQL dump from an existing site.
1. Edit one of the `CREATE TABLE` lines to use `MyISAM` engine with spaces: `ENGINE = MyISAM` 
1. Check out PR.
1. Run `npm run build`
1. Run `node ./dist/bin/vip-import-validate-sql @{target test site} test-dump.sql`
1. Verify that the error was caught. E.g.:
```
Error:  SQL Error: ENGINE != InnoDB on line(s) 40.
Recommendation: Ensure your application works with InnoDB and update your SQL dump to include only 'ENGINE=InnoDB' engine definitions in 'CREATE TABLE' statements. We suggest you search for all 'ENGINE=X' entries and replace them with 'ENGINE=InnoDB'!

SQL validation failed due to 1 error(s)
```
