### PR TITLE
chore(dev-deps): update dockerode from 3.3.4 to 4.0.0

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -125,7 +125,7 @@
         "@types/uuid": "^9.0.5",
         "@types/xml2js": "^0.4.12",
         "babel-jest": "^29.5.0",
-        "dockerode": "^3.3.4",
+        "dockerode": "^4.0.0",
         "eslint": "^8.35.0",
         "jest": "^29.5.0",
         "nock": "13.3.4",
@@ -4754,9 +4754,9 @@
       "dev": true
     },
     "node_modules/buildcheck": {
-      "version": "0.0.3",
-      "resolved": "https://registry.npmjs.org/buildcheck/-/buildcheck-0.0.3.tgz",
-      "integrity": "sha512-pziaA+p/wdVImfcbsZLNF32EiWyujlQLwolMqUQE8xpKNOH7KmZQaY8sXN7DGOEzPAElo9QTaeNRfGnf3iOJbA==",
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/buildcheck/-/buildcheck-0.0.6.tgz",
+      "integrity": "sha512-8f9ZJCUXyT1M35Jx7MkBgmBMo3oHTTBIPLiY9xyL0pl3T5RwcPEY8cUHr5LBNfu/fk6c2T4DJZuVM/8ZZT2D2A==",
       "optional": true,
       "engines": {
         "node": ">=10.0.0"
@@ -5466,14 +5466,14 @@
       }
     },
     "node_modules/cpu-features": {
-      "version": "0.0.4",
-      "resolved": "https://registry.npmjs.org/cpu-features/-/cpu-features-0.0.4.tgz",
-      "integrity": "sha512-fKiZ/zp1mUwQbnzb9IghXtHtDoTMtNeb8oYGx6kX2SYfhnG0HNdBEBIzB9b5KlXu5DQPhfy3mInbBxFcgwAr3A==",
+      "version": "0.0.9",
+      "resolved": "https://registry.npmjs.org/cpu-features/-/cpu-features-0.0.9.tgz",
+      "integrity": "sha512-AKjgn2rP2yJyfbepsmLfiYcmtNn/2eUvocUyM/09yB0YDiz39HteK/5/T4Onf0pmdYDMgkBoGvRLvEguzyL7wQ==",
       "hasInstallScript": true,
       "optional": true,
       "dependencies": {
-        "buildcheck": "0.0.3",
-        "nan": "^2.15.0"
+        "buildcheck": "~0.0.6",
+        "nan": "^2.17.0"
       },
       "engines": {
         "node": ">=10.0.0"
@@ -5767,9 +5767,10 @@
       }
     },
     "node_modules/docker-modem": {
-      "version": "3.0.6",
-      "resolved": "https://registry.npmjs.org/docker-modem/-/docker-modem-3.0.6.tgz",
-      "integrity": "sha512-h0Ow21gclbYsZ3mkHDfsYNDqtRhXS8fXr51bU0qr1dxgTMJj0XufbzX+jhNOvA8KuEEzn6JbvLVhXyv+fny9Uw==",
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/docker-modem/-/docker-modem-5.0.0.tgz",
+      "integrity": "sha512-J1gOocUHrYOI0u5+SbM9eg84igD40NfUJoWL9Hc2a6hF3oN6PFA9fmzu2Ai8fddXrVUJbENx5STOlcvhTau4rA==",
+      "dev": true,
       "dependencies": {
         "debug": "^4.1.1",
         "readable-stream": "^3.5.0",
@@ -5781,12 +5782,13 @@
       }
     },
     "node_modules/dockerode": {
-      "version": "3.3.5",
-      "resolved": "https://registry.npmjs.org/dockerode/-/dockerode-3.3.5.tgz",
-      "integrity": "sha512-/0YNa3ZDNeLr/tSckmD69+Gq+qVNhvKfAHNeZJBnp7EOP6RGKV8ORrJHkUn20So5wU+xxT7+1n5u8PjHbfjbSA==",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/dockerode/-/dockerode-4.0.0.tgz",
+      "integrity": "sha512-3LF7/3MPz5+9RsUo91rD0MCcx0yxjC9bnbtgtVjOLKyKxlZSJ7/Kk3OPAgARlwlWHqXwAGYhmkAHYx7IwD0tJQ==",
+      "dev": true,
       "dependencies": {
         "@balena/dockerignore": "^1.0.2",
-        "docker-modem": "^3.0.0",
+        "docker-modem": "^5.0.0",
         "tar-fs": "~2.0.1"
       },
       "engines": {
@@ -9854,6 +9856,33 @@
         "node": ">=4"
       }
     },
