### PR TITLE
ci: run tests and checks in parallel

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ permissions:
   contents: read
 
 jobs:
-  preflight:
+  checks:
     name: ${{ matrix.config.name }}
     runs-on: ubuntu-latest
     strategy:
@@ -46,7 +46,6 @@ jobs:
   test:
     name: Run tests
     runs-on: ubuntu-latest
-    needs: preflight
     strategy:
       fail-fast: true
       matrix:


### PR DESCRIPTION
## Description

This PR updates the CI workflow to allow for running tests and checks (linters, type checks etc.) in parallel. This makes the workflow faster because ESLint takes circa 6 minutes to run, and tests are run after it.

## Steps to Test

No testable changes.
