### PR TITLE
chore(dev-deps): update TypeScript type definitions

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -114,7 +114,7 @@
         "@types/args": "^5.0.1",
         "@types/cli-table": "^0.3.2",
         "@types/configstore": "5.0.1",
-        "@types/debug": "4.1.8",
+        "@types/debug": "^4.1.9",
         "@types/dockerode": "^3.3.18",
         "@types/ejs": "^3.1.2",
         "@types/js-yaml": "^4.0.6",
@@ -3700,9 +3700,9 @@
       "dev": true
     },
     "node_modules/@types/debug": {
-      "version": "4.1.8",
-      "resolved": "https://registry.npmjs.org/@types/debug/-/debug-4.1.8.tgz",
-      "integrity": "sha512-/vPO1EPOs306Cvhwv7KfVfYvOJqA/S/AXjaHQiJboCZzcNDb+TIJFN9/2C9DZ//ijSKWioNyUxD792QmDJ+HKQ==",
+      "version": "4.1.9",
+      "resolved": "https://registry.npmjs.org/@types/debug/-/debug-4.1.9.tgz",
+      "integrity": "sha512-8Hz50m2eoS56ldRlepxSBa6PWEVCtzUo/92HgLc2qTMnotJNIm7xP+UZhyWoYsyOdd5dxZ+NZLb24rsKyFs2ow==",
       "dev": true,
       "dependencies": {
         "@types/ms": "*"
@@ -16074,9 +16074,9 @@
       "dev": true
     },
     "@types/debug": {
-      "version": "4.1.8",
-      "resolved": "https://registry.npmjs.org/@types/debug/-/debug-4.1.8.tgz",
-      "integrity": "sha512-/vPO1EPOs306Cvhwv7KfVfYvOJqA/S/AXjaHQiJboCZzcNDb+TIJFN9/2C9DZ//ijSKWioNyUxD792QmDJ+HKQ==",
+      "version": "4.1.9",
+      "resolved": "https://registry.npmjs.org/@types/debug/-/debug-4.1.9.tgz",
+      "integrity": "sha512-8Hz50m2eoS56ldRlepxSBa6PWEVCtzUo/92HgLc2qTMnotJNIm7xP+UZhyWoYsyOdd5dxZ+NZLb24rsKyFs2ow==",
       "dev": true,
       "requires": {
         "@types/ms": "*"

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -3823,9 +3823,9 @@
       }
     },
     "node_modules/@types/proxy-from-env": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@types/proxy-from-env/-/proxy-from-env-1.0.1.tgz",
-      "integrity": "sha512-luG++TFHyS61eKcfkR1CVV6a1GMNXDjtqEQIIfaSHax75xp0HU3SlezjOi1yqubJwrG8e9DeW59n6wTblIDwFg==",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@types/proxy-from-env/-/proxy-from-env-1.0.2.tgz",
+      "integrity": "sha512-69oo0n4YzfxciixHK4c7AgEc4QDYQ4NVIWb/LpgqKqf3bpDqqxyEDTBvGDKQvO7PGO6bnsq932qZtJosAf66ow==",
       "dev": true,
       "dependencies": {
         "@types/node": "*"
@@ -16197,9 +16197,9 @@
       }
     },
     "@types/proxy-from-env": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@types/proxy-from-env/-/proxy-from-env-1.0.1.tgz",
-      "integrity": "sha512-luG++TFHyS61eKcfkR1CVV6a1GMNXDjtqEQIIfaSHax75xp0HU3SlezjOi1yqubJwrG8e9DeW59n6wTblIDwFg==",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@types/proxy-from-env/-/proxy-from-env-1.0.2.tgz",
+      "integrity": "sha512-69oo0n4YzfxciixHK4c7AgEc4QDYQ4NVIWb/LpgqKqf3bpDqqxyEDTBvGDKQvO7PGO6bnsq932qZtJosAf66ow==",
       "dev": true,
       "requires": {
         "@types/node": "*"

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -3719,9 +3719,9 @@
       }
     },
     "node_modules/@types/dockerode": {
-      "version": "3.3.19",
-      "resolved": "https://registry.npmjs.org/@types/dockerode/-/dockerode-3.3.19.tgz",
-      "integrity": "sha512-7CC5yIpQi+bHXwDK43b/deYXteP3Lem9gdocVVHJPSRJJLMfbiOchQV3rDmAPkMw+n3GIVj7m1six3JW+VcwwA==",
+      "version": "3.3.20",
+      "resolved": "https://registry.npmjs.org/@types/dockerode/-/dockerode-3.3.20.tgz",
+      "integrity": "sha512-Q+1e3z6SPWXR/Sk+WIyJFVsSDg78S7MDaGcwAh1WKlveO1tVO8TF1rOzJir5GLnqzEdUbclFKlw/4rhwESxwPw==",
       "dev": true,
       "dependencies": {
         "@types/docker-modem": "*",
@@ -16093,9 +16093,9 @@
       }
     },
     "@types/dockerode": {
-      "version": "3.3.19",
-      "resolved": "https://registry.npmjs.org/@types/dockerode/-/dockerode-3.3.19.tgz",
-      "integrity": "sha512-7CC5yIpQi+bHXwDK43b/deYXteP3Lem9gdocVVHJPSRJJLMfbiOchQV3rDmAPkMw+n3GIVj7m1six3JW+VcwwA==",
+      "version": "3.3.20",
+      "resolved": "https://registry.npmjs.org/@types/dockerode/-/dockerode-3.3.20.tgz",
+      "integrity": "sha512-Q+1e3z6SPWXR/Sk+WIyJFVsSDg78S7MDaGcwAh1WKlveO1tVO8TF1rOzJir5GLnqzEdUbclFKlw/4rhwESxwPw==",
       "dev": true,
       "requires": {
         "@types/docker-modem": "*",

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -3384,17 +3384,6 @@
         "node": ">=14.0.0"
       }
     },
