### PR TITLE
feat(dev-env): add PHP 8.3 image

### DIFF
--- a/__tests__/lib/dev-environment/dev-environment-cli.js
+++ b/__tests__/lib/dev-environment/dev-environment-cli.js
@@ -584,10 +584,10 @@ describe( 'lib/dev-environment/dev-environment-cli', () => {
 
 	describe( 'resolvePhpVersion', () => {
 		it.each( [
-			[ '7.4', DEV_ENVIRONMENT_PHP_VERSIONS[ '7.4' ] ],
-			[ '8.0', DEV_ENVIRONMENT_PHP_VERSIONS[ '8.0' ] ],
-			[ '8.1', DEV_ENVIRONMENT_PHP_VERSIONS[ '8.1' ] ],
-			[ '8.2', DEV_ENVIRONMENT_PHP_VERSIONS[ '8.2' ] ],
+			[ '7.4', DEV_ENVIRONMENT_PHP_VERSIONS[ '7.4' ].image ],
+			[ '8.0', DEV_ENVIRONMENT_PHP_VERSIONS[ '8.0' ].image ],
+			[ '8.1', DEV_ENVIRONMENT_PHP_VERSIONS[ '8.1' ].image ],
+			[ '8.2', DEV_ENVIRONMENT_PHP_VERSIONS[ '8.2' ].image ],
 			[ 'image:php:8.0', 'image:php:8.0' ],
 			[
 				'ghcr.io/automattic/vip-container-images/php-fpm-ubuntu:8.0',

--- a/__tests__/lib/dev-environment/dev-environment-cli.js
+++ b/__tests__/lib/dev-environment/dev-environment-cli.js
@@ -588,6 +588,7 @@ describe( 'lib/dev-environment/dev-environment-cli', () => {
 			[ '8.0', DEV_ENVIRONMENT_PHP_VERSIONS[ '8.0' ].image ],
 			[ '8.1', DEV_ENVIRONMENT_PHP_VERSIONS[ '8.1' ].image ],
 			[ '8.2', DEV_ENVIRONMENT_PHP_VERSIONS[ '8.2' ].image ],
+			[ '8.3', DEV_ENVIRONMENT_PHP_VERSIONS[ '8.3' ].image ],
 			[ 'image:php:8.0', 'image:php:8.0' ],
 			[
 				'ghcr.io/automattic/vip-container-images/php-fpm-ubuntu:8.0',

--- a/src/bin/vip-dev-env-update.js
+++ b/src/bin/vip-dev-env-update.js
@@ -85,7 +85,9 @@ cmd.argv( process.argv, async ( arg, opt ) => {
 			muPlugins: currentInstanceData.muPlugins.dir || currentInstanceData.muPlugins.tag || 'latest',
 			wordpress: currentInstanceData.wordpress.tag || 'trunk',
 			elasticsearch: currentInstanceData.elasticsearch,
-			php: currentInstanceData.php || DEV_ENVIRONMENT_PHP_VERSIONS.default,
+			php:
+				currentInstanceData.php ||
+				DEV_ENVIRONMENT_PHP_VERSIONS[ Object.keys( DEV_ENVIRONMENT_PHP_VERSIONS )[ 0 ] ].image,
 			mariadb: currentInstanceData.mariadb,
 			phpmyadmin: currentInstanceData.phpmyadmin,
 			xdebug: currentInstanceData.xdebug,

--- a/src/lib/constants/dev-environment.ts
+++ b/src/lib/constants/dev-environment.ts
@@ -47,7 +47,10 @@ export const DEV_ENVIRONMENT_PHP_VERSIONS: Record< string, PhpImage > = {
 		image: 'ghcr.io/automattic/vip-container-images/php-fpm:8.0',
 		label: '8.0 (EOL soon)',
 	},
-	7.4: { image: 'ghcr.io/automattic/vip-container-images/php-fpm:7.4', label: '7.4 (EOL; not supported)' },
+	7.4: {
+		image: 'ghcr.io/automattic/vip-container-images/php-fpm:7.4',
+		label: '7.4 (EOL; not supported)',
+	},
 } as const;
 
 export const DEV_ENVIRONMENT_VERSION = '2.0.0';

--- a/src/lib/constants/dev-environment.ts
+++ b/src/lib/constants/dev-environment.ts
@@ -28,11 +28,26 @@ export const DEV_ENVIRONMENT_WORDPRESS_CACHE_KEY = 'wordpress-versions.json';
 
 export const DEV_ENVIRONMENT_WORDPRESS_VERSION_TTL = 86400; // once per day
 
-export const DEV_ENVIRONMENT_PHP_VERSIONS: Record< string, string | undefined > = {
-	'8.0': 'ghcr.io/automattic/vip-container-images/php-fpm:8.0',
-	8.2: 'ghcr.io/automattic/vip-container-images/php-fpm:8.2',
-	8.1: 'ghcr.io/automattic/vip-container-images/php-fpm:8.1',
-	7.4: 'ghcr.io/automattic/vip-container-images/php-fpm:7.4',
+interface PhpImage {
+	image: string;
+	label: string;
+}
+
+export const DEV_ENVIRONMENT_PHP_VERSIONS: Record< string, PhpImage > = {
+	'8.0': {
+		image: 'ghcr.io/automattic/vip-container-images/php-fpm:8.0',
+		label: '8.0 (recommended)',
+	},
+	8.2: {
+		image: 'ghcr.io/automattic/vip-container-images/php-fpm:8.2',
+		label: '8.2 (experimental)',
+	},
+	8.1: { image: 'ghcr.io/automattic/vip-container-images/php-fpm:8.1', label: '8.1' },
+	7.4: { image: 'ghcr.io/automattic/vip-container-images/php-fpm:7.4', label: '7.4 (outdated)' },
+	8.3: {
+		image: 'ghcr.io/automattic/vip-container-images/php-fpm:8.3',
+		label: '8.3 (experimental, not officially supported)',
+	},
 } as const;
 
 export const DEV_ENVIRONMENT_VERSION = '2.0.0';

--- a/src/lib/constants/dev-environment.ts
+++ b/src/lib/constants/dev-environment.ts
@@ -34,20 +34,20 @@ interface PhpImage {
 }
 
 export const DEV_ENVIRONMENT_PHP_VERSIONS: Record< string, PhpImage > = {
-	'8.0': {
-		image: 'ghcr.io/automattic/vip-container-images/php-fpm:8.0',
-		label: '8.0 (recommended)',
-	},
+	8.1: { image: 'ghcr.io/automattic/vip-container-images/php-fpm:8.1', label: '8.1 (recommended)' },
 	8.2: {
 		image: 'ghcr.io/automattic/vip-container-images/php-fpm:8.2',
 		label: '8.2 (experimental)',
 	},
-	8.1: { image: 'ghcr.io/automattic/vip-container-images/php-fpm:8.1', label: '8.1' },
-	7.4: { image: 'ghcr.io/automattic/vip-container-images/php-fpm:7.4', label: '7.4 (outdated)' },
 	8.3: {
 		image: 'ghcr.io/automattic/vip-container-images/php-fpm:8.3',
-		label: '8.3 (experimental, not officially supported)',
+		label: '8.3 (experimental, not supported)',
 	},
+	'8.0': {
+		image: 'ghcr.io/automattic/vip-container-images/php-fpm:8.0',
+		label: '8.0 (EOL soon)',
+	},
+	7.4: { image: 'ghcr.io/automattic/vip-container-images/php-fpm:7.4', label: '7.4 (EOL; not supported)' },
 } as const;
 
 export const DEV_ENVIRONMENT_VERSION = '2.0.0';

--- a/src/lib/constants/dev-environment.ts
+++ b/src/lib/constants/dev-environment.ts
@@ -34,11 +34,11 @@ interface PhpImage {
 }
 
 export const DEV_ENVIRONMENT_PHP_VERSIONS: Record< string, PhpImage > = {
-	8.1: { image: 'ghcr.io/automattic/vip-container-images/php-fpm:8.1', label: '8.1 (recommended)' },
 	8.2: {
 		image: 'ghcr.io/automattic/vip-container-images/php-fpm:8.2',
-		label: '8.2 (experimental)',
+		label: '8.2 (recommended)',
 	},
+	8.1: { image: 'ghcr.io/automattic/vip-container-images/php-fpm:8.1', label: '8.1' },
 	8.3: {
 		image: 'ghcr.io/automattic/vip-container-images/php-fpm:8.3',
 		label: '8.3 (experimental, not supported)',

--- a/src/lib/dev-environment/dev-environment-cli.ts
+++ b/src/lib/dev-environment/dev-environment-cli.ts
@@ -665,11 +665,11 @@ export function resolvePhpVersion( version: string ): string {
 	}
 
 	let result: string;
-	if ( DEV_ENVIRONMENT_PHP_VERSIONS[ version ] === undefined ) {
-		const images = Object.values( DEV_ENVIRONMENT_PHP_VERSIONS ) as string[];
-		const image = images.find( value => value === version );
+	if ( ! ( version in DEV_ENVIRONMENT_PHP_VERSIONS ) ) {
+		const images = Object.values( DEV_ENVIRONMENT_PHP_VERSIONS );
+		const image = images.find( value => value.image === version );
 		if ( image ) {
-			result = image;
+			result = image.image;
 		} else if ( version.includes( '/' ) ) {
 			// Assuming this is a Docker image
 			// This can happen when we first called `vip dev-env update -P image:ghcr.io/...`
@@ -677,10 +677,10 @@ export function resolvePhpVersion( version: string ): string {
 			// but we still want to use it.
 			result = version;
 		} else {
-			result = images[ 0 ];
+			result = images[ 0 ].image;
 		}
 	} else {
-		result = DEV_ENVIRONMENT_PHP_VERSIONS[ version ] as string;
+		result = DEV_ENVIRONMENT_PHP_VERSIONS[ version ].image;
 	}
 
 	debug( 'Resolved PHP image: %j', result );
@@ -692,11 +692,15 @@ export async function promptForPhpVersion( initialValue: string ): Promise< stri
 
 	let answer = initialValue;
 	if ( isStdinTTY ) {
-		const choices = Object.keys( DEV_ENVIRONMENT_PHP_VERSIONS );
+		const choices = [];
+		Object.keys( DEV_ENVIRONMENT_PHP_VERSIONS ).forEach( version => {
+			const phpImage = DEV_ENVIRONMENT_PHP_VERSIONS[ version ];
+			choices.push( { message: phpImage.label, value: version } );
+		} );
 		const images = Object.values( DEV_ENVIRONMENT_PHP_VERSIONS );
-		let initial = images.findIndex( version => version === initialValue );
+		let initial = images.findIndex( version => version.image === initialValue );
 		if ( initial === -1 ) {
-			choices.push( initialValue );
+			choices.push( { message: initialValue, value: initialValue } );
 			initial = choices.length - 1;
 		}
 

--- a/src/lib/dev-environment/dev-environment-core.ts
+++ b/src/lib/dev-environment/dev-environment-core.ts
@@ -192,11 +192,7 @@ function preProcessInstanceData( instanceData: InstanceData ): InstanceData {
 
 	newInstanceData.php =
 		instanceData.php ||
-<<<<<<< HEAD
-		( DEV_ENVIRONMENT_PHP_VERSIONS[ Object.keys( DEV_ENVIRONMENT_PHP_VERSIONS )[ 0 ] ] as string );
-=======
 		DEV_ENVIRONMENT_PHP_VERSIONS[ Object.keys( DEV_ENVIRONMENT_PHP_VERSIONS )[ 0 ] ].image;
->>>>>>> 5d41aa3a (feat(dev-env): add PHP 8.3 image)
 	if ( newInstanceData.php.startsWith( 'image:' ) ) {
 		newInstanceData.php = newInstanceData.php.slice( 'image:'.length );
 	}

--- a/src/lib/dev-environment/dev-environment-core.ts
+++ b/src/lib/dev-environment/dev-environment-core.ts
@@ -192,7 +192,11 @@ function preProcessInstanceData( instanceData: InstanceData ): InstanceData {
 
 	newInstanceData.php =
 		instanceData.php ||
+<<<<<<< HEAD
 		( DEV_ENVIRONMENT_PHP_VERSIONS[ Object.keys( DEV_ENVIRONMENT_PHP_VERSIONS )[ 0 ] ] as string );
+=======
+		DEV_ENVIRONMENT_PHP_VERSIONS[ Object.keys( DEV_ENVIRONMENT_PHP_VERSIONS )[ 0 ] ].image;
+>>>>>>> 5d41aa3a (feat(dev-env): add PHP 8.3 image)
 	if ( newInstanceData.php.startsWith( 'image:' ) ) {
 		newInstanceData.php = newInstanceData.php.slice( 'image:'.length );
 	}


### PR DESCRIPTION
## Description

This PR adds the PHP 8.3 image to the dev environment.

It depends on Automattic/vip-container-images#526

## Steps to Test

1. `vip dev-env create` works and sets the specified PHP version
2. `vip dev-env update` works and sets the specified PHP version
3. `vip dev-env create` and `...update` show the prompt like this:
```
? PHP version to use … 
  8.0 (recommended)
  8.2 (experimental)
  8.1
  7.4 (outdated)
▸ 8.3 (experimental, not officially supported)
```