+    "node_modules/lando/node_modules/docker-modem": {
+      "version": "3.0.8",
+      "resolved": "https://registry.npmjs.org/docker-modem/-/docker-modem-3.0.8.tgz",
+      "integrity": "sha512-f0ReSURdM3pcKPNS30mxOHSbaFLcknGmQjwSfmbcdOw1XWKXVhukM3NJHhr7NpY9BIyyWQb0EBo3KQvvuU5egQ==",
+      "dependencies": {
+        "debug": "^4.1.1",
+        "readable-stream": "^3.5.0",
+        "split-ca": "^1.0.1",
+        "ssh2": "^1.11.0"
+      },
+      "engines": {
+        "node": ">= 8.0"
+      }
+    },
+    "node_modules/lando/node_modules/dockerode": {
+      "version": "3.3.5",
+      "resolved": "https://registry.npmjs.org/dockerode/-/dockerode-3.3.5.tgz",
+      "integrity": "sha512-/0YNa3ZDNeLr/tSckmD69+Gq+qVNhvKfAHNeZJBnp7EOP6RGKV8ORrJHkUn20So5wU+xxT7+1n5u8PjHbfjbSA==",
+      "dependencies": {
+        "@balena/dockerignore": "^1.0.2",
+        "docker-modem": "^3.0.0",
+        "tar-fs": "~2.0.1"
+      },
+      "engines": {
+        "node": ">= 8.0"
+      }
+    },
     "node_modules/lando/node_modules/find-up": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/find-up/-/find-up-3.0.0.tgz",
