### PR TITLE
fix(dev-env): Fix typo on suggested start command after updating env

### DIFF
--- a/src/bin/vip-dev-env-update.js
+++ b/src/bin/vip-dev-env-update.js
@@ -116,7 +116,7 @@ cmd.argv( process.argv, async ( arg, opt ) => {
 			'\n' +
 			chalk.green( '✓' ) +
 			' environment updated. Please start environment again for changes to take effect: ' +
-			chalk.bold( `vip dev env --slug ${ slug } start` );
+			chalk.bold( `vip dev-env --slug ${ slug } start` );
 		console.log( message );
 		await trackEvent( 'dev_env_update_command_success', trackingInfo );
 	} catch ( error ) {


### PR DESCRIPTION
## Description

Fixes a minor typo on the suggested command to restart an environment after updating with `vip dev-env update`.