### PR TITLE
Disable Windows patch

### DIFF
--- a/src/bin/vip-dev-env-start.js
+++ b/src/bin/vip-dev-env-start.js
@@ -8,9 +8,7 @@
 /**
  * External dependencies
  */
-import chalk from 'chalk';
 import debugLib from 'debug';
-import { exec } from 'child_process';
 
 /**
  * Internal dependencies
@@ -29,9 +27,6 @@ import {
 import { bootstrapLando } from '../lib/dev-environment/dev-environment-lando';
 
 const debug = debugLib( '@automattic/vip:bin:dev-environment' );
-
-// PowerShell command for Windows Docker patch
-const dockerWindowsPathCmd = 'wsl -d docker-desktop bash -c "sysctl -w vm.max_map_count=262144"';
 
 const examples = [
 	{

--- a/src/bin/vip-dev-env-start.js
+++ b/src/bin/vip-dev-env-start.js
@@ -72,6 +72,8 @@ command()
 			skipWpVersionsCheck: !! opt.skipWpVersionsCheck,
 		};
 		try {
+			/*
+			// Temporarily disabled
 			if ( process.platform === 'win32' ) {
 				debug( 'Windows platform detected. Applying Docker patch...' );
 
@@ -87,6 +89,7 @@ command()
 					}
 				} );
 			}
+			*/
 
 			await startEnvironment( lando, slug, options );
 

--- a/src/bin/vip-dev-env-start.js
+++ b/src/bin/vip-dev-env-start.js
@@ -72,25 +72,6 @@ command()
 			skipWpVersionsCheck: !! opt.skipWpVersionsCheck,
 		};
 		try {
-			/*
-			// Temporarily disabled
-			if ( process.platform === 'win32' ) {
-				debug( 'Windows platform detected. Applying Docker patch...' );
-
-				exec( dockerWindowsPathCmd, { shell: 'powershell.exe' }, ( error, stdout ) => {
-					if ( error ) {
-						debug( error );
-						console.log(
-							`${ chalk.red( '✕' ) } There was an error while applying the Windows Docker patch.`
-						);
-					} else {
-						debug( stdout );
-						console.log( `${ chalk.green( '✓' ) } Docker patch for Windows applied.` );
-					}
-				} );
-			}
-			*/
-
 			await startEnvironment( lando, slug, options );
 
 			const processingTime = Math.ceil( ( new Date() - startProcessing ) / 1000 ); // in seconds


### PR DESCRIPTION
## Description

This patch seems to be not needed anymore, and it's not applying neither for `docker-desktop` image nor `Ubuntu` which we recommend.

## Steps to Test

Outline the steps to test and verify the PR here.

Example:

1. Check out PR.
1. Run `npm run build`
1. Start an env with Elasticsearch enabled on Windows cmd.exe or PowerShell.
1. Verify the service is accessible and working.  
