### PR TITLE
fix: do not abort if a temporary directory cannot be removed on exit

### DIFF
--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -52,8 +52,14 @@ export function makeTempDir( prefix = 'vip-cli' ): string {
 	debug( `Created a directory to hold temporary files: ${ tempDir }` );
 
 	process.on( 'exit', () => {
-		fs.rmSync( tempDir, { recursive: true, force: true } );
-		debug( `Removed temporary directory: ${ tempDir }` );
+		try {
+			fs.rmSync( tempDir, { recursive: true, force: true, maxRetries: 10 } );
+			debug( `Removed temporary directory: ${ tempDir }` );
+		} catch ( err ) {
+			console.warn(
+				`Failed to remove temporary directory ${ tempDir } (${ ( err as Error ).message })`
+			);
+		}
 	} );
 
 	return tempDir;


### PR DESCRIPTION
## Description

This PR tries to solve the following error:

```
✕ Please contact VIP Support with the following information:
Error: ENOTEMPTY: directory not empty, rmdir '\\?\C:\Users\redacted\AppData\Local\Temp\2\vip-cli-7h5vGM'
at Object.rmdirSync (node:fs:1229:10)
at _rmdirSync (node:internal/fs/rimraf:260:21)
at rimrafSync (node:internal/fs/rimraf:193:7)
at Object.rmSync (node:fs:1278:10)
at process.<anonymous> (C:\Users\redacted\downloads\vip-cli-02665e4ce41f3daaad9112dc50e1ceed17e30b20\vip-cli-02665e4ce41f3daaad9112dc50e1ceed17e30b20\dist\lib\utils.js:59:17)
at process.emit (node:events:526:35)
Error: Unexpected error
Debug: VIP-CLI v2.32.4, Node v18.17.0, win32 10.0.19045
```

1. We now print a warning that the temporary directory cannot be removed instead of generating a fatal error.
2. We retry several times to remove the directory before giving up.

## Steps to Test

N/A - I was unable to reproduce the bug locally :-(
