### PR TITLE
Fixed Slowlogs local unit test

### DIFF
--- a/__tests__/bin/vip-slowlogs.js
+++ b/__tests__/bin/vip-slowlogs.js
@@ -84,14 +84,22 @@ describe( 'getSlowlogs', () => {
 		expect( slowlogsLib.getRecentSlowlogs ).toHaveBeenCalledWith( 1, 3, 500 );
 
 		expect( console.log ).toHaveBeenCalledTimes( 1 );
+		expect( console.log ).toHaveBeenCalledWith( expect.stringContaining( 'timestamp' ) );
+		expect( console.log ).toHaveBeenCalledWith( expect.stringContaining( 'rows sent' ) );
+		expect( console.log ).toHaveBeenCalledWith( expect.stringContaining( 'rows examined' ) );
+		expect( console.log ).toHaveBeenCalledWith( expect.stringContaining( 'query time' ) );
+		expect( console.log ).toHaveBeenCalledWith( expect.stringContaining( 'request uri' ) );
+		expect( console.log ).toHaveBeenCalledWith( expect.stringContaining( 'query' ) );
 		expect( console.log ).toHaveBeenCalledWith(
-			'┌────────────────────────────────┬───────────┬───────────────┬────────────┬─────────────────────┬────────────────────────┐\n' +
-				'│ timestamp                      │ rows sent │ rows examined │ query time │ request uri         │ query                  │\n' +
-				'├────────────────────────────────┼───────────┼───────────────┼────────────┼─────────────────────┼────────────────────────┤\n' +
-				'│ 2021-11-05T20:18:36.234041811Z │ 1         │ 1             │ 0.1        │ dashboard.wpvip.com │ SELECT * FROM wp_posts │\n' +
-				'├────────────────────────────────┼───────────┼───────────────┼────────────┼─────────────────────┼────────────────────────┤\n' +
-				'│ 2021-11-09T20:47:07.301221112Z │ 1         │ 1             │ 0.1        │ dashboard.wpvip.com │ SELECT * FROM wp_posts │\n' +
-				'└────────────────────────────────┴───────────┴───────────────┴────────────┴─────────────────────┴────────────────────────┘'
+			expect.stringContaining( '2021-11-05T20:18:36.234041811Z' )
+		);
+		expect( console.log ).toHaveBeenCalledWith(
+			expect.stringContaining( '2021-11-09T20:47:07.301221112Z' )
+		);
+		expect( console.log ).toHaveBeenCalledWith( expect.stringContaining( '0.1' ) );
+		expect( console.log ).toHaveBeenCalledWith( expect.stringContaining( 'dashboard.wpvip.com' ) );
+		expect( console.log ).toHaveBeenCalledWith(
+			expect.stringContaining( 'SELECT * FROM wp_posts' )
 		);
 
 		const trackingParams = {


### PR DESCRIPTION
## Description

Fixed Slowlogs test running on the local environment

```
Summary of all failing tests
 FAIL  __tests__/bin/vip-slowlogs.js
  ● getSlowlogs › should display the slowlogs in the output

    expect(jest.fn()).toHaveBeenCalledWith(...expected)

    Expected: "┌────────────────────────────────┬───────────┬───────────────┬────────────┬─────────────────────┬────────────────────────┐
    │ timestamp                      │ rows sent │ rows examined │ query time │ request uri         │ query                  │
    ├────────────────────────────────┼───────────┼───────────────┼────────────┼─────────────────────┼────────────────────────┤
    │ 2021-11-05T20:18:36.234041811Z │ 1         │ 1             │ 0.1        │ dashboard.wpvip.com │ SELECT * FROM wp_posts │
    ├────────────────────────────────┼───────────┼───────────────┼────────────┼─────────────────────┼────────────────────────┤
    │ 2021-11-09T20:47:07.301221112Z │ 1         │ 1             │ 0.1        │ dashboard.wpvip.com │ SELECT * FROM wp_posts │
    └────────────────────────────────┴───────────┴───────────────┴────────────┴─────────────────────┴────────────────────────┘"
    Received: "┌────────────────────────────────┬───────────┬───────────────┬────────────┬─────────────────────┬────────────────────────┐
    │ timestamp                      │ rows sent │ rows examined │ query time │ request uri         │ query                  │
    ├────────────────────────────────┼───────────┼───────────────┼────────────┼─────────────────────┼────────────────────────┤
    │ 2021-11-05T20:18:36.234041811Z │ 1         │ 1             │ 0.1        │ dashboard.wpvip.com │ SELECT * FROM wp_posts │
    ├────────────────────────────────┼───────────┼───────────────┼────────────┼─────────────────────┼────────────────────────┤
    │ 2021-11-09T20:47:07.301221112Z │ 1         │ 1             │ 0.1        │ dashboard.wpvip.com │ SELECT * FROM wp_posts │
    └────────────────────────────────┴───────────┴───────────────┴────────────┴─────────────────────┴────────────────────────┘"

    Number of calls: 1

      85 |
      86 | 		expect( console.log ).toHaveBeenCalledTimes( 1 );
    > 87 | 		expect( console.log ).toHaveBeenCalledWith(
         | 		                      ^
      88 | 			'┌────────────────────────────────┬───────────┬───────────────┬────────────┬─────────────────────┬────────────────────────┐\n' +
      89 | 				'│ timestamp                      │ rows sent │ rows examined │ query time │ request uri         │ query                  │\n' +
      90 | 				'├────────────────────────────────┼───────────┼───────────────┼────────────┼─────────────────────┼────────────────────────┤\n' +

      at Object.toHaveBeenCalledWith (__tests__/bin/vip-slowlogs.js:87:25)

```

## Steps to Test

1. Check out PR.
1. Run `npm run build` and `npm link`
1. Run `node ./dist/bin/vip @SITE_ID.production slowlogs`
1. Verify list of slowlogs or "No logs found" if don't have any slowlogs to be listed