### PR TITLE
fix(dev-env): update certificate Common Name

### DIFF
--- a/src/lib/dev-environment/dev-environment-lando.ts
+++ b/src/lib/dev-environment/dev-environment-lando.ts
@@ -84,7 +84,7 @@ async function getLandoConfig(): Promise< LandoConfig > {
 		proxyName: 'vip-dev-env-proxy',
 		userConfRoot: landoDir,
 		home: fakeHomeDir,
-		domain: 'lndo.site',
+		domain: 'vipdev.lndo.site',
 		version: 'unknown',
 	};
 


### PR DESCRIPTION
## Description

This PR changes Lando's CA Common Name to `vipdev.lndo.site` to cover `*.vipdev.lndo.site`. It still does not cover subdomains of subdomains of `lndo.site`, and I am not sure there is an easy solution for that.

Related: BB8-10592

## Steps to Test

E2E tests should pass.