### PR TITLE
CANTINA-957: Dev-env: Make message after update more clear

### DIFF
--- a/src/bin/vip-dev-env-update.js
+++ b/src/bin/vip-dev-env-update.js
@@ -119,8 +119,8 @@ cmd.argv( process.argv, async ( arg, opt ) => {
 		const message =
 			'\n' +
 			chalk.green( '✓' ) +
-			' environment updated. Please start environment again for changes to take effect: '
-			+ chalk.bold( `vip dev env --slug ${ slug } start` );
+			' environment updated. Please start environment again for changes to take effect: ' +
+			chalk.bold( `vip dev env --slug ${ slug } start` );
 		console.log( message );
 		await trackEvent( 'dev_env_update_command_success', trackingInfo );
 	} catch ( error ) {

--- a/src/bin/vip-dev-env-update.js
+++ b/src/bin/vip-dev-env-update.js
@@ -119,7 +119,8 @@ cmd.argv( process.argv, async ( arg, opt ) => {
 		const message =
 			'\n' +
 			chalk.green( '✓' ) +
-			' environment updated. Restart environment for changes to take an affect.';
+			' environment updated. Please start environment again for changes to take effect: '
+			+ chalk.bold( `vip dev env --slug ${ slug } start` );
 		console.log( message );
 		await trackEvent( 'dev_env_update_command_success', trackingInfo );
 	} catch ( error ) {


### PR DESCRIPTION
## Description

This messaging is to clarify and to prevent users from attempting `vip dev-env restart` since that command doesn't exist.

```
✓ environment updated. Please start environment again for changes to take effect: vip dev env --slug es-site start
```

## Steps to Test

1) `npm run build`
2) ` ./dist/bin/vip-dev-env-update.js --slug es-site`
3) See message match description