### PR TITLE
Fetch environment name from server to fix environment selector label

### DIFF
--- a/src/bin/vip-import-media-abort.js
+++ b/src/bin/vip-import-media-abort.js
@@ -31,6 +31,7 @@ const appQuery = `
 		id
 		appId
 		type
+		name
 		primaryDomain {
 			id
 			name

--- a/src/bin/vip-import-media-status.js
+++ b/src/bin/vip-import-media-status.js
@@ -27,6 +27,7 @@ const appQuery = `
 		id
 		appId
 		type
+		name
 		primaryDomain {
 			id
 			name

--- a/src/bin/vip-import-sql-status.js
+++ b/src/bin/vip-import-sql-status.js
@@ -27,6 +27,7 @@ environments{
 	id
 	appId
 	type
+	name
 	isK8sResident
 	primaryDomain {
 		id


### PR DESCRIPTION
## Description

The environment selector was not being reflective of the complete environment label for a few commands
This PR fetches the required [field](https://github.com/Automattic/vip-cli/blob/7421424e16095e0084748b46deff358e7f384b13/src/lib/cli/command.js#L602) from the API to build the full label
