### PR TITLE
fix(validate-sql): Display matched site-urls

### DIFF
--- a/src/lib/validations/sql.ts
+++ b/src/lib/validations/sql.ts
@@ -327,7 +327,7 @@ const checks: Checks = {
 	},
 	siteHomeUrl: {
 		matcher: "'(siteurl|home)',\\s?'(.*?)'",
-		matchHandler: ( lineNumber, results ) => ( { text: results[ 1 ] } ),
+		matchHandler: ( lineNumber, results ) => ( { text: results[ 1 ] + ' ' + results[ 2 ] } ),
 		outputFormatter: infoCheckFormatter,
 		results: [],
 		message: 'Siteurl/home matches',


### PR DESCRIPTION
## Description

The output of the vip import validate-sql command looks like this:

```
✅ ALTER TABLE statement was found 0 times.
✅ SET UNIQUE_CHECKS = 0 was found 0 times.
siteurl
```

Here, we are adding the actual site url alongside the `siteurl` text:

```diff
- siteurl
+ siteurl https://example.com
```

## Steps to Test

1. Check out PR.
1. Run `npm run build`
1. Export an sql file using the export command: Example: `vip export sql @app.env`
1. Unzip the exported sql file: `gunzip <filepath>`
2. Run the validate-sql command: `node ./dist/bin/vip import validate-sql <unzipped_filepath>
