### PR TITLE
feat: show detailed error information in debug mode

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -118,6 +118,7 @@
         "@types/ejs": "^3.1.5",
         "@types/jest": "^29.5.8",
         "@types/js-yaml": "^4.0.9",
+        "@types/node": "^18.19.5",
         "@types/node-fetch": "^2.6.9",
         "@types/proxy-from-env": "^1.0.4",
         "@types/semver": "^7.5.5",
@@ -3851,9 +3852,12 @@
       "dev": true
     },
     "node_modules/@types/node": {
-      "version": "18.16.16",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.16.16.tgz",
-      "integrity": "sha512-NpaM49IGQQAUlBhHMF82QH80J08os4ZmyF9MkpCzWAGuOHqE4gTEbhzd7L3l5LmWuZ6E0OiC1FweQ4tsiW35+g=="
+      "version": "18.19.5",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.19.5.tgz",
+      "integrity": "sha512-22MG6T02Hos2JWfa1o5jsIByn+bc5iOt1IS4xyg6OG68Bu+wMonVZzdrgCw693++rpLE9RUT/Bx15BeDzO0j+g==",
+      "dependencies": {
+        "undici-types": "~5.26.4"
+      }
     },
     "node_modules/@types/node-fetch": {
       "version": "2.6.9",
@@ -12773,6 +12777,11 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/undici-types": {
+      "version": "5.26.5",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
+      "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA=="
+    },
     "node_modules/unicode-canonical-property-names-ecmascript": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/unicode-canonical-property-names-ecmascript/-/unicode-canonical-property-names-ecmascript-2.0.0.tgz",
@@ -16361,9 +16370,12 @@
       "dev": true
     },
     "@types/node": {
-      "version": "18.16.16",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.16.16.tgz",
-      "integrity": "sha512-NpaM49IGQQAUlBhHMF82QH80J08os4ZmyF9MkpCzWAGuOHqE4gTEbhzd7L3l5LmWuZ6E0OiC1FweQ4tsiW35+g=="
+      "version": "18.19.5",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.19.5.tgz",
+      "integrity": "sha512-22MG6T02Hos2JWfa1o5jsIByn+bc5iOt1IS4xyg6OG68Bu+wMonVZzdrgCw693++rpLE9RUT/Bx15BeDzO0j+g==",
+      "requires": {
+        "undici-types": "~5.26.4"
+      }
     },
     "@types/node-fetch": {
       "version": "2.6.9",
@@ -22839,6 +22851,11 @@
         "has-symbols": "^1.0.3",
         "which-boxed-primitive": "^1.0.2"
       }
