### PR TITLE
chore: generate and verify provenance statements

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,6 +42,26 @@ jobs:
       - name: Run ${{ matrix.config.tool }}
         run: npm run '${{ matrix.config.tool }}'
 
+  audit:
+    name: Verify signatures and provenance statements
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out the source code
+        uses: actions/checkout@v3
+
+      - name: Set up Node.js environment
+        uses: actions/setup-node@v3
+        with:
+          node-version: lts/*
+          cache: npm
+          cache-dependency-path: npm-shrinkwrap.json
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Run audit
+        run: npm audit signatures
+
   test:
     name: Run tests
     runs-on: ubuntu-latest

--- a/package.json
+++ b/package.json
@@ -186,6 +186,7 @@
     }
   },
   "publishConfig": {
-    "access": "public"
+    "access": "public",
+    "provenance": true
   }
 }


### PR DESCRIPTION
## Description

Provenance data give consumers a verifiable way to link a package back to its source repository and the specific build instructions used to publish it. This can increase supply-chain security for our packages. We can also use provenance attestations to reduce the risk of supply chain attacks targetted at us.

> The provenance attestation is established by publicly providing a link to a package's source code and build instructions from the build environment. This allows developers to verify where and how your package was built before they download it.
> 
> Publish attestations are generated by the registry when a package is published by an authorized user. When an npm package is published with provenance, it is signed by Sigstore public good servers and logged in a public transparency ledger, where users can view this information.

Ref: https://github.blog/2023-04-19-introducing-npm-package-provenance/
Ref: https://docs.npmjs.com/generating-provenance-statements
Ref: https://github.blog/changelog/2023-09-26-npm-provenance-general-availability/

## Steps to Test

Provenance generation: N/A - no testable changes.
Provenance verification:
```
$ npm audit signatures
audited 1117 packages in 10s

1117 packages have verified registry signatures

7 packages have verified attestations
```

