### PR TITLE
refactor: use `semver` instead of `check-node-version`

### DIFF
--- a/helpers/prepublishOnly.js
+++ b/helpers/prepublishOnly.js
@@ -1,5 +1,4 @@
-const util = require( 'node:util' );
-const check = util.promisify( require( 'check-node-version' ) );
+const { minVersion, satisfies, valid } = require( 'semver' );
 const { exec } = require( 'node:child_process' );
 const { EOL } = require( 'node:os' );
 const packageJSON = require( '../package.json' );
@@ -34,11 +33,15 @@ const releaseTag = process.env.npm_config_tag ?? 'latest';
 		}
 
 		if ( config.nodeEnforceVersion ) {
-			const { isSatisfied, versions } = await check( { node: config.nodeEnforceVersion } );
+			const supported = packageJSON.engines.node;
+			const current = process.versions.node ?? process.version;
+			const isSatisfied = satisfies( current, supported );
 
 			if ( ! isSatisfied ) {
 				return bail(
-					`Node version ${ versions.node.version } is not supported. Please use Node version ${ config.nodeEnforceVersion } or higher.`
+					`Node version ${ valid( current ) } is not supported. Please use Node version ${ valid(
+						minVersion( supported )
+					) } or higher.`
 				);
 			}
 		}

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -129,7 +129,6 @@
         "@types/xml2js": "^0.4.12",
         "babel-jest": "^29.5.0",
         "babel-plugin-module-resolver": "5.0.0",
-        "check-node-version": "^4.2.1",
         "dockerode": "^3.3.4",
         "eslint": "^8.35.0",
         "eslint-plugin-flowtype": "^8.0.3",
@@ -5239,102 +5238,6 @@
         "node": ">=16"
       }
     },
-    "node_modules/check-node-version": {
-      "version": "4.2.1",
-      "resolved": "https://registry.npmjs.org/check-node-version/-/check-node-version-4.2.1.tgz",
-      "integrity": "sha512-YYmFYHV/X7kSJhuN/QYHUu998n/TRuDe8UenM3+m5NrkiH670lb9ILqHIvBencvJc4SDh+XcbXMR4b+TtubJiw==",
-      "dev": true,
-      "dependencies": {
-        "chalk": "^3.0.0",
-        "map-values": "^1.0.1",
-        "minimist": "^1.2.0",
-        "object-filter": "^1.0.2",
-        "run-parallel": "^1.1.4",
-        "semver": "^6.3.0"
-      },
-      "bin": {
-        "check-node-version": "bin.js"
-      },
-      "engines": {
-        "node": ">=8.3.0"
-      }
-    },
-    "node_modules/check-node-version/node_modules/ansi-styles": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
-      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-      "dev": true,
-      "dependencies": {
-        "color-convert": "^2.0.1"
-      },
-      "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
-      }
-    },
-    "node_modules/check-node-version/node_modules/chalk": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-3.0.0.tgz",
-      "integrity": "sha512-4D3B6Wf41KOYRFdszmDqMCGq5VV/uMAB273JILmO+3jAlh8X4qDtdtgCR3fxtbLEMzSx22QdhnDcJvu2u1fVwg==",
-      "dev": true,
-      "dependencies": {
-        "ansi-styles": "^4.1.0",
-        "supports-color": "^7.1.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/check-node-version/node_modules/color-convert": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
-      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-      "dev": true,
-      "dependencies": {
-        "color-name": "~1.1.4"
-      },
-      "engines": {
-        "node": ">=7.0.0"
-      }
-    },
-    "node_modules/check-node-version/node_modules/color-name": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-      "dev": true
-    },
-    "node_modules/check-node-version/node_modules/has-flag": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
-      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
-      "dev": true,
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/check-node-version/node_modules/semver": {
-      "version": "6.3.1",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
-      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
-      "dev": true,
-      "bin": {
-        "semver": "bin/semver.js"
-      }
-    },
-    "node_modules/check-node-version/node_modules/supports-color": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
-      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
-      "dev": true,
-      "dependencies": {
-        "has-flag": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
     "node_modules/chokidar": {
       "version": "3.5.3",
       "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.5.3.tgz",
@@ -10432,12 +10335,6 @@
         "node": ">=6"
       }
     },