+    },
+    "undici-types": {
+      "version": "5.26.5",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
+      "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA=="
     },
     "unicode-canonical-property-names-ecmascript": {
       "version": "2.0.0",

--- a/package.json
+++ b/package.json
@@ -119,6 +119,7 @@
     "@types/ejs": "^3.1.5",
     "@types/jest": "^29.5.8",
     "@types/js-yaml": "^4.0.9",
+    "@types/node": "^18.19.5",
     "@types/node-fetch": "^2.6.9",
     "@types/proxy-from-env": "^1.0.4",
     "@types/semver": "^7.5.5",

--- a/src/lib/cli/command.js
+++ b/src/lib/cli/command.js
@@ -20,7 +20,7 @@ function uncaughtError( err ) {
 		return;
 	}
 	if ( err instanceof UserError ) {
-		exit.withError( err.message );
+		exit.withError( err );
 	}
 
 	console.log( chalk.red( '✕' ), 'Please contact VIP Support with the following information:' );

--- a/src/lib/cli/exit.ts
+++ b/src/lib/cli/exit.ts
@@ -1,4 +1,5 @@
 import { red, yellow } from 'chalk';
+import debug from 'debug';
 
 import env from '../../lib/env';
 
@@ -13,6 +14,10 @@ export function withError( message: Error | string ): never {
 			env.os.name
 		} ${ env.os.version }`
 	);
+
+	if ( debug.names.length > 0 && message instanceof Error ) {
+		console.error( yellow( 'Debug: ' ), message );
+	}
 
 	process.exit( 1 );
 }

--- a/src/lib/cli/exit.ts
+++ b/src/lib/cli/exit.ts
@@ -4,7 +4,8 @@ import debug from 'debug';
 import env from '../../lib/env';
 
 export function withError( message: Error | string ): never {
-	console.error( `${ red( 'Error: ' ) } ${ message.toString().replace( /^Error:\s*/, '' ) }` );
+	const msg = message instanceof Error ? message.message : message;
+	console.error( `${ red( 'Error: ' ) } ${ msg.replace( /^Error:\s*/, '' ) }` );
 
 	// Debug ouput is printed below error output both for information
 	// hierarchy and to make it more likely that the user copies it to their

--- a/src/lib/cli/exit.ts
+++ b/src/lib/cli/exit.ts
@@ -13,7 +13,7 @@ export function withError( message: Error | string ): never {
 	console.log(
 		`${ yellow( 'Debug: ' ) } VIP-CLI v${ env.app.version }, Node ${ env.node.version }, ${
 			env.os.name
-		} ${ env.os.version }`
+		} ${ env.os.version } ${ env.os.arch }`
 	);
 
 	if ( debug.names.length > 0 && message instanceof Error ) {

--- a/src/lib/cli/progress.ts
+++ b/src/lib/cli/progress.ts
@@ -33,7 +33,7 @@ export interface StepFromServer {
 export class ProgressTracker {
 	hasFailure: boolean;
 	hasPrinted: boolean;
-	printInterval: NodeJS.Timer | undefined;
+	printInterval: NodeJS.Timeout | undefined;
 
 	// Track the state of each step
 	stepsFromCaller: Map< string, Step >;

--- a/src/lib/client-file-uploader.ts
+++ b/src/lib/client-file-uploader.ts
@@ -90,7 +90,9 @@ export const getFileHash = async (
 		await pipeline( src, dst );
 		return dst.digest().toString( 'hex' );
 	} catch ( err ) {
-		throw new Error( `could not generate file hash: ${ ( err as Error ).message }` );
+		throw new Error( `could not generate file hash: ${ ( err as Error ).message }`, {
+			cause: err,
+		} );
 	} finally {
 		src.close();
 	}
@@ -104,7 +106,7 @@ const gzipFile = async ( uncompressedFileName: string, compressedFileName: strin
 			createWriteStream( compressedFileName )
 		);
 	} catch ( err ) {
-		throw new Error( `could not compress file: ${ ( err as Error ).message }` );
+		throw new Error( `could not compress file: ${ ( err as Error ).message }`, { cause: err } );
 	}
 };
 
@@ -173,7 +175,8 @@ export async function uploadImportSqlFileToS3( {
 		tmpDir = await getWorkingTempDir();
 	} catch ( err ) {
 		throw new Error(
-			`Unable to create temporary working directory: ${ ( err as Error ).message }`
+			`Unable to create temporary working directory: ${ ( err as Error ).message }`,
+			{ cause: err }
 		);
 	}
 
@@ -305,7 +308,9 @@ async function uploadUsingPutObject( {
 	try {
 		parsedResponse = ( await parser.parseStringPromise( result ) ) as UploadErrorResponse;
 	} catch ( err ) {
-		throw new Error( `Invalid response from cloud service. ${ ( err as Error ).message }` );
+		throw new Error( `Invalid response from cloud service. ${ ( err as Error ).message }`, {
+			cause: err,
+		} );
 	}
 
 	const { Code, Message } = parsedResponse.Error;

--- a/src/lib/client-file-uploader.ts
+++ b/src/lib/client-file-uploader.ts
@@ -90,7 +90,7 @@ export const getFileHash = async (
 		await pipeline( src, dst );
 		return dst.digest().toString( 'hex' );
 	} catch ( err ) {
-		throw new Error( `could not generate file hash: ${ ( err as Error ).message }`, {
+		throw new Error( `Could not generate file hash: ${ ( err as Error ).message }`, {
 			cause: err,
 		} );
 	} finally {
@@ -106,7 +106,7 @@ const gzipFile = async ( uncompressedFileName: string, compressedFileName: strin
 			createWriteStream( compressedFileName )
 		);
 	} catch ( err ) {
-		throw new Error( `could not compress file: ${ ( err as Error ).message }`, { cause: err } );
+		throw new Error( `Could not compress file: ${ ( err as Error ).message }`, { cause: err } );
 	}
 };
 

--- a/src/lib/dev-environment/dev-environment-cli.ts
+++ b/src/lib/dev-environment/dev-environment-cli.ts
@@ -129,7 +129,9 @@ const verifyDNSResolution = async ( slug: string ): Promise< void > => {
 		address = await lookup( testDomain, 4 );
 		debug( `Got DNS response ${ address.address }` );
 	} catch ( error ) {
-		throw new UserError( `DNS resolution for ${ testDomain } failed. ${ advice }` );
+		throw new UserError( `DNS resolution for ${ testDomain } failed. ${ advice }`, {
+			cause: error,
+		} );
 	}
 
 	if ( address.address !== expectedIP ) {

--- a/src/lib/dev-environment/dev-environment-core.ts
+++ b/src/lib/dev-environment/dev-environment-core.ts
@@ -408,7 +408,8 @@ export function readEnvironmentData( slug: string ): InstanceData {
 	} catch ( error: unknown ) {
 		const err = error as Error;
 		throw new UserError(
-			`There was an error reading file "${ instanceDataTargetPath }": ${ err.message }.`
+			`There was an error reading file "${ instanceDataTargetPath }": ${ err.message }.`,
+			{ cause: error }
 		);
 	}
 
@@ -417,7 +418,8 @@ export function readEnvironmentData( slug: string ): InstanceData {
 	} catch ( error: unknown ) {
 		const err = error as Error;
 		throw new UserError(
-			`There was an error parsing file "${ instanceDataTargetPath }": ${ err.message }. You may need to recreate the environment.`
+			`There was an error parsing file "${ instanceDataTargetPath }": ${ err.message }. You may need to recreate the environment.`,
+			{ cause: error }
 		);
 	}
 

--- a/src/lib/env.ts
+++ b/src/lib/env.ts
@@ -1,4 +1,4 @@
-import { platform, release } from 'node:os';
+import { arch, platform, release } from 'node:os';
 
 import pkg from '../../package.json';
 
@@ -10,6 +10,7 @@ interface AppInfo {
 interface OSInfo {
 	name: string;
 	version: string;
+	arch: string;
 }
 
 interface NodeInfo {
@@ -31,6 +32,7 @@ const app: AppInfo = {
 const os: OSInfo = {
 	name: platform(),
 	version: release(),
+	arch: arch(),
 };
 
 const node: NodeInfo = {

--- a/src/lib/media-import/progress.ts
+++ b/src/lib/media-import/progress.ts
@@ -14,7 +14,7 @@ type MediaImportStatus = Pick<
 export class MediaImportProgressTracker {
 	hasFailure: boolean;
 	hasPrinted: boolean;
-	printInterval: NodeJS.Timer | undefined;
+	printInterval: NodeJS.Timeout | undefined;
 	status: MediaImportStatus;
 
 	// Spinnerz go brrrr

--- a/src/lib/user-error.ts
+++ b/src/lib/user-error.ts
@@ -1,6 +1,6 @@
 export default class UserError extends Error {
-	constructor( message: string ) {
-		super( message );
+	constructor( message: string, options?: ErrorOptions ) {
+		super( message, options );
 		this.name = 'UserError';
 	}
 }

--- a/src/lib/validations/line-by-line.ts
+++ b/src/lib/validations/line-by-line.ts
@@ -55,7 +55,7 @@ export async function fileLineValidations(
 	} );
 
 	readInterface.on( 'error', ( err: Error ) => {
-		throw new Error( ` Error validating input file: ${ err.toString() }`, { cause: err } );
+		throw new Error( `Error validating input file: ${ err.toString() }`, { cause: err } );
 	} );
 
 	// Block until the processing completes

--- a/src/lib/validations/line-by-line.ts
+++ b/src/lib/validations/line-by-line.ts
@@ -55,7 +55,7 @@ export async function fileLineValidations(
 	} );
 
 	readInterface.on( 'error', ( err: Error ) => {
-		throw new Error( ` Error validating input file: ${ err.toString() }` );
+		throw new Error( ` Error validating input file: ${ err.toString() }`, { cause: err } );
 	} );
 
 	// Block until the processing completes

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "lib": [ "es2021" ],
+    "lib": [ "ES2022" ],
     "module": "node16",
     "strict": true,
     "esModuleInterop": true,
@@ -9,7 +9,7 @@
     "moduleResolution": "node16",
 
     // Target latest version of ECMAScript.
-    "target": "esnext",
+    "target": "ES2022",
     // Don't parse types from JS as TS doesn't play well with Flow-ish JS.
     "allowJs": false,
     // Don't emit; allow Babel to transform files.


### PR DESCRIPTION
## Description

This PR enables detailed errors in the debug mode.

## Pull request checklist

- [ ] Update [SETUP.md](https://github.com/Automattic/vip-cli/blob/trunk/docs/SETUP.md#list-of-environmental-variables) with any new environmental variables.
- [ ] Update [the documentation](https://github.com/Automattic/vip-cli/blob/trunk/docs).
- [x] [Manually test](https://github.com/Automattic/vip-cli/blob/trunk/docs/TESTING.md#manual-testing) the relevant changes.
- [x] Follow the [pull request checklist](https://github.com/Automattic/vip-cli/blob/trunk/docs/RELEASING.md#new-pull-requests)
- [ ] Add/update [automated tests](https://github.com/Automattic/vip-cli/blob/trunk/docs/TESTING.md#automated-testing) as needed.

## New release checklist

- [ ] [Automated tests](https://github.com/Automattic/vip-cli/blob/trunk/docs/TESTING.md#automated-testing) pass.
- [ ] The [Preparing for release checklist](https://github.com/Automattic/vip-cli/blob/trunk/docs/RELEASING.md#preparing-for-release) is completed.

## Steps to Test

```sh
vip dev-env create --slug CaseSensitive < /dev/null
vip dev-env start --slug CaseSensitive -d
```

Observe the detailed error information in the output.

```sh
vip dev-env start --slug CaseSensitive
```

There will be no error details in this case.

An error message might look something like this:
```
Debug:  UserError: There was an error reading file "~/.local/share/vip/dev-environment/casesensitive/instance_data.json": ENOENT: no such file or directory, open '~/.local/share/vip/dev-environment/casesensitive/instance_data.json'.
    at readEnvironmentData (~/automattic/vip-cli/dist/lib/dev-environment/dev-environment-core.js:276:11)
    at AsyncEvents.<anonymous> (~/automattic/vip-cli/dist/lib/dev-environment/dev-environment-lando.js:170:72)
    at Object.onceWrapper (node:events:629:26)
    at AsyncEvents.handle (~/automattic/vip-cli/node_modules/lando/lib/events.js:84:25)
From previous event:
    at AsyncEvents.handle (~/automattic/vip-cli/node_modules/lando/lib/events.js:85:22)
    at ~/automattic/vip-cli/node_modules/lando/lib/events.js:117:21
    at process.processImmediate (node:internal/timers:478:21)
From previous event:
    at AsyncEvents.emit (~/automattic/vip-cli/node_modules/lando/lib/events.js:111:20)
    at ~/automattic/vip-cli/node_modules/lando/lib/router.js:25:22
From previous event:
    at exports.eventWrapper (~/automattic/vip-cli/node_modules/lando/lib/router.js:25:4)
    at Engine.engineCmd (~/automattic/vip-cli/node_modules/lando/lib/engine.js:17:104)
    at Engine.build (~/automattic/vip-cli/node_modules/lando/lib/engine.js:69:17)
    at ~/automattic/vip-cli/node_modules/lando/lib/app.js:354:29
From previous event:
    at App.rebuild (~/automattic/vip-cli/node_modules/lando/lib/app.js:354:6)
    at landoRebuild (~/automattic/vip-cli/dist/lib/dev-environment/dev-environment-lando.js:233:15)
    at async startEnvironment (~/automattic/vip-cli/dist/lib/dev-environment/dev-environment-core.js:74:5)
    at async ~/automattic/vip-cli/dist/bin/vip-dev-env-start.js:34:5
    at async _args.default.argv (~/automattic/vip-cli/dist/lib/cli/command.js:440:11) {
  [cause]: Error: ENOENT: no such file or directory, open '~/.local/share/vip/dev-environment/casesensitive/instance_data.json'
      at Object.readFileUtf8 (node:internal/fs/sync:25:18)
      at Object.readFileSync (node:fs:441:19)
      at readEnvironmentData (~/automattic/vip-cli/dist/lib/dev-environment/dev-environment-core.js:273:42)
      at AsyncEvents.<anonymous> (~/automattic/vip-cli/dist/lib/dev-environment/dev-environment-lando.js:170:72)
      at Object.onceWrapper (node:events:629:26)
      at AsyncEvents.handle (~/automattic/vip-cli/node_modules/lando/lib/events.js:84:25)
      at ~/automattic/vip-cli/node_modules/lando/lib/events.js:117:21
      at tryCatcher (~/automattic/vip-cli/node_modules/bluebird/js/release/util.js:16:23)
      at Object.gotValue (~/automattic/vip-cli/node_modules/bluebird/js/release/reduce.js:166:18)
      at Object.gotAccum (~/automattic/vip-cli/node_modules/bluebird/js/release/reduce.js:155:25)
      at Object.tryCatcher (~/automattic/vip-cli/node_modules/bluebird/js/release/util.js:16:23)
      at Promise._settlePromiseFromHandler (~/automattic/vip-cli/node_modules/bluebird/js/release/promise.js:547:31)
      at Promise._settlePromise (~/automattic/vip-cli/node_modules/bluebird/js/release/promise.js:604:18)
      at Promise._settlePromiseCtx (~/automattic/vip-cli/node_modules/bluebird/js/release/promise.js:641:10)
      at _drainQueueStep (~/automattic/vip-cli/node_modules/bluebird/js/release/async.js:97:12)
      at _drainQueue (~/automattic/vip-cli/node_modules/bluebird/js/release/async.js:86:9) {
    errno: -2,
    code: 'ENOENT',
    syscall: 'open',
    path: '~/.local/share/vip/dev-environment/casesensitive/instance_data.json'
  }
}
```