-    "node_modules/@lando/compose/node_modules/js-yaml": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
-      "integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
-      "dependencies": {
-        "argparse": "^2.0.1"
-      },
-      "bin": {
-        "js-yaml": "bin/js-yaml.js"
-      }
-    },
     "node_modules/@lando/mailhog": {
       "version": "0.5.0",
       "resolved": "https://registry.npmjs.org/@lando/mailhog/-/mailhog-0.5.0.tgz",
@@ -3406,17 +3395,6 @@
       },
       "engines": {
         "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@lando/mailhog/node_modules/js-yaml": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
-      "integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
-      "dependencies": {
-        "argparse": "^2.0.1"
-      },
-      "bin": {
-        "js-yaml": "bin/js-yaml.js"
       }
     },
     "node_modules/@lando/phpmyadmin": {
@@ -3431,17 +3409,6 @@
       },
       "engines": {
         "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@lando/phpmyadmin/node_modules/js-yaml": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
-      "integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
-      "dependencies": {
-        "argparse": "^2.0.1"
-      },
-      "bin": {
-        "js-yaml": "bin/js-yaml.js"
       }
     },
     "node_modules/@nicolo-ribaudo/chokidar-2": {
@@ -3832,9 +3799,9 @@
       }
     },
     "node_modules/@types/semver": {
-      "version": "7.5.2",
-      "resolved": "https://registry.npmjs.org/@types/semver/-/semver-7.5.2.tgz",
-      "integrity": "sha512-7aqorHYgdNO4DM36stTiGO3DvKoex9TQRwsJU6vMaFGyqpBA1MNZkz+PG3gaNUPpTAOYhT1WR7M1JyA3fbS9Cw==",
+      "version": "7.5.3",
+      "resolved": "https://registry.npmjs.org/@types/semver/-/semver-7.5.3.tgz",
+      "integrity": "sha512-OxepLK9EuNEIPxWNME+C6WwbRAOOI2o2BaQEGzz5Lu2e4Z5eDnEo+/aVEDMIXywoJitJ7xWd641wrGLZdtwRyw==",
       "dev": true
     },
     "node_modules/@types/shelljs": {
@@ -15800,16 +15767,6 @@
         "js-yaml": "^4.1.0",
         "lodash": "^4.17.21",
         "tar": "^6.1.11"
-      },
-      "dependencies": {
-        "js-yaml": {
-          "version": "4.1.0",
-          "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
-          "integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
-          "requires": {
-            "argparse": "^2.0.1"
-          }
-        }
       }
     },
     "@lando/mailhog": {
@@ -15820,16 +15777,6 @@
         "js-yaml": "^4.1.0",
         "lodash": "^4.17.21",
         "tar": "^6.1.11"
-      },
-      "dependencies": {
-        "js-yaml": {
-          "version": "4.1.0",
-          "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
-          "integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
-          "requires": {
-            "argparse": "^2.0.1"
-          }
-        }
       }
     },
     "@lando/phpmyadmin": {
@@ -15841,16 +15788,6 @@
         "lodash": "^4.17.21",
         "semver": "^7.3.2",
         "tar": "^6.1.11"
-      },
-      "dependencies": {
-        "js-yaml": {
-          "version": "4.1.0",
-          "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
-          "integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
-          "requires": {
-            "argparse": "^2.0.1"
-          }
-        }
       }
     },
     "@nicolo-ribaudo/chokidar-2": {
@@ -16206,9 +16143,9 @@
       }
     },
     "@types/semver": {
-      "version": "7.5.2",
-      "resolved": "https://registry.npmjs.org/@types/semver/-/semver-7.5.2.tgz",
-      "integrity": "sha512-7aqorHYgdNO4DM36stTiGO3DvKoex9TQRwsJU6vMaFGyqpBA1MNZkz+PG3gaNUPpTAOYhT1WR7M1JyA3fbS9Cw==",
+      "version": "7.5.3",
+      "resolved": "https://registry.npmjs.org/@types/semver/-/semver-7.5.3.tgz",
+      "integrity": "sha512-OxepLK9EuNEIPxWNME+C6WwbRAOOI2o2BaQEGzz5Lu2e4Z5eDnEo+/aVEDMIXywoJitJ7xWd641wrGLZdtwRyw==",
       "dev": true
     },
     "@types/shelljs": {

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -3729,9 +3729,9 @@
       }
     },
     "node_modules/@types/ejs": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/@types/ejs/-/ejs-3.1.2.tgz",