@@ -10309,9 +10338,9 @@
       "integrity": "sha1-MHXOk7whuPq0PhvE2n6BFe0ee6s="
     },
     "node_modules/nan": {
-      "version": "2.17.0",
-      "resolved": "https://registry.npmjs.org/nan/-/nan-2.17.0.tgz",
-      "integrity": "sha512-2ZTgtl0nJsO0KQCjEpxcIr5D+Yv90plTitZt9JBfQvVJDS5seMl3FOvsh3+9CoYWXf/1l5OaZzzF6nDm4cagaQ==",
+      "version": "2.18.0",
+      "resolved": "https://registry.npmjs.org/nan/-/nan-2.18.0.tgz",
+      "integrity": "sha512-W7tfG7vMOGtD30sHoZSSc/JVYiyDPEyQVso/Zz+/uQd0B0L46gtC+pHha5FFMRpil6fm/AoEcRWyOVi4+E/f8w==",
       "optional": true
     },
     "node_modules/napi-build-utils": {
@@ -11879,20 +11908,20 @@
       "dev": true
     },
     "node_modules/ssh2": {
-      "version": "1.11.0",
-      "resolved": "https://registry.npmjs.org/ssh2/-/ssh2-1.11.0.tgz",
-      "integrity": "sha512-nfg0wZWGSsfUe/IBJkXVll3PEZ//YH2guww+mP88gTpuSU4FtZN7zu9JoeTGOyCNx2dTDtT9fOpWwlzyj4uOOw==",
+      "version": "1.14.0",
+      "resolved": "https://registry.npmjs.org/ssh2/-/ssh2-1.14.0.tgz",
+      "integrity": "sha512-AqzD1UCqit8tbOKoj6ztDDi1ffJZ2rV2SwlgrVVrHPkV5vWqGJOVp5pmtj18PunkPJAuKQsnInyKV+/Nb2bUnA==",
       "hasInstallScript": true,
       "dependencies": {
-        "asn1": "^0.2.4",
+        "asn1": "^0.2.6",
         "bcrypt-pbkdf": "^1.0.2"
       },
       "engines": {
         "node": ">=10.16.0"
       },
       "optionalDependencies": {
-        "cpu-features": "~0.0.4",
-        "nan": "^2.16.0"
+        "cpu-features": "~0.0.8",
+        "nan": "^2.17.0"
       }
     },
     "node_modules/stack-trace": {
@@ -16859,9 +16888,9 @@
       "dev": true
     },
     "buildcheck": {
-      "version": "0.0.3",
-      "resolved": "https://registry.npmjs.org/buildcheck/-/buildcheck-0.0.3.tgz",
-      "integrity": "sha512-pziaA+p/wdVImfcbsZLNF32EiWyujlQLwolMqUQE8xpKNOH7KmZQaY8sXN7DGOEzPAElo9QTaeNRfGnf3iOJbA==",
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/buildcheck/-/buildcheck-0.0.6.tgz",
+      "integrity": "sha512-8f9ZJCUXyT1M35Jx7MkBgmBMo3oHTTBIPLiY9xyL0pl3T5RwcPEY8cUHr5LBNfu/fk6c2T4DJZuVM/8ZZT2D2A==",
       "optional": true
     },
     "cacheable-request": {
@@ -17386,13 +17415,13 @@
       }
     },
     "cpu-features": {
-      "version": "0.0.4",
-      "resolved": "https://registry.npmjs.org/cpu-features/-/cpu-features-0.0.4.tgz",
-      "integrity": "sha512-fKiZ/zp1mUwQbnzb9IghXtHtDoTMtNeb8oYGx6kX2SYfhnG0HNdBEBIzB9b5KlXu5DQPhfy3mInbBxFcgwAr3A==",
+      "version": "0.0.9",
+      "resolved": "https://registry.npmjs.org/cpu-features/-/cpu-features-0.0.9.tgz",
+      "integrity": "sha512-AKjgn2rP2yJyfbepsmLfiYcmtNn/2eUvocUyM/09yB0YDiz39HteK/5/T4Onf0pmdYDMgkBoGvRLvEguzyL7wQ==",
       "optional": true,
       "requires": {
-        "buildcheck": "0.0.3",
-        "nan": "^2.15.0"
+        "buildcheck": "~0.0.6",
+        "nan": "^2.17.0"
       }
     },
     "create-jest": {
@@ -17600,9 +17629,10 @@
       }
     },
     "docker-modem": {
-      "version": "3.0.6",
-      "resolved": "https://registry.npmjs.org/docker-modem/-/docker-modem-3.0.6.tgz",
-      "integrity": "sha512-h0Ow21gclbYsZ3mkHDfsYNDqtRhXS8fXr51bU0qr1dxgTMJj0XufbzX+jhNOvA8KuEEzn6JbvLVhXyv+fny9Uw==",
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/docker-modem/-/docker-modem-5.0.0.tgz",
+      "integrity": "sha512-J1gOocUHrYOI0u5+SbM9eg84igD40NfUJoWL9Hc2a6hF3oN6PFA9fmzu2Ai8fddXrVUJbENx5STOlcvhTau4rA==",
+      "dev": true,
       "requires": {
         "debug": "^4.1.1",
         "readable-stream": "^3.5.0",
@@ -17611,12 +17641,13 @@
       }
     },
     "dockerode": {
-      "version": "3.3.5",
-      "resolved": "https://registry.npmjs.org/dockerode/-/dockerode-3.3.5.tgz",
-      "integrity": "sha512-/0YNa3ZDNeLr/tSckmD69+Gq+qVNhvKfAHNeZJBnp7EOP6RGKV8ORrJHkUn20So5wU+xxT7+1n5u8PjHbfjbSA==",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/dockerode/-/dockerode-4.0.0.tgz",
+      "integrity": "sha512-3LF7/3MPz5+9RsUo91rD0MCcx0yxjC9bnbtgtVjOLKyKxlZSJ7/Kk3OPAgARlwlWHqXwAGYhmkAHYx7IwD0tJQ==",
+      "dev": true,
       "requires": {
         "@balena/dockerignore": "^1.0.2",
-        "docker-modem": "^3.0.0",
+        "docker-modem": "^5.0.0",
         "tar-fs": "~2.0.1"
       }
     },
@@ -20577,6 +20608,27 @@
           "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.1.tgz",
           "integrity": "sha512-+O9Jct8wf++lXxxFc4hc8LsjaSq0HFzzL7cVsw8pRDIPdjKD2mT4ytDZlLuSBZ4cLKZFXIrMGO7DbQCtMJJMKw=="
         },
+        "docker-modem": {
+          "version": "3.0.8",
+          "resolved": "https://registry.npmjs.org/docker-modem/-/docker-modem-3.0.8.tgz",
+          "integrity": "sha512-f0ReSURdM3pcKPNS30mxOHSbaFLcknGmQjwSfmbcdOw1XWKXVhukM3NJHhr7NpY9BIyyWQb0EBo3KQvvuU5egQ==",
+          "requires": {
+            "debug": "^4.1.1",
+            "readable-stream": "^3.5.0",
+            "split-ca": "^1.0.1",
+            "ssh2": "^1.11.0"
+          }
+        },
+        "dockerode": {
+          "version": "3.3.5",
+          "resolved": "https://registry.npmjs.org/dockerode/-/dockerode-3.3.5.tgz",
+          "integrity": "sha512-/0YNa3ZDNeLr/tSckmD69+Gq+qVNhvKfAHNeZJBnp7EOP6RGKV8ORrJHkUn20So5wU+xxT7+1n5u8PjHbfjbSA==",
+          "requires": {
+            "@balena/dockerignore": "^1.0.2",
+            "docker-modem": "^3.0.0",
+            "tar-fs": "~2.0.1"
+          }
+        },
         "find-up": {
           "version": "3.0.0",
           "resolved": "https://registry.npmjs.org/find-up/-/find-up-3.0.0.tgz",
@@ -20949,9 +21001,9 @@
       "integrity": "sha1-MHXOk7whuPq0PhvE2n6BFe0ee6s="
     },
     "nan": {
-      "version": "2.17.0",
-      "resolved": "https://registry.npmjs.org/nan/-/nan-2.17.0.tgz",
-      "integrity": "sha512-2ZTgtl0nJsO0KQCjEpxcIr5D+Yv90plTitZt9JBfQvVJDS5seMl3FOvsh3+9CoYWXf/1l5OaZzzF6nDm4cagaQ==",
+      "version": "2.18.0",
+      "resolved": "https://registry.npmjs.org/nan/-/nan-2.18.0.tgz",
+      "integrity": "sha512-W7tfG7vMOGtD30sHoZSSc/JVYiyDPEyQVso/Zz+/uQd0B0L46gtC+pHha5FFMRpil6fm/AoEcRWyOVi4+E/f8w==",
       "optional": true
     },
     "napi-build-utils": {
@@ -22082,14 +22134,14 @@
       "dev": true
     },
     "ssh2": {
-      "version": "1.11.0",
-      "resolved": "https://registry.npmjs.org/ssh2/-/ssh2-1.11.0.tgz",
-      "integrity": "sha512-nfg0wZWGSsfUe/IBJkXVll3PEZ//YH2guww+mP88gTpuSU4FtZN7zu9JoeTGOyCNx2dTDtT9fOpWwlzyj4uOOw==",
+      "version": "1.14.0",
+      "resolved": "https://registry.npmjs.org/ssh2/-/ssh2-1.14.0.tgz",
+      "integrity": "sha512-AqzD1UCqit8tbOKoj6ztDDi1ffJZ2rV2SwlgrVVrHPkV5vWqGJOVp5pmtj18PunkPJAuKQsnInyKV+/Nb2bUnA==",
       "requires": {
-        "asn1": "^0.2.4",
+        "asn1": "^0.2.6",
         "bcrypt-pbkdf": "^1.0.2",
-        "cpu-features": "~0.0.4",
-        "nan": "^2.16.0"
+        "cpu-features": "~0.0.8",
+        "nan": "^2.17.0"
       }
     },
     "stack-trace": {

--- a/package.json
+++ b/package.json
@@ -126,7 +126,7 @@
     "@types/uuid": "^9.0.5",
     "@types/xml2js": "^0.4.12",
     "babel-jest": "^29.5.0",
-    "dockerode": "^3.3.4",
+    "dockerode": "^4.0.0",
     "eslint": "^8.35.0",
     "jest": "^29.5.0",
     "nock": "13.3.4",


### PR DESCRIPTION
## Description

This PR updates `dockerode` from 3.3.4 to 4.0.0. No changelog is available, but from the diff, it seems like the changes mostly affect image build-related stuff.

We use `dockerode` in our E2E tests; if everything goes well, I am going to update Lando to switch to Dockerode 4.

## Steps to Test

E2E tests should pass.
