### PR TITLE
Change default response on WordPress upgrade prompt to 'no'

### DIFF
--- a/src/lib/dev-environment/dev-environment-core.ts
+++ b/src/lib/dev-environment/dev-environment-core.ts
@@ -762,7 +762,7 @@ async function maybeUpdateWordPressImage( slug: string ): Promise< boolean > {
 		type: 'select',
 		name: 'upgrade',
 		message: 'Would you like to upgrade WordPress? ',
-		choices: [ 'no', "no (don't ask anymore)", 'yes' ],
+		choices: [ 'no', 'yes', "no (don't ask anymore)" ],
 	} );
 
 	// If the user takes the new WP version path

--- a/src/lib/dev-environment/dev-environment-core.ts
+++ b/src/lib/dev-environment/dev-environment-core.ts
@@ -761,8 +761,8 @@ async function maybeUpdateWordPressImage( slug: string ): Promise< boolean > {
 	const confirm = await prompt( {
 		type: 'select',
 		name: 'upgrade',
-		message: 'Would You like to change the WordPress version? ',
-		choices: [ 'yes', 'no', "no (don't ask anymore)" ],
+		message: 'Would you like to updgrade WordPress? ',
+		choices: [ 'no', "no (don't ask anymore)", 'yes' ],
 	} );
 
 	// If the user takes the new WP version path

--- a/src/lib/dev-environment/dev-environment-core.ts
+++ b/src/lib/dev-environment/dev-environment-core.ts
@@ -761,7 +761,7 @@ async function maybeUpdateWordPressImage( slug: string ): Promise< boolean > {
 	const confirm = await prompt( {
 		type: 'select',
 		name: 'upgrade',
-		message: 'Would you like to updgrade WordPress? ',
+		message: 'Would you like to upgrade WordPress? ',
 		choices: [ 'no', "no (don't ask anymore)", 'yes' ],
 	} );
 


### PR DESCRIPTION
## Description

I propose to change the default response to the WordPress upgrade prompt that one gets when starting their VIP dev environment to 'no'. I think this would lower the risk of messing up one's local env by accidentally breezing through the prompt and unintentionally upgrading the version of WordPress in use.

In our situation, WordPress is heavily customized to the point where we cannot let WordPress update itself in our VIP cloud environments, and we want our dev envs to match that (unless we're actually testing a WordPress upgrade). It would be nice to be able to think a little less when starting our dev envs, rather than having to select a non-default response every time.

## Steps to Test

Given that you have a local VIP dev env running WordPress < 6.3,

1. Check out PR.
1. Run `npm run build`
1. Run `npm link`
1. Start your VIP dev env in another shell and see the different order of options at the prompt
