### PR TITLE
ci: do not run `npm test` in prepublishOnly during CI

### DIFF
--- a/helpers/prepublishOnly.js
+++ b/helpers/prepublishOnly.js
@@ -7,7 +7,7 @@ const config = {
 	gitAllowDirty: true,
 	gitEnforceBranch: 'trunk',
 	nodeEnforceVersion: packageJSON.engines.node,
-	testBeforePublish: true,
+	testBeforePublish: process.env.CI !== 'true',
 };
 
 const releaseTag = process.env.npm_config_tag ?? 'latest';


### PR DESCRIPTION
## Description

When we publish the package from GitHub Actions, `npm test` is run too many times. And because `npm run lint` for some reason is extremely slow, it takes ~30 minutes to publish a package.

The first time we run `npm test` from `Automattic/vip-actions/npm-publish` ([here](https://github.com/Automattic/vip-actions/blob/v0.1.2/npm-publish/bin/publish.sh#L98))

The second time this happens during [`npm publish --dry-run`](https://github.com/Automattic/vip-actions/blob/v0.1.2/npm-publish/bin/publish.sh#L112), and the third time during [`npm publish`](https://github.com/Automattic/vip-actions/blob/v0.1.2/npm-publish/bin/publish.sh#L122)

`npm publish` invokes the `prepublishOnly` script; it invokes [`npm test`](https://github.com/Automattic/vip-cli/blob/ec440fc2c54ba21d8e60326568b03bf2bfcd948c/helpers/prepublishOnly.js#L52).

In this PR, we ask `prepublishOnly` not to run `npm test` when running inside a CI environment. This is detected by the `CI=true` in the environment.

Ref: https://github.com/Automattic/vip-cli/actions/runs/6338409874/job/17215454287

## Steps to Test

`CI=true npm publish --dry-run` should not invoke `npm test`; `npm publish --dry-run` should.
