### PR TITLE
chore(dev-deps): update nock from 13.3.4 to 13.3.7

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -128,7 +128,7 @@
         "dockerode": "^4.0.0",
         "eslint": "^8.35.0",
         "jest": "^29.5.0",
-        "nock": "13.3.4",
+        "nock": "13.3.7",
         "prettier": "npm:wp-prettier@2.8.5",
         "rimraf": "5.0.5",
         "typescript": "^5.1.3"
@@ -10391,14 +10391,13 @@
       "integrity": "sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ=="
     },
     "node_modules/nock": {
-      "version": "13.3.4",
-      "resolved": "https://registry.npmjs.org/nock/-/nock-13.3.4.tgz",
-      "integrity": "sha512-DDpmn5oLEdCTclEqweOT4U7bEpuoifBMFUXem9sA4turDAZ5tlbrEoWqCorwXey8CaAw44mst5JOQeVNiwtkhw==",
+      "version": "13.3.7",
+      "resolved": "https://registry.npmjs.org/nock/-/nock-13.3.7.tgz",
+      "integrity": "sha512-z3voRxo6G0JxqCsjuzERh1ReFC4Vp2b7JpSgcMJB6jnJbUszf88awAeQLIID2UNMwbMh9/Zm5sFscagj0QYHEg==",
       "dev": true,
       "dependencies": {
         "debug": "^4.1.0",
         "json-stringify-safe": "^5.0.1",
-        "lodash": "^4.17.21",
         "propagate": "^2.0.0"
       },
       "engines": {
@@ -21095,14 +21094,13 @@
       "integrity": "sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ=="
     },
     "nock": {
-      "version": "13.3.4",
-      "resolved": "https://registry.npmjs.org/nock/-/nock-13.3.4.tgz",
-      "integrity": "sha512-DDpmn5oLEdCTclEqweOT4U7bEpuoifBMFUXem9sA4turDAZ5tlbrEoWqCorwXey8CaAw44mst5JOQeVNiwtkhw==",
+      "version": "13.3.7",
+      "resolved": "https://registry.npmjs.org/nock/-/nock-13.3.7.tgz",
+      "integrity": "sha512-z3voRxo6G0JxqCsjuzERh1ReFC4Vp2b7JpSgcMJB6jnJbUszf88awAeQLIID2UNMwbMh9/Zm5sFscagj0QYHEg==",
       "dev": true,
       "requires": {
         "debug": "^4.1.0",
         "json-stringify-safe": "^5.0.1",
-        "lodash": "^4.17.21",
         "propagate": "^2.0.0"
       }
     },

--- a/package.json
+++ b/package.json
@@ -129,7 +129,7 @@
     "dockerode": "^4.0.0",
     "eslint": "^8.35.0",
     "jest": "^29.5.0",
-    "nock": "13.3.4",
+    "nock": "13.3.7",
     "prettier": "npm:wp-prettier@2.8.5",
     "rimraf": "5.0.5",
     "typescript": "^5.1.3"


### PR DESCRIPTION
## Description

This PR updates `nock` from 13.3.4 to 13.3.7.

## Steps to Test

CI should pass.
