### PR TITLE
fix: Properly propagate quotes

### DIFF
--- a/__tests__/lib/cli/format.js
+++ b/__tests__/lib/cli/format.js
@@ -36,12 +36,12 @@ describe( 'utils/cli/format', () => {
 				expected: [ '"{\\"json\\":broken json with spaces}"' ],
 			},
 			{
-				input: [ '--foo=\'bar1 "bar2" "bar3"\'' ],
-				expected: [ '--foo=\'bar1 "bar2" "bar3"\'' ],
+				input: [ '--foo=bar1 "bar2" "bar3"' ],
+				expected: [ '--foo="bar1 \\"bar2\\" \\"bar3\\""' ],
 			},
 			{
-				input: [ '--foo', '\'bar1 "bar2" "bar3"\'' ],
-				expected: [ '--foo', '\'bar1 "bar2" "bar3"\'' ],
+				input: [ '--foo', 'bar1 "bar2" "bar3"' ],
+				expected: [ '--foo', '"bar1 \\"bar2\\" \\"bar3\\""' ],
 			},
 		] )( 'should requote args when needed - %o', ( { input, expected } ) => {
 			const result = requoteArgs( input );

--- a/__tests__/lib/cli/format.js
+++ b/__tests__/lib/cli/format.js
@@ -35,6 +35,14 @@ describe( 'utils/cli/format', () => {
 				input: [ '{"json":broken json with spaces}' ],
 				expected: [ '"{"json":broken json with spaces}"' ],
 			},
+			{
+				input: [ '--foo=\'bar1 "bar2" "bar3"\'' ],
+				expected: [ '--foo=\'bar1 "bar2" "bar3"\'' ],
+			},
+			{
+				input: [ '--foo', '\'bar1 "bar2" "bar3"\'' ],
+				expected: [ '--foo', '\'bar1 "bar2" "bar3"\'' ],
+			},
 		] )( 'should requote args when needed - %o', ( { input, expected } ) => {
 			const result = requoteArgs( input );
 			expect( result ).toStrictEqual( expected );

--- a/__tests__/lib/cli/format.js
+++ b/__tests__/lib/cli/format.js
@@ -33,7 +33,7 @@ describe( 'utils/cli/format', () => {
 			},
 			{
 				input: [ '{"json":broken json with spaces}' ],
-				expected: [ '"{"json":broken json with spaces}"' ],
+				expected: [ '"{\\"json\\":broken json with spaces}"' ],
 			},
 			{
 				input: [ '--foo=\'bar1 "bar2" "bar3"\'' ],

--- a/src/lib/cli/format.ts
+++ b/src/lib/cli/format.ts
@@ -134,7 +134,8 @@ export function keyValue( values: Tuple[] ): string {
 export function requoteArgs( args: string[] ): string[] {
 	return args.map( arg => {
 		if ( arg.includes( '--' ) && arg.includes( '=' ) && arg.includes( ' ' ) ) {
-			return arg.replace( /^--([^=]*)=(.*)$/, '--$1="$2"' );
+			const quote = arg.includes( '"' ) ? "'" : '"';
+			return arg.replace( /^--([^=]*)=(.*)$/, `--$1=${ quote }$2${ quote }` );
 		}
 
 		if ( arg.includes( ' ' ) && ! isJsonObject( arg ) ) {

--- a/src/lib/cli/format.ts
+++ b/src/lib/cli/format.ts
@@ -134,7 +134,7 @@ export function keyValue( values: Tuple[] ): string {
 export function requoteArgs( args: string[] ): string[] {
 	return args.map( arg => {
 		if ( arg.includes( '--' ) && arg.includes( '=' ) && arg.includes( ' ' ) ) {
-			return arg.replace( /"/g, '\\"' ).replace( /^--([^=]*)=(.*)$/, `--$1="$2"` );
+			return arg.replace( /"/g, '\\"' ).replace( /^--([^=]*)=(.*)$/, '--$1="$2"' );
 		}
 
 		if ( arg.includes( ' ' ) && ! isJsonObject( arg ) ) {

--- a/src/lib/cli/format.ts
+++ b/src/lib/cli/format.ts
@@ -134,12 +134,11 @@ export function keyValue( values: Tuple[] ): string {
 export function requoteArgs( args: string[] ): string[] {
 	return args.map( arg => {
 		if ( arg.includes( '--' ) && arg.includes( '=' ) && arg.includes( ' ' ) ) {
-			const quote = arg.includes( '"' ) ? "'" : '"';
-			return arg.replace( /^--([^=]*)=(.*)$/, `--$1=${ quote }$2${ quote }` );
+			return arg.replace( /"/g, '\\"' ).replace( /^--([^=]*)=(.*)$/, `--$1="$2"` );
 		}
 
 		if ( arg.includes( ' ' ) && ! isJsonObject( arg ) ) {
-			return `"${ arg }"`;
+			return `"${ arg.replace( /"/g, '\\"' ) }"`;
 		}
 
 		return arg;


### PR DESCRIPTION
## Description

Fix an issue with propagating quotes to wp shell. Here is the issue with current implementation:

If you execute `vip @app.env -- wp --foo='bar1 "bar2" "bar3"'` the command that gets executed in the shell is: `vip @app.env -- wp --foo="bar1 "bar2" "bar3""`. This PR fixes that quoting issue.