-    "node_modules/map-values": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/map-values/-/map-values-1.0.1.tgz",
-      "integrity": "sha1-douOecAJvytk/ugG4ip7HEGQyZA=",
-      "dev": true
-    },
     "node_modules/mem": {
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/mem/-/mem-4.3.0.tgz",
@@ -10763,12 +10660,6 @@
       "engines": {
         "node": ">=0.10.0"
       }
-    },
-    "node_modules/object-filter": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/object-filter/-/object-filter-1.0.2.tgz",
-      "integrity": "sha1-rwt5f/6+r4pSxmN87b6IFs/sG8g=",
-      "dev": true
     },
     "node_modules/object-hash": {
       "version": "1.3.1",
@@ -17329,77 +17220,6 @@
       "resolved": "https://registry.npmjs.org/check-disk-space/-/check-disk-space-3.4.0.tgz",
       "integrity": "sha512-drVkSqfwA+TvuEhFipiR1OC9boEGZL5RrWvVsOthdcvQNXyCCuKkEiTOTXZ7qxSf/GLwq4GvzfrQD/Wz325hgw=="
     },
-    "check-node-version": {
-      "version": "4.2.1",
-      "resolved": "https://registry.npmjs.org/check-node-version/-/check-node-version-4.2.1.tgz",
-      "integrity": "sha512-YYmFYHV/X7kSJhuN/QYHUu998n/TRuDe8UenM3+m5NrkiH670lb9ILqHIvBencvJc4SDh+XcbXMR4b+TtubJiw==",
-      "dev": true,
-      "requires": {
-        "chalk": "^3.0.0",
-        "map-values": "^1.0.1",
-        "minimist": "^1.2.0",
-        "object-filter": "^1.0.2",
-        "run-parallel": "^1.1.4",
-        "semver": "^6.3.0"
-      },
-      "dependencies": {
-        "ansi-styles": {
-          "version": "4.3.0",
-          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
-          "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-          "dev": true,
-          "requires": {
-            "color-convert": "^2.0.1"
-          }
-        },
-        "chalk": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-3.0.0.tgz",
-          "integrity": "sha512-4D3B6Wf41KOYRFdszmDqMCGq5VV/uMAB273JILmO+3jAlh8X4qDtdtgCR3fxtbLEMzSx22QdhnDcJvu2u1fVwg==",
-          "dev": true,
-          "requires": {
-            "ansi-styles": "^4.1.0",
-            "supports-color": "^7.1.0"
-          }
-        },
-        "color-convert": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
-          "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-          "dev": true,
-          "requires": {
-            "color-name": "~1.1.4"
-          }
-        },
-        "color-name": {
-          "version": "1.1.4",
-          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-          "dev": true
-        },
-        "has-flag": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
-          "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
-          "dev": true
-        },
-        "semver": {
-          "version": "6.3.1",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
-          "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
-          "dev": true
-        },
-        "supports-color": {
-          "version": "7.2.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
-          "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
-          "dev": true,
-          "requires": {
-            "has-flag": "^4.0.0"
-          }
-        }
-      }
-    },
     "chokidar": {
       "version": "3.5.3",
       "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.5.3.tgz",
@@ -21174,12 +20994,6 @@
         "p-defer": "^1.0.0"
       }
     },
-    "map-values": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/map-values/-/map-values-1.0.1.tgz",
-      "integrity": "sha1-douOecAJvytk/ugG4ip7HEGQyZA=",
-      "dev": true
-    },
     "mem": {
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/mem/-/mem-4.3.0.tgz",
@@ -21434,12 +21248,6 @@
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
       "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM="
-    },
-    "object-filter": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/object-filter/-/object-filter-1.0.2.tgz",
-      "integrity": "sha1-rwt5f/6+r4pSxmN87b6IFs/sG8g=",
-      "dev": true
     },
     "object-hash": {
       "version": "1.3.1",

--- a/package.json
+++ b/package.json
@@ -131,7 +131,6 @@
     "@types/xml2js": "^0.4.12",
     "babel-jest": "^29.5.0",
     "babel-plugin-module-resolver": "5.0.0",
-    "check-node-version": "^4.2.1",
     "dockerode": "^3.3.4",
     "eslint": "^8.35.0",
     "eslint-plugin-flowtype": "^8.0.3",


### PR DESCRIPTION
## Description

This PR removes the `check-node-version` package and uses `semver` for version checks in `helpers/prepublishOnly.js`.

## Steps to Test

```js
const { minVersion, satisfies, valid } = require('semver');

const supported = require('./package.json').engines.node;
const current = process.version;

console.log(satisfies(current, supported));
console.log(current, supported);
console.log(valid(current), valid(minVersion(supported)));
```

:-)
