### PR TITLE
SQL Import Status: Ensure we pull site type ID from server for validation

### DIFF
--- a/src/bin/vip-import-sql-status.js
+++ b/src/bin/vip-import-sql-status.js
@@ -18,6 +18,7 @@ const appQuery = `
 id,
 name,
 type,
+typeId,
 environments{
 	id
 	appId


### PR DESCRIPTION
## Description

We changed the way we validate if an app is supported for SQL / DB import operations in [this](https://github.com/Automattic/vip-cli/pull/1507) PR

This PR builds on that to ensure that we're validating the app against the correct parameter, i.e. `typeId` field from the server response.

## Steps to Reproduce & Test

1. Run `npm run build`
1. Run `./dist/bin/vip-import-sql-status.js @<siteId>.production`
1. Verify message `The type of application you specified does not currently support SQL imports.`
2. Pull down PR
3. Run `npm run build`
4. Run `./dist/bin/vip-import-sql-status.js @<siteId>.production`
5. Validate proper response
