### PR TITLE
fix(--format=json): Do not print header if specified format is json

### DIFF
--- a/src/lib/cli/command.js
+++ b/src/lib/cli/command.js
@@ -492,7 +492,9 @@ args.argv = async function ( argv, cb ) {
 		res = await cb( this.sub, options );
 		if ( _opts.format && res ) {
 			if ( res.header ) {
-				if ( options.format !== 'json' ) console.log( formatData( res.header, 'keyValue' ) );
+				if ( options.format !== 'json' ) {
+					console.log( formatData( res.header, 'keyValue' ) );
+				}
 				res = res.data;
 			}
 

--- a/src/lib/cli/command.js
+++ b/src/lib/cli/command.js
@@ -492,7 +492,7 @@ args.argv = async function ( argv, cb ) {
 		res = await cb( this.sub, options );
 		if ( _opts.format && res ) {
 			if ( res.header ) {
-				console.log( formatData( res.header, 'keyValue' ) );
+				if ( options.format !== 'json' ) console.log( formatData( res.header, 'keyValue' ) );
 				res = res.data;
 			}
 


### PR DESCRIPTION
## Description

Presently, if output format specified is json (`--format=json`), it prints a json object, but the output is prefixed by a key-value pair as header, which is not json. As a result, if someone wants to programmatically parse the json output, it would fail. In this PR, we are removing the header for json formats.

⚠️ The downside is, it also means we are dropping the data that falls outside json format. Let's discuss if that is accepable.

Before:

```
$ vip app 3202 --format=json
===================================
+ id: 3202
+ name: pmc-thr
+ repo: wpcomvip/pmc-thr
===================================
[
	{
		"id": 3202,
		"appId": 3202,
		"name": "production",
		"type": "production",
		"branch": "master",
		"currentCommit": "944a330",
		"primaryDomain": "www.hollywoodreporter.com",
		"launched": true
	},
...
```

After:

```
$ vip app 3202 --format=json
[
	{
		"id": 3202,
		"appId": 3202,
		"name": "production",
		"type": "production",
		"branch": "master",
		"currentCommit": "944a330",
		"primaryDomain": "www.hollywoodreporter.com",
		"launched": true
	},
...
```

## How to test

1. Pull the PR
2. `rm -rf dist && npm run build && npm link`
3. Run `node ./dist/bin/vip app 3202` and `node ./dist/bin/vip app 3202 --format=json`
