### PR TITLE
feat(dev-env): add quiet mode for "import sql"

### DIFF
--- a/__tests__/commands/dev-env-sync-sql.js
+++ b/__tests__/commands/dev-env-sync-sql.js
@@ -134,7 +134,7 @@ describe( 'commands/DevEnvSyncSQLCommand', () => {
 			const cmd = new DevEnvSyncSQLCommand( app, env, 'test-slug' );
 			await cmd.runImport();
 
-			expect( mockImport ).toHaveBeenCalledWith( true );
+			expect( mockImport ).toHaveBeenCalled();
 		} );
 	} );
 

--- a/src/bin/vip-dev-env-import-sql.js
+++ b/src/bin/vip-dev-env-import-sql.js
@@ -37,8 +37,9 @@ command( {
 	.option( 'slug', 'Custom name of the dev environment' )
 	.option( [ 'r', 'search-replace' ], 'Perform Search and Replace on the specified SQL file' )
 	.option( 'in-place', 'Search and Replace explicitly on the given input file' )
-	.option( 'skip-validate', 'Do not perform file validation.' )
-	.option( 'quiet', 'Suppress prompts.' )
+	.option( 'skip-validate', 'Do not perform file validation' )
+	.option( [ 'k', 'skip-reindex' ], 'Do not reindex data in Elasticsearch after import' )
+	.option( 'quiet', 'Suppress prompts' )
 	.examples( examples )
 	.argv( process.argv, async ( unmatchedArgs, opt ) => {
 		const [ fileName ] = unmatchedArgs;

--- a/src/bin/vip-dev-env-import-sql.js
+++ b/src/bin/vip-dev-env-import-sql.js
@@ -39,7 +39,7 @@ command( {
 	.option( 'in-place', 'Search and Replace explicitly on the given input file' )
 	.option( 'skip-validate', 'Do not perform file validation' )
 	.option( [ 'k', 'skip-reindex' ], 'Do not reindex data in Elasticsearch after import' )
-	.option( 'quiet', 'Suppress prompts' )
+	.option( 'quiet', 'Suppress prompts and informational messages' )
 	.examples( examples )
 	.argv( process.argv, async ( unmatchedArgs, opt ) => {
 		const [ fileName ] = unmatchedArgs;

--- a/src/bin/vip-dev-env-import-sql.js
+++ b/src/bin/vip-dev-env-import-sql.js
@@ -38,6 +38,7 @@ command( {
 	.option( [ 'r', 'search-replace' ], 'Perform Search and Replace on the specified SQL file' )
 	.option( 'in-place', 'Search and Replace explicitly on the given input file' )
 	.option( 'skip-validate', 'Do not perform file validation.' )
+	.option( 'quiet', 'Suppress prompts.' )
 	.examples( examples )
 	.argv( process.argv, async ( unmatchedArgs, opt ) => {
 		const [ fileName ] = unmatchedArgs;

--- a/src/commands/dev-env-sync-sql.js
+++ b/src/commands/dev-env-sync-sql.js
@@ -177,9 +177,10 @@ export class DevEnvSyncSQLCommand {
 		const importOptions = {
 			inPlace: true,
 			skipValidate: true,
+			quiet: true,
 		};
 		const importCommand = new DevEnvImportSQLCommand( this.sqlFile, importOptions, this.slug );
-		await importCommand.run( true );
+		await importCommand.run();
 	}
 
 	/**


### PR DESCRIPTION
## Description

Related: #1561 

This PR adds:
* `--skip-reindex` flag to disable reindexing (like other boolean options, it can be negated to request reindexing: `--no-skip-reindex explicitly`). The default is to reindex if the WP CLI `vip-search` command is available;
* `--quiet` flag to suppress extra output from the script (in addition, in this mode, `--quiet` is passed to WP CLI, and `--silent` is passed to `mysql`).

These options can be combined together.

## Pull request checklist

- [ ] Update [SETUP.md](https://github.com/Automattic/vip-cli/blob/trunk/docs/SETUP.md#list-of-environmental-variables) with any new environmental variables.
- [ ] Update [the documentation](https://github.com/Automattic/vip-cli/blob/trunk/docs).
- [x] [Manually test](https://github.com/Automattic/vip-cli/blob/trunk/docs/TESTING.md#manual-testing) the relevant changes.
- [x] Follow the [pull request checklist](https://github.com/Automattic/vip-cli/blob/trunk/docs/RELEASING.md#new-pull-requests)
- [ ] Add/update [automated tests](https://github.com/Automattic/vip-cli/blob/trunk/docs/TESTING.md#automated-testing) as needed.

## New release checklist

- [ ] [Automated tests](https://github.com/Automattic/vip-cli/blob/trunk/docs/TESTING.md#automated-testing) pass.
- [ ] The [Preparing for release checklist](https://github.com/Automattic/vip-cli/blob/trunk/docs/RELEASING.md#preparing-for-release) is completed.

## Steps to Test

See #1561

```sh
vip dev-env create --elasticsearch true < /dev/null
vip dev-env start
vip dev-env exec -q -- wp db export - > data.sql
# This command will show more information
vip dev-env import sql data.sql
# This one won't
vip dev-env import sql data.sql -q
# This will suppress reindexing
vip dev-env import sql data.sql --skip-reindex
```
