### PR TITLE
Display read-only disclaimer for vip-db-phpmyadmin cmd

### DIFF
--- a/src/commands/phpmyadmin.ts
+++ b/src/commands/phpmyadmin.ts
@@ -1,6 +1,7 @@
 /**
  * External dependencies
  */
+import chalk from 'chalk';
 import { GraphQLFormattedError } from 'graphql';
 import gql from 'graphql-tag';
 import opn from 'opn';
@@ -72,6 +73,9 @@ export class PhpMyAdminCommand {
 			exit.withError( 'No environment was specified' );
 		}
 
+		const message =
+			'Note: PHPMyAdmin sessions are read-only. If you run a query that writes to DB, it will fail.';
+		console.log( chalk.yellow( message ) );
 		this.log( 'Generating PhpMyAdmin URL...' );
 
 		let url;


### PR DESCRIPTION
## Description

We are adding a disclaimer to inform the PhpMyAdmin users that the sessions are read-only.

## Steps to Test

1. Check out PR.
1. Run `npm run build`
1. Run `./dist/bin/vip-cookies.js nom`
1. Verify cookies are delicious.
