### PR TITLE
build: disable promise/no-multiple-resolved

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -3,7 +3,8 @@
   "rules": {
     "no-console": 0,
     "security/detect-object-injection": 0,
-    "security/detect-non-literal-fs-filename": 0
+    "security/detect-non-literal-fs-filename": 0,
+    "promise/no-multiple-resolved": 0
   },
   "overrides": [
     {


### PR DESCRIPTION
## Description

This PR disables the `promise/no-multiple-resolved` rule because it causes major slowdown for the Lint job.

```
$ TIMING=1 DEBUG=eslint:linter npx eslint . --ext ts
...
  eslint:linter Linting code for /home/volodymyr/automattic/vip-cli/src/lib/site-import/status.ts (pass 1) +1ms
  eslint:linter Verify +0ms
  eslint:linter With ConfigArray: /home/volodymyr/automattic/vip-cli/src/lib/site-import/status.ts +0ms
  eslint:linter Parsing: /home/volodymyr/automattic/vip-cli/src/lib/site-import/status.ts +0ms
  eslint:linter Parsing successful: /home/volodymyr/automattic/vip-cli/src/lib/site-import/status.ts +17ms
  eslint:linter Scope analysis: /home/volodymyr/automattic/vip-cli/src/lib/site-import/status.ts +0ms
  eslint:linter Scope analysis successful: /home/volodymyr/automattic/vip-cli/src/lib/site-import/status.ts +0ms
  eslint:linter Generating fixed text for /home/volodymyr/automattic/vip-cli/src/lib/site-import/status.ts (pass 1) +5m
...
Rule                                       |  Time (ms) | Relative
:------------------------------------------|-----------:|--------:
promise/no-multiple-resolved               | 302949.116 |    98.5%
prettier/prettier                          |   1762.054 |     0.6%
@typescript-eslint/no-misused-promises     |    683.756 |     0.2%
import/no-duplicates                       |    325.211 |     0.1%
@typescript-eslint/no-floating-promises    |    294.379 |     0.1%
@typescript-eslint/no-unsafe-argument      |    267.663 |     0.1%
@typescript-eslint/no-unsafe-return        |    158.369 |     0.1%
@typescript-eslint/no-unsafe-assignment    |    145.742 |     0.0%
security/detect-bidi-characters            |    105.555 |     0.0%
@typescript-eslint/no-unsafe-member-access |     97.572 |     0.0%
```

It took 5 minutes(!) to lint `src/lib/site-import/status.ts`, and the slowest rule was `promise/no-multiple-resolved`.

This is most likely related to another rule we suppress:

```
vip-cli/src/lib/site-import/status.ts
  264:24  error  Async arrow function has a complexity of 25. Maximum allowed is 20  complexity
```

The function is too complex for `eslint-plugin-promise` to analyze it (or maybe its analysis algorithm is inefficient).

Unfortunately, `/* eslint-disable promise/no-multiple-resolved */` does not turn off the rule; it just disables all diagnostics from that rule.

## Steps to Test

CI should pass.