### PR TITLE
Fix False UP status for multisite dev-envs

### DIFF
--- a/src/lib/dev-environment/dev-environment-lando.ts
+++ b/src/lib/dev-environment/dev-environment-lando.ts
@@ -503,7 +503,7 @@ export async function checkEnvHealth(
 			} );
 		} );
 
-	const urlsToScan = Object.keys( urls );
+	const urlsToScan = Object.keys( urls ).filter( url => ! url.includes( '*' ) );
 	let scanResults: ScanResult[] = [];
 	if ( Array.isArray( app.urls ) ) {
 		scanResults = app.urls;


### PR DESCRIPTION

## Description

When we have one environment up any other multisite environment would also report UP (even if it is down). That is because the `*` urls return 404 which is considered success. We consider nginx up if the last url tried is up.

This change removes the `*` urls from the list.

So if the URLs are:
```
 NGINX URLS        http://multisite.vipdev.lndo.site/                                                                 
                   https://multisite.vipdev.lndo.site/                                                                
                   http://*.multisite.vipdev.lndo.site/                                                               
                   https://*.multisite.vipdev.lndo.site/  
```

We will not try `http://*.multisite.vipdev.lndo.site/` and `https://*.multisite.vipdev.lndo.site/`.


This change 

## Steps to Test

1) Create multisite environment
1) Create another environment (multisite or not, doesnt matter)
1) Start second environment
1) `$ npm run build && ./dist/bin/vip-dev-env-list.js ` should only report the second env up