### PR TITLE
chore(deps): update jwt-decode from 3.1.2 to 4.0.0

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -30,7 +30,7 @@
         "ini": "2.0.0",
         "js-yaml": "^4.1.0",
         "json2csv": "5.0.7",
-        "jwt-decode": "3.1.2",
+        "jwt-decode": "4.0.0",
         "lando": "github:automattic/lando-cli.git#5efb9eb",
         "node-fetch": "^2.6.1",
         "opn": "5.5.0",
@@ -9813,9 +9813,12 @@
       }
     },
     "node_modules/jwt-decode": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/jwt-decode/-/jwt-decode-3.1.2.tgz",
-      "integrity": "sha512-UfpWE/VZn0iP50d8cz9NrZLM9lSWhcJ+0Gt/nm4by88UL+J1SiKN8/5dkjMmbEzwL2CAe+67GsegCbIKtbp75A=="
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/jwt-decode/-/jwt-decode-4.0.0.tgz",
+      "integrity": "sha512-+KJGIyHgkGuIq3IEBNftfhW/LfWhXUIY6OmyVWjliu5KH1y0fw7VQ8YndE2O4qZdMSd9SqbnC8GOcZEy0Om7sA==",
+      "engines": {
+        "node": ">=18"
+      }
     },
     "node_modules/keyv": {
       "version": "3.1.0",
@@ -20620,9 +20623,9 @@
       }
     },
     "jwt-decode": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/jwt-decode/-/jwt-decode-3.1.2.tgz",
-      "integrity": "sha512-UfpWE/VZn0iP50d8cz9NrZLM9lSWhcJ+0Gt/nm4by88UL+J1SiKN8/5dkjMmbEzwL2CAe+67GsegCbIKtbp75A=="
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/jwt-decode/-/jwt-decode-4.0.0.tgz",
+      "integrity": "sha512-+KJGIyHgkGuIq3IEBNftfhW/LfWhXUIY6OmyVWjliu5KH1y0fw7VQ8YndE2O4qZdMSd9SqbnC8GOcZEy0Om7sA=="
     },
     "keyv": {
       "version": "3.1.0",

--- a/package.json
+++ b/package.json
@@ -155,7 +155,7 @@
     "ini": "2.0.0",
     "js-yaml": "^4.1.0",
     "json2csv": "5.0.7",
-    "jwt-decode": "3.1.2",
+    "jwt-decode": "4.0.0",
     "lando": "github:automattic/lando-cli.git#5efb9eb",
     "node-fetch": "^2.6.1",
     "opn": "5.5.0",

--- a/src/lib/token.ts
+++ b/src/lib/token.ts
@@ -1,4 +1,4 @@
-import jwtDecode from 'jwt-decode';
+import { jwtDecode } from 'jwt-decode';
 import { v4 as uuid } from 'uuid';
 
 import { API_HOST, PRODUCTION_API_HOST } from './api';


### PR DESCRIPTION
## Description

This PR updates `jwt-decode` from 3.1.2 to [4.0.0](https://github.com/auth0/jwt-decode/releases/tag/v4.0.0). There are breaking changes. Luckily, we use `jwt-decode` only in one place, which is easy to fix.

## Steps to Test

CI should pass.