-      "integrity": "sha512-ZmiaE3wglXVWBM9fyVC17aGPkLo/UgaOjEiI2FXQfyczrCefORPxIe+2dVmnmk3zkVIbizjrlQzmPGhSYGXG5g==",
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/@types/ejs/-/ejs-3.1.3.tgz",
+      "integrity": "sha512-mv5T/JI/bu+pbfz1o+TLl1NF0NIBbjS0Vl6Ppz1YY9DkXfzZT0lelXpfS5i3ZS3U/p90it7uERQpBvLYoK8e4A==",
       "dev": true
     },
     "node_modules/@types/graceful-fs": {
@@ -16103,9 +16103,9 @@
       }
     },
     "@types/ejs": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/@types/ejs/-/ejs-3.1.2.tgz",
-      "integrity": "sha512-ZmiaE3wglXVWBM9fyVC17aGPkLo/UgaOjEiI2FXQfyczrCefORPxIe+2dVmnmk3zkVIbizjrlQzmPGhSYGXG5g==",
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/@types/ejs/-/ejs-3.1.3.tgz",
+      "integrity": "sha512-mv5T/JI/bu+pbfz1o+TLl1NF0NIBbjS0Vl6Ppz1YY9DkXfzZT0lelXpfS5i3ZS3U/p90it7uERQpBvLYoK8e4A==",
       "dev": true
     },
     "@types/graceful-fs": {

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -3805,9 +3805,9 @@
       "dev": true
     },
     "node_modules/@types/shelljs": {
-      "version": "0.8.12",
-      "resolved": "https://registry.npmjs.org/@types/shelljs/-/shelljs-0.8.12.tgz",
-      "integrity": "sha512-ZA8U81/gldY+rR5zl/7HSHrG2KDfEb3lzG6uCUDhW1DTQE9yC/VBQ45fXnXq8f3CgInfhZmjtdu/WOUlrXRQUg==",
+      "version": "0.8.13",
+      "resolved": "https://registry.npmjs.org/@types/shelljs/-/shelljs-0.8.13.tgz",
+      "integrity": "sha512-++uMLOQSLlse1kCfEOwhgmHuaABZwinkylmUKCpvcEGZUov3TtM+gJZloSkW/W+9pEAEg/VBOwiSR05oqJsa5A==",
       "dev": true,
       "dependencies": {
         "@types/glob": "~7.2.0",
@@ -16149,9 +16149,9 @@
       "dev": true
     },
     "@types/shelljs": {
-      "version": "0.8.12",
-      "resolved": "https://registry.npmjs.org/@types/shelljs/-/shelljs-0.8.12.tgz",
-      "integrity": "sha512-ZA8U81/gldY+rR5zl/7HSHrG2KDfEb3lzG6uCUDhW1DTQE9yC/VBQ45fXnXq8f3CgInfhZmjtdu/WOUlrXRQUg==",
+      "version": "0.8.13",
+      "resolved": "https://registry.npmjs.org/@types/shelljs/-/shelljs-0.8.13.tgz",
+      "integrity": "sha512-++uMLOQSLlse1kCfEOwhgmHuaABZwinkylmUKCpvcEGZUov3TtM+gJZloSkW/W+9pEAEg/VBOwiSR05oqJsa5A==",
       "dev": true,
       "requires": {
         "@types/glob": "~7.2.0",

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -3813,9 +3813,9 @@
       "dev": true
     },
     "node_modules/@types/node-fetch": {
-      "version": "2.6.5",
-      "resolved": "https://registry.npmjs.org/@types/node-fetch/-/node-fetch-2.6.5.tgz",
-      "integrity": "sha512-OZsUlr2nxvkqUFLSaY2ZbA+P1q22q+KrlxWOn/38RX+u5kTkYL2mTujEpzUhGkS+K/QCYp9oagfXG39XOzyySg==",
+      "version": "2.6.6",
+      "resolved": "https://registry.npmjs.org/@types/node-fetch/-/node-fetch-2.6.6.tgz",
+      "integrity": "sha512-95X8guJYhfqiuVVhRFxVQcf4hW/2bCuoPwDasMf/531STFoNoWTT7YDnWdXHEZKqAGUigmpG31r2FE70LwnzJw==",
       "dev": true,
       "dependencies": {
         "@types/node": "*",
@@ -16187,9 +16187,9 @@
       "dev": true
     },
     "@types/node-fetch": {
-      "version": "2.6.5",
-      "resolved": "https://registry.npmjs.org/@types/node-fetch/-/node-fetch-2.6.5.tgz",
-      "integrity": "sha512-OZsUlr2nxvkqUFLSaY2ZbA+P1q22q+KrlxWOn/38RX+u5kTkYL2mTujEpzUhGkS+K/QCYp9oagfXG39XOzyySg==",
+      "version": "2.6.6",
+      "resolved": "https://registry.npmjs.org/@types/node-fetch/-/node-fetch-2.6.6.tgz",
+      "integrity": "sha512-95X8guJYhfqiuVVhRFxVQcf4hW/2bCuoPwDasMf/531STFoNoWTT7YDnWdXHEZKqAGUigmpG31r2FE70LwnzJw==",
       "dev": true,
       "requires": {
         "@types/node": "*",

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -111,7 +111,7 @@
         "@babel/preset-typescript": "7.22.15",
         "@jest/globals": "^29.5.0",
         "@jest/test-sequencer": "^29.5.0",
-        "@types/args": "5.0.0",
+        "@types/args": "^5.0.1",
         "@types/cli-table": "^0.3.2",
         "@types/configstore": "5.0.1",
         "@types/debug": "4.1.8",
@@ -3641,9 +3641,9 @@
       }
     },
     "node_modules/@types/args": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/@types/args/-/args-5.0.0.tgz",
-      "integrity": "sha512-3fNb8ja/wQWFrHf5SQC5S3n0iBXdnT3PTPEJni2tBQRuv0BnAsz5u12U5gPRBSR7xdY6fI6QjWoTK/8ysuTt0w==",
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/@types/args/-/args-5.0.1.tgz",
+      "integrity": "sha512-Eiz42PjJ9rP1U00jKox3TZxmB2AXfw2Fz/sF75x9zAAa2GCId+K8jv92wdsx5KCa3tMhuY+nwav4tQAwy71kHQ==",
       "dev": true
     },
     "node_modules/@types/babel__core": {
@@ -16015,9 +16015,9 @@
       }
     },
     "@types/args": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/@types/args/-/args-5.0.0.tgz",
-      "integrity": "sha512-3fNb8ja/wQWFrHf5SQC5S3n0iBXdnT3PTPEJni2tBQRuv0BnAsz5u12U5gPRBSR7xdY6fI6QjWoTK/8ysuTt0w==",
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/@types/args/-/args-5.0.1.tgz",
+      "integrity": "sha512-Eiz42PjJ9rP1U00jKox3TZxmB2AXfw2Fz/sF75x9zAAa2GCId+K8jv92wdsx5KCa3tMhuY+nwav4tQAwy71kHQ==",
       "dev": true
     },
     "@types/babel__core": {

--- a/package.json
+++ b/package.json
@@ -113,7 +113,7 @@
     "@babel/preset-typescript": "7.22.15",
     "@jest/globals": "^29.5.0",
     "@jest/test-sequencer": "^29.5.0",
-    "@types/args": "5.0.0",
+    "@types/args": "^5.0.1",
     "@types/cli-table": "^0.3.2",
     "@types/configstore": "5.0.1",
     "@types/debug": "4.1.8",

--- a/package.json
+++ b/package.json
@@ -116,7 +116,7 @@
     "@types/args": "^5.0.1",
     "@types/cli-table": "^0.3.2",
     "@types/configstore": "5.0.1",
-    "@types/debug": "4.1.8",
+    "@types/debug": "^4.1.9",
     "@types/dockerode": "^3.3.18",
     "@types/ejs": "^3.1.2",
     "@types/js-yaml": "^4.0.6",


### PR DESCRIPTION
## Description

* update `@types/args` from 5.0.0 to 5.0.1
* update `@types/debug` from 4.1.8 to 4.1.9
* update `@types/dockerode` from 3.3.19 to 3.3.20
* update `@types/ejs` from 3.1.2 to 3.1.3
* update `@types/node-fetch` from 2.6.5 to 2.6.6
* update `@types/proxy-from-env` from 1.0.1 to 1.0.2
* update `@types/semver` from 7.5.2 to 7.5.3
* update `@types/shelljs` from 0.8.12 to 0.8.13

## Steps to Test

CI should pass.
