### PR TITLE
fix(dev-env): display ports exposed by services

### DIFF
--- a/src/lib/dev-environment/dev-environment-lando.ts
+++ b/src/lib/dev-environment/dev-environment-lando.ts
@@ -454,12 +454,18 @@ async function getExtraServicesConnections(
 	const extraServices: Record< string, string > = {};
 	const allServices = await lando.engine.list( { project: app.project } );
 
-	for ( const service of allServices ) {
-		const displayConfiguration = extraServiceDisplayConfiguration.find(
-			conf => conf.name === service.service
-		);
+	const defaultDisplayConfiguration = {
+		skip: false,
+		label: null,
+		protocol: null,
+	};
 
-		if ( ! displayConfiguration || displayConfiguration.skip ) {
+	for ( const service of allServices ) {
+		const displayConfiguration =
+			extraServiceDisplayConfiguration.find( conf => conf.name === service.service ) ??
+			defaultDisplayConfiguration;
+
+		if ( displayConfiguration.skip ) {
 			continue;
 		}
 


### PR DESCRIPTION
## Description

This PR fixes the bug introduced in 72e975cde106e5811012d6a8ba9b474194dd2814 ([link](https://github.com/Automattic/vip-cli/commit/72e975cde106e5811012d6a8ba9b474194dd2814#diff-15dbc43165de0e5b07bbd1cc20ebe7a756e8f08ac7cdb252729414a57bb04e22R446))

## Steps to Test

1. Apply the patch
2. `vip dev-env create < /dev/null && vip dev-env start`
3. Observe that the database information is displayed in the output (smth like `DATABASE          127.0.0.1:32803`)
