### PR TITLE
fix: CLI not respecting proxy settings when creating local dev environment

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@automattic/vip",
-  "version": "2.32.5",
+  "version": "2.32.4",
   "description": "The VIP Javascript library & CLI",
   "main": "index.js",
   "bin": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@automattic/vip",
-  "version": "2.32.4",
+  "version": "2.32.5",
   "description": "The VIP Javascript library & CLI",
   "main": "index.js",
   "bin": {

--- a/src/lib/dev-environment/dev-environment-core.ts
+++ b/src/lib/dev-environment/dev-environment-core.ts
@@ -1,20 +1,19 @@
 /**
  * External dependencies
  */
+import os from 'node:os';
+import fs from 'node:fs';
+import path from 'node:path';
 import debugLib from 'debug';
 import xdgBasedir from 'xdg-basedir';
 import fetch from 'node-fetch';
-import os from 'os';
-import fs from 'fs';
 import ejs from 'ejs';
-import path from 'path';
 import chalk from 'chalk';
 import { prompt } from 'enquirer';
 import copydir from 'copy-dir';
 import type Lando from 'lando';
 import { v4 as uuid } from 'uuid';
 import semver from 'semver';
-import { createProxyAgent } from '../http/proxy-agent';
 
 /**
  * Internal dependencies
@@ -50,6 +49,7 @@ import type { AppInfo, ComponentConfig, InstanceData, WordPressConfig } from './
 import { appQueryFragments as softwareQueryFragment } from '../config/software';
 import UserError from '../user-error';
 import { AppEnvironment } from '../../graphqlTypes';
+import { createProxyAgent } from '../http/proxy-agent';
 
 const debug = debugLib( '@automattic/vip:bin:dev-environment' );
 

--- a/src/lib/dev-environment/dev-environment-core.ts
+++ b/src/lib/dev-environment/dev-environment-core.ts
@@ -814,10 +814,12 @@ async function maybeUpdateVersion( slug: string ): Promise< boolean > {
 /**
  * Makes a web call to raw.githubusercontent.com
  */
-export function fetchVersionList(): Promise<WordPressTag[]> {
-	const url = `https://${DEV_ENVIRONMENT_RAW_GITHUB_HOST}${DEV_ENVIRONMENT_WORDPRESS_VERSIONS_URI}`;
-	const proxyAgent = createProxyAgent(url);
-	return fetch( url, { agent: proxyAgent ?? undefined } ).then( res => res.json() as unknown as WordPressTag[] );
+export function fetchVersionList(): Promise< WordPressTag[] > {
+	const url = `https://${ DEV_ENVIRONMENT_RAW_GITHUB_HOST }${ DEV_ENVIRONMENT_WORDPRESS_VERSIONS_URI }`;
+	const proxyAgent = createProxyAgent( url );
+	return fetch( url, { agent: proxyAgent ?? undefined } ).then(
+		res => res.json() as unknown as WordPressTag[]
+	);
 }
 
 /**

--- a/src/lib/dev-environment/dev-environment-core.ts
+++ b/src/lib/dev-environment/dev-environment-core.ts
@@ -14,6 +14,7 @@ import copydir from 'copy-dir';
 import type Lando from 'lando';
 import { v4 as uuid } from 'uuid';
 import semver from 'semver';
+import { createProxyAgent } from '../http/proxy-agent';
 
 /**
  * Internal dependencies
@@ -813,9 +814,10 @@ async function maybeUpdateVersion( slug: string ): Promise< boolean > {
 /**
  * Makes a web call to raw.githubusercontent.com
  */
-export function fetchVersionList(): Promise< WordPressTag[] > {
-	const url = `https://${ DEV_ENVIRONMENT_RAW_GITHUB_HOST }${ DEV_ENVIRONMENT_WORDPRESS_VERSIONS_URI }`;
-	return fetch( url ).then( res => res.json() as unknown as WordPressTag[] );
+export function fetchVersionList(): Promise<WordPressTag[]> {
+	const url = `https://${DEV_ENVIRONMENT_RAW_GITHUB_HOST}${DEV_ENVIRONMENT_WORDPRESS_VERSIONS_URI}`;
+	const proxyAgent = createProxyAgent(url);
+	return fetch( url, { agent: proxyAgent ?? undefined } ).then( res => res.json() as unknown as WordPressTag[] );
 }
 
 /**


### PR DESCRIPTION
## Description
This pull request fixes #1489.

## Steps to Test

1. Configure a proxy and provide https_proxy settings.
2. Check out PR.
3. Run `export VIP_USE_PROXY=1`
4. Run `npm run build`
5. Run `npm install -g .`
6. Run `vip dev-env create -s myApp`.
7. Step through the process and observe "WordPress - Which version would you like" question provides a list of WordPress versions to choose from in addition to "Trunk -> Prerelease (HEAD)".
