### PR TITLE
Update prepare-release to use release-branch

### DIFF
--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -30,3 +30,4 @@ jobs:
         with:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           npm-version-type: ${{ inputs.npm-version-type }}
+          release-branch: trunk


### PR DESCRIPTION
## Description

Temporarily changes the `npm-prepare-release` to use `trunk` as release branch.
