### PR TITLE
fix(dev-env): always lowercase environment slug

### DIFF
--- a/src/bin/vip-dev-env-create.js
+++ b/src/bin/vip-dev-env-create.js
@@ -20,6 +20,7 @@ import {
 	validateDependencies,
 	processStringOrBooleanOption,
 	handleDeprecatedOptions,
+	processSlug,
 } from '../lib/dev-environment/dev-environment-cli';
 import {
 	getConfigurationFileOptions,
@@ -69,7 +70,7 @@ const examples = [
 ];
 
 const cmd = command()
-	.option( 'slug', 'Custom name of the dev environment' )
+	.option( 'slug', 'Custom name of the dev environment', undefined, processSlug )
 	.option( 'title', 'Title for the WordPress site' )
 	.option( 'multisite', 'Enable multisite install', undefined, processStringOrBooleanOption );
 

--- a/src/bin/vip-dev-env-destroy.js
+++ b/src/bin/vip-dev-env-destroy.js
@@ -9,6 +9,7 @@ import {
 	getEnvTrackingInfo,
 	getEnvironmentName,
 	handleCLIException,
+	processSlug,
 	validateDependencies,
 } from '../lib/dev-environment/dev-environment-cli';
 import { destroyEnvironment } from '../lib/dev-environment/dev-environment-core';
@@ -29,7 +30,7 @@ const examples = [
 ];
 
 command()
-	.option( 'slug', 'Custom name of the dev environment' )
+	.option( 'slug', 'Custom name of the dev environment', undefined, processSlug )
 	.option( 'soft', 'Keep config files needed to start an environment intact' )
 	.examples( examples )
 	.argv( process.argv, async ( arg, opt ) => {

--- a/src/bin/vip-dev-env-exec.js
+++ b/src/bin/vip-dev-env-exec.js
@@ -7,6 +7,7 @@ import {
 	getEnvironmentName,
 	handleCLIException,
 	processBooleanOption,
+	processSlug,
 	validateDependencies,
 } from '../lib/dev-environment/dev-environment-cli';
 import { exec, getEnvironmentPath } from '../lib/dev-environment/dev-environment-core';
@@ -30,7 +31,7 @@ const examples = [
 ];
 
 command( { wildcardCommand: true } )
-	.option( 'slug', 'Custom name of the dev environment' )
+	.option( 'slug', 'Custom name of the dev environment', undefined, processSlug )
 	.option( 'force', 'Disable validations before task execution', undefined, processBooleanOption )
 	.option( 'quiet', 'Suppress output', undefined, processBooleanOption )
 	.examples( examples )

--- a/src/bin/vip-dev-env-import-media.js
+++ b/src/bin/vip-dev-env-import-media.js
@@ -6,6 +6,7 @@ import {
 	getEnvironmentName,
 	getEnvTrackingInfo,
 	handleCLIException,
+	processSlug,
 } from '../lib/dev-environment/dev-environment-cli';
 import { importMediaPath } from '../lib/dev-environment/dev-environment-core';
 import { trackEvent } from '../lib/tracker';
@@ -27,7 +28,7 @@ command( {
 	requiredArgs: 1,
 } )
 	.examples( examples )
-	.option( 'slug', 'Custom name of the dev environment' )
+	.option( 'slug', 'Custom name of the dev environment', undefined, processSlug )
 	.argv( process.argv, async ( unmatchedArgs, opt ) => {
 		const [ filePath ] = unmatchedArgs;
 		const slug = await getEnvironmentName( opt );

--- a/src/bin/vip-dev-env-import-sql.js
+++ b/src/bin/vip-dev-env-import-sql.js
@@ -7,6 +7,7 @@ import {
 	getEnvTrackingInfo,
 	handleCLIException,
 	getEnvironmentName,
+	processSlug,
 } from '../lib/dev-environment/dev-environment-cli';
 import { makeCommandTracker } from '../lib/tracker';
 
@@ -34,7 +35,7 @@ const examples = [
 command( {
 	requiredArgs: 1,
 } )
-	.option( 'slug', 'Custom name of the dev environment' )
+	.option( 'slug', 'Custom name of the dev environment', undefined, processSlug )
 	.option( [ 'r', 'search-replace' ], 'Perform Search and Replace on the specified SQL file' )
 	.option( 'in-place', 'Search and Replace explicitly on the given input file' )
 	.option( 'skip-validate', 'Do not perform file validation' )

--- a/src/bin/vip-dev-env-info.js
+++ b/src/bin/vip-dev-env-info.js
@@ -8,6 +8,7 @@ import {
 	getEnvTrackingInfo,
 	getEnvironmentName,
 	handleCLIException,
+	processSlug,
 	validateDependencies,
 } from '../lib/dev-environment/dev-environment-cli';
 import {
@@ -31,7 +32,7 @@ const examples = [
 ];
 
 command()
-	.option( 'slug', 'Custom name of the dev environment' )
+	.option( 'slug', 'Custom name of the dev environment', undefined, processSlug )
 	.option( 'all', 'Show Info for all local dev environments' )
 	.option( 'extended', 'Show extended information about the dev environment' )
 	.examples( examples )

--- a/src/bin/vip-dev-env-logs.js
+++ b/src/bin/vip-dev-env-logs.js
@@ -8,6 +8,7 @@ import {
 	getEnvTrackingInfo,
 	getEnvironmentName,
 	handleCLIException,
+	processSlug,
 	validateDependencies,
 } from '../lib/dev-environment/dev-environment-cli';
 import { showLogs } from '../lib/dev-environment/dev-environment-core';
@@ -34,7 +35,7 @@ const examples = [
 ];
 
 command()
-	.option( 'slug', 'Custom name of the dev environment' )
+	.option( 'slug', 'Custom name of the dev environment', undefined, processSlug )
 	.option( [ 'f', 'follow' ], 'Follow logs for a specific service in local dev environment' )
 	.option(
 		'service',

--- a/src/bin/vip-dev-env-shell.js
+++ b/src/bin/vip-dev-env-shell.js
@@ -9,6 +9,7 @@ import {
 	validateDependencies,
 	getEnvironmentName,
 	handleCLIException,
+	processSlug,
 } from '../lib/dev-environment/dev-environment-cli';
 import { getEnvironmentPath } from '../lib/dev-environment/dev-environment-core';
 import { bootstrapLando, landoShell } from '../lib/dev-environment/dev-environment-lando';
@@ -70,7 +71,7 @@ function getCommand( args ) {
 }
 
 command( { wildcardCommand: true } )
-	.option( 'slug', 'Custom name of the dev environment' )
+	.option( 'slug', 'Custom name of the dev environment', undefined, processSlug )
 	.option( 'root', 'Spawn a root shell' )
 	.option( 'service', 'Spawn a shell in a specific service (php if omitted)' )
 	.examples( examples )

--- a/src/bin/vip-dev-env-start.js
+++ b/src/bin/vip-dev-env-start.js
@@ -10,6 +10,7 @@ import {
 	getEnvironmentName,
 	handleCLIException,
 	postStart,
+	processSlug,
 } from '../lib/dev-environment/dev-environment-cli';
 import { startEnvironment } from '../lib/dev-environment/dev-environment-core';
 import { bootstrapLando } from '../lib/dev-environment/dev-environment-lando';
@@ -30,7 +31,7 @@ const examples = [
 ];
 
 command()
-	.option( 'slug', 'Custom name of the dev environment' )
+	.option( 'slug', 'Custom name of the dev environment', undefined, processSlug )
 	.option( 'skip-rebuild', 'Only start stopped services' )
 	.option(
 		[ 'w', 'skip-wp-versions-check' ],

--- a/src/bin/vip-dev-env-stop.js
+++ b/src/bin/vip-dev-env-stop.js
@@ -9,6 +9,7 @@ import {
 	getEnvTrackingInfo,
 	getEnvironmentName,
 	handleCLIException,
+	processSlug,
 	validateDependencies,
 } from '../lib/dev-environment/dev-environment-cli';
 import { stopEnvironment } from '../lib/dev-environment/dev-environment-core';
@@ -25,7 +26,7 @@ const examples = [
 ];
 
 command()
-	.option( 'slug', 'Custom name of the dev environment' )
+	.option( 'slug', 'Custom name of the dev environment', undefined, processSlug )
 	.examples( examples )
 	.argv( process.argv, async ( arg, opt ) => {
 		const slug = await getEnvironmentName( opt );

--- a/src/bin/vip-dev-env-sync-sql.js
+++ b/src/bin/vip-dev-env-sync-sql.js
@@ -6,6 +6,7 @@ import { DEV_ENVIRONMENT_FULL_COMMAND } from '../lib/constants/dev-environment';
 import {
 	getEnvironmentName,
 	processBooleanOption,
+	processSlug,
 } from '../lib/dev-environment/dev-environment-cli';
 import { getEnvironmentPath } from '../lib/dev-environment/dev-environment-core';
 import { bootstrapLando, isEnvUp } from '../lib/dev-environment/dev-environment-lando';
@@ -49,7 +50,7 @@ command( {
 	requiredArgs: 0,
 	module: 'dev-env-sync-sql',
 } )
-	.option( 'slug', 'Custom name of the dev environment' )
+	.option( 'slug', 'Custom name of the dev environment', undefined, processSlug )
 	.option( 'force', 'Disable validations before running sync', undefined, processBooleanOption )
 	.examples( examples )
 	.argv( process.argv, async ( arg, opt ) => {

--- a/src/bin/vip-dev-env-update.js
+++ b/src/bin/vip-dev-env-update.js
@@ -15,6 +15,7 @@ import {
 	getEnvironmentName,
 	handleCLIException,
 	handleDeprecatedOptions,
+	processSlug,
 	promptForArguments,
 	validateDependencies,
 } from '../lib/dev-environment/dev-environment-cli';
@@ -39,7 +40,12 @@ const examples = [
 		description: 'Retriggers setup wizard in order to change environment configuration',
 	},
 ];
-const cmd = command().option( 'slug', 'Custom name of the dev environment' );
+const cmd = command().option(
+	'slug',
+	'Custom name of the dev environment',
+	undefined,
+	processSlug
+);
 
 addDevEnvConfigurationOptions( cmd );
 

--- a/src/lib/dev-environment/dev-environment-cli.ts
+++ b/src/lib/dev-environment/dev-environment-cli.ts
@@ -837,6 +837,11 @@ export function processStringOrBooleanOption( value: string | boolean ): string 
 	return value;
 }
 
+export function processSlug( value: unknown ): string {
+	// eslint-disable-next-line @typescript-eslint/no-base-to-string
+	return ( value ?? '' ).toString().toLowerCase();
+}
+
 declare function isNaN( value: unknown ): boolean;
 declare function parseFloat( value: unknown ): number;
 


### PR DESCRIPTION
## Description

This PR fixes the issue of starting environments with capital letters in their slugs on a case-sensitive filesystem.

Fixes: #1635

## Pull request checklist

- [ ] Update [SETUP.md](https://github.com/Automattic/vip-cli/blob/trunk/docs/SETUP.md#list-of-environmental-variables) with any new environmental variables.
- [ ] Update [the documentation](https://github.com/Automattic/vip-cli/blob/trunk/docs).
- [x] [Manually test](https://github.com/Automattic/vip-cli/blob/trunk/docs/TESTING.md#manual-testing) the relevant changes.
- [x] Follow the [pull request checklist](https://github.com/Automattic/vip-cli/blob/trunk/docs/RELEASING.md#new-pull-requests)
- [ ] Add/update [automated tests](https://github.com/Automattic/vip-cli/blob/trunk/docs/TESTING.md#automated-testing) as needed.

## New release checklist

- [ ] [Automated tests](https://github.com/Automattic/vip-cli/blob/trunk/docs/TESTING.md#automated-testing) pass.
- [ ] The [Preparing for release checklist](https://github.com/Automattic/vip-cli/blob/trunk/docs/RELEASING.md#preparing-for-release) is completed.

## Steps to Test

See #1635

After applying the patch and rebuilding, the following should work:
```sh
vip dev-env create --slug CaseSensitive < /dev/null
vip dev-env start --slug CaseSensitive
```
