### PR TITLE
Add vip dev-env purge command logic

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "vip-dev-env-start": "dist/bin/vip-dev-env-start.js",
     "vip-dev-env-stop": "dist/bin/vip-dev-env-stop.js",
     "vip-dev-env-logs": "dist/bin/vip-dev-env-logs.js",
+    "vip-dev-env-purge": "dist/bin/vip-dev-env-purge.js",
     "vip-export": "dist/bin/vip-export.js",
     "vip-export-sql": "dist/bin/vip-export-sql.js",
     "vip-dev-env-sync": "dist/bin/vip-dev-env-sync.js",

--- a/src/bin/vip-dev-env-purge.js
+++ b/src/bin/vip-dev-env-purge.js
@@ -74,8 +74,7 @@ command()
 		const removeFiles = ! ( opt.soft || false );
 
 		try {
-			for ( const envName of allEnvNames ) {
-				const slug = envName;
+			for ( const slug of allEnvNames ) {
 
 				try {
 					// eslint-disable-next-line no-await-in-loop

--- a/src/bin/vip-dev-env-purge.js
+++ b/src/bin/vip-dev-env-purge.js
@@ -1,0 +1,68 @@
+#!/usr/bin/env node
+
+/**
+ * External dependencies
+ */
+import debugLib from 'debug';
+import chalk from 'chalk';
+
+/**
+ * Internal dependencies
+ */
+import { trackEvent } from '../lib/tracker';
+import command from '../lib/cli/command';
+import { destroyEnvironment, getAllEnvironmentNames } from '../lib/dev-environment/dev-environment-core';
+import { DEV_ENVIRONMENT_FULL_COMMAND } from '../lib/constants/dev-environment';
+import {
+	getEnvTrackingInfo,
+	handleCLIException,
+	validateDependencies,
+} from '../lib/dev-environment/dev-environment-cli';
+import { bootstrapLando } from '../lib/dev-environment/dev-environment-lando';
+
+const debug = debugLib( '@automattic/vip:bin:dev-environment' );
+
+const examples = [
+	{
+		usage: `${ DEV_ENVIRONMENT_FULL_COMMAND } purge`,
+		description: 'Destroys all local dev environments',
+	},
+];
+
+command()
+	.option( 'soft', 'Keep config files needed to start an environment intact' )
+	.examples( examples )
+	.argv( process.argv, async ( arg, opt ) => {
+		const allEnvNames = getAllEnvironmentNames();
+        const trackingInfo = { all: true };
+        await trackEvent( 'dev_env_purge_command_execute', trackingInfo );
+
+        try {
+            for ( const envName of allEnvNames ) {
+                const slug = envName;
+                const lando = await bootstrapLando();
+                await validateDependencies( lando, slug );
+    
+                const trackingInfo = getEnvTrackingInfo( slug );
+                await trackEvent( 'dev_env_destroy_command_execute', trackingInfo );
+    
+                debug( 'Args: ', arg, 'Options: ', opt );
+    
+                try {
+                    const removeFiles = ! ( opt.soft || false );
+                    await destroyEnvironment( lando, slug, removeFiles );
+    
+                    const message = chalk.green( '✓' ) + ' Environment destroyed.\n';
+                    console.log( message );
+                    await trackEvent( 'dev_env_destroy_command_success', trackingInfo );
+                } catch ( error ) {
+                    await handleCLIException( error, 'dev_env_destroy_command_error', trackingInfo );
+                    process.exitCode = 1;
+                }
+            }
+        } catch ( error ) {
+            await handleCLIException( error, 'dev_env_purge_command_error', trackingInfo );
+            process.exitCode = 1;
+        }
+        
+	} );

--- a/src/bin/vip-dev-env-purge.js
+++ b/src/bin/vip-dev-env-purge.js
@@ -44,18 +44,22 @@ command()
 		try {
 			for ( const envName of allEnvNames ) {
 				const slug = envName;
+				// eslint-disable-next-line no-await-in-loop
 				await validateDependencies( lando, slug );
 				const trackingInfoChild = getEnvTrackingInfo( slug );
+				// eslint-disable-next-line no-await-in-loop
 				await trackEvent( 'dev_env_destroy_command_execute', trackingInfoChild );
 
 				debug( 'Args: ', arg, 'Options: ', opt );
 
 				try {
 					const removeFiles = ! ( opt.soft || false );
+					// eslint-disable-next-line no-await-in-loop
 					await destroyEnvironment( lando, slug, removeFiles );
 
 					const message = chalk.green( '✓' ) + ' Environment destroyed.\n';
 					console.log( message );
+					// eslint-disable-next-line no-await-in-loop
 					await trackEvent( 'dev_env_destroy_command_success', trackingInfoChild );
 				} catch ( error ) {
 					await handleCLIException( error, 'dev_env_destroy_command_error', trackingInfoChild );

--- a/src/bin/vip-dev-env-purge.js
+++ b/src/bin/vip-dev-env-purge.js
@@ -3,25 +3,25 @@
 /**
  * External dependencies
  */
-import debugLib from 'debug';
 import chalk from 'chalk';
+import debugLib from 'debug';
 
 /**
  * Internal dependencies
  */
-import { trackEvent } from '../lib/tracker';
 import command from '../lib/cli/command';
-import {
-	destroyEnvironment,
-	getAllEnvironmentNames,
-} from '../lib/dev-environment/dev-environment-core';
 import { DEV_ENVIRONMENT_FULL_COMMAND } from '../lib/constants/dev-environment';
 import {
 	getEnvTrackingInfo,
 	handleCLIException,
 	validateDependencies,
 } from '../lib/dev-environment/dev-environment-cli';
+import {
+	destroyEnvironment,
+	getAllEnvironmentNames,
+} from '../lib/dev-environment/dev-environment-core';
 import { bootstrapLando } from '../lib/dev-environment/dev-environment-lando';
+import { trackEvent } from '../lib/tracker';
 
 const debug = debugLib( '@automattic/vip:bin:dev-environment' );
 
@@ -62,6 +62,7 @@ command()
 					// eslint-disable-next-line no-await-in-loop
 					await trackEvent( 'dev_env_destroy_command_success', trackingInfoChild );
 				} catch ( error ) {
+					// eslint-disable-next-line no-await-in-loop
 					await handleCLIException( error, 'dev_env_destroy_command_error', trackingInfoChild );
 					process.exitCode = 1;
 				}

--- a/src/bin/vip-dev-env-purge.js
+++ b/src/bin/vip-dev-env-purge.js
@@ -64,10 +64,7 @@ command()
 		}
 
 		const trackingInfo = { all: true };
-		// eslint-disable-next-line no-await-in-loop
 		await trackEvent( 'dev_env_purge_command_execute', trackingInfo );
-
-		// eslint-disable-next-line no-await-in-loop
 		await validateDependencies( lando, '' );
 		const removeFiles = ! ( opt.soft || false );
 
@@ -86,7 +83,6 @@ command()
 					process.exitCode = 1;
 				}
 			}
-			// eslint-disable-next-line no-await-in-loop
 			await trackEvent( 'dev_env_purge_command_success', trackingInfo );
 		} catch ( error ) {
 			await handleCLIException( error, 'dev_env_purge_command_error', trackingInfo );

--- a/src/bin/vip-dev-env-purge.js
+++ b/src/bin/vip-dev-env-purge.js
@@ -46,8 +46,6 @@ command()
 
 		const allEnvNames = getAllEnvironmentNames();
 		const lando = await bootstrapLando();
-		const trackingInfo = { all: true };
-		await trackEvent( 'dev_env_purge_command_execute', trackingInfo );
 
 		if ( allEnvNames.length === 0 ) {
 			console.log( 'No environments to purge!' );
@@ -65,9 +63,9 @@ command()
 			}
 		}
 
-		const trackingInfoChild = getEnvTrackingInfo( slug );
+		const trackingInfo = { all: true };
 		// eslint-disable-next-line no-await-in-loop
-		await trackEvent( 'dev_env_purge_command_execute', trackingInfoChild );
+		await trackEvent( 'dev_env_purge_command_execute', trackingInfo );
 
 		// eslint-disable-next-line no-await-in-loop
 		await validateDependencies( lando, '' );
@@ -75,7 +73,6 @@ command()
 
 		try {
 			for ( const slug of allEnvNames ) {
-
 				try {
 					// eslint-disable-next-line no-await-in-loop
 					await destroyEnvironment( lando, slug, removeFiles );
@@ -83,13 +80,14 @@ command()
 					const message = chalk.green( '✓' ) + ' Environment destroyed.\n';
 					console.log( message );
 				} catch ( error ) {
+					const trackingInfoChild = getEnvTrackingInfo( slug );
 					// eslint-disable-next-line no-await-in-loop
 					await handleCLIException( error, 'dev_env_purge_command_error', trackingInfoChild );
 					process.exitCode = 1;
 				}
 			}
 			// eslint-disable-next-line no-await-in-loop
-			await trackEvent( 'dev_env_purge_command_success', trackingInfoChild );
+			await trackEvent( 'dev_env_purge_command_success', trackingInfo );
 		} catch ( error ) {
 			await handleCLIException( error, 'dev_env_purge_command_error', trackingInfo );
 			process.exitCode = 1;

--- a/src/bin/vip-dev-env.js
+++ b/src/bin/vip-dev-env.js
@@ -20,4 +20,5 @@ command( {
 	.command( 'shell', 'Spawns a shell in a dev environment' )
 	.command( 'logs', 'View logs from a local WordPress environment' )
 	.command( 'sync', 'Pull data from production to local development environment' )
+	.command( 'purge', 'Destroy all existing environments' )
 	.argv( process.argv );


### PR DESCRIPTION
## Description

Hello 👋🏼 here is an example of how we might add a `purge` command to VIP CLI `dev-env`. It leverages `getAllEnvironmentNames()` and loops through and awaits `destroyEnvironment` on each name listed.

## Steps to Test

This will need to be plugged into typical testing workflows. I did `npm link` and also `node --inspect` locally and it successfully destroyed all local `dev-env` environments. 