### PR TITLE
Add step to enable PHPMyAdmin in the phpmyadmin command

### DIFF
--- a/src/commands/phpmyadmin.ts
+++ b/src/commands/phpmyadmin.ts
@@ -75,7 +75,7 @@ async function generatePhpMyAdminAccess( envId: number ): Promise< string > {
 	return resp?.data?.generatePHPMyAdminAccess?.url as string;
 }
 
-async function enable( envId: number ): Promise< string > {
+async function enablePhpMyAdmin( envId: number ): Promise< string > {
 	// Disable global error handling so that we can handle errors ourselves
 	disableGlobalGraphQLErrorHandling();
 
@@ -165,10 +165,10 @@ export class PhpMyAdminCommand {
 		}
 	}
 
-	async enablePhpMyAdmin(): Promise< void > {
+	async maybeEnablePhpMyAdmin(): Promise< void > {
 		const status = await this.getStatus();
 		if ( ! [ 'running', 'enabled' ].includes( status ) ) {
-			await enable( this.env.id as number );
+			await enablePhpMyAdmin( this.env.id as number );
 			await pollUntil( this.getStatus.bind( this ), 1000, ( sts: string ) => sts === 'running' );
 
 			// Additional 30s for LB routing to be updated
@@ -194,7 +194,7 @@ export class PhpMyAdminCommand {
 		this.progressTracker.startPrinting();
 		try {
 			this.progressTracker.stepRunning( this.steps.ENABLE );
-			await this.enablePhpMyAdmin();
+			await this.maybeEnablePhpMyAdmin();
 			this.progressTracker.stepSuccess( this.steps.ENABLE );
 		} catch ( err ) {
 			this.progressTracker.stepFailed( this.steps.ENABLE );

--- a/src/commands/phpmyadmin.ts
+++ b/src/commands/phpmyadmin.ts
@@ -14,13 +14,35 @@ import API, {
 	enableGlobalGraphQLErrorHandling,
 } from '../lib/api';
 import * as exit from '../lib/cli/exit';
+import { ProgressTracker } from '../lib/cli/progress';
 import { CommandTracker } from '../lib/tracker';
+import { pollUntil } from '../lib/utils';
 
 export const GENERATE_PHP_MY_ADMIN_URL_MUTATION = gql`
 	mutation GeneratePhpMyAdminAccess($input: GeneratePhpMyAdminAccessInput) {
 		generatePHPMyAdminAccess(input: $input) {
 			expiresAt
 			url
+		}
+	}
+`;
+
+export const GET_PHP_MY_ADMIN_STATUS_QUERY = gql`
+	query PhpMyAdminStatus($appId: Int!, $envId: Int!) {
+		app(id: $appId) {
+			environments(id: $envId) {
+				phpMyAdminStatus {
+					status
+				}
+			}
+		}
+	}
+`;
+
+export const ENABLE_PHP_MY_ADMIN_MUTATION = gql`
+	mutation EnablePhpMyAdmin($input: EnablePhpMyAdminInput) {
+		enablePHPMyAdmin(input: $input) {
+			success
 		}
 	}
 `;
@@ -46,16 +68,65 @@ async function generatePhpMyAdminAccess( envId: number ): Promise< string > {
 	return resp?.data?.generatePHPMyAdminAccess?.url as string;
 }
 
+async function enablePhpMyAdmin( envId: number ): Promise< string > {
+	// Disable global error handling so that we can handle errors ourselves
+	disableGlobalGraphQLErrorHandling();
+
+	const api = await API();
+	const resp = await api.mutate( {
+		mutation: ENABLE_PHP_MY_ADMIN_MUTATION,
+		variables: {
+			input: {
+				environmentId: envId,
+			},
+		},
+	} );
+
+	// Re-enable global error handling
+	enableGlobalGraphQLErrorHandling();
+
+	// eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+	return resp?.data?.generatePHPMyAdminAccess?.url as string;
+}
+
+async function getPhpMyAdminStatus( appId: number, envId: number ): Promise< string > {
+	// Disable global error handling so that we can handle errors ourselves
+	disableGlobalGraphQLErrorHandling();
+
+	const api = await API();
+
+	const resp = await api.query( {
+		query: GET_PHP_MY_ADMIN_STATUS_QUERY,
+		variables: { appId, envId },
+		fetchPolicy: 'network-only',
+	} );
+
+	// Re-enable global error handling
+	enableGlobalGraphQLErrorHandling();
+
+	// eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+	return resp?.data?.app?.environments?.[ 0 ]?.phpMyAdminStatus?.status as string;
+}
+
 export class PhpMyAdminCommand {
 	app: App;
 	env: AppEnvironment;
 	silent?: boolean;
 	track: CommandTracker;
+	steps = {
+		ENABLE: 'enable',
+		GENERATE: 'generate',
+	};
+	private progressTracker: ProgressTracker;
 
 	constructor( app: App, env: AppEnvironment, trackerFn: CommandTracker = async () => {} ) {
 		this.app = app;
 		this.env = env;
 		this.track = trackerFn;
+		this.progressTracker = new ProgressTracker( [
+			{ id: this.steps.ENABLE, name: 'Enabling PHPMyAdmin for this site' },
+			{ id: this.steps.GENERATE, name: 'Generating access link' },
+		] );
 	}
 
 	log( msg: string ) {
@@ -65,13 +136,43 @@ export class PhpMyAdminCommand {
 		console.log( msg );
 	}
 
+	stopProgressTracker() {
+		this.progressTracker.print();
+		this.progressTracker.stopPrinting();
+	}
+
 	async openUrl( url: string ) {
 		const { default: open } = await import( 'open' );
 		void open( url, { wait: false } );
 	}
 
+	async getStatus() {
+		try {
+			return await getPhpMyAdminStatus( this.app.id as number, this.env.id as number );
+		} catch ( err ) {
+			exit.withError(
+				'Failed to get PhpMyAdmin status. Please try again. If the problem persists, please contact support.'
+			);
+		}
+	}
+
+	async enablePhpMyAdmin() {
+		const status = await this.getStatus();
+		if ( ! [ 'running', 'enabled' ].includes( status ) ) {
+			await enablePhpMyAdmin( this.env.id as number );
+			await pollUntil( this.getStatus.bind( this ), 1000, ( sts: string ) => sts === 'running' );
+
+			// Additional 30s for LB routing to be updated
+			await new Promise( resolve => setTimeout( resolve, 30000 ) );
+		}
+	}
+
 	async run( silent = false ) {
 		this.silent = silent;
+
+		if ( ! this.app.id ) {
+			exit.withError( 'No app was specified' );
+		}
 
 		if ( ! this.env.id ) {
 			exit.withError( 'No environment was specified' );
@@ -80,12 +181,24 @@ export class PhpMyAdminCommand {
 		const message =
 			'Note: PHPMyAdmin sessions are read-only. If you run a query that writes to DB, it will fail.';
 		console.log( chalk.yellow( message ) );
-		this.log( 'Generating PhpMyAdmin URL...' );
+
+		this.progressTracker.startPrinting();
+		try {
+			this.progressTracker.stepRunning( this.steps.ENABLE );
+			await this.enablePhpMyAdmin();
+			this.progressTracker.stepSuccess( this.steps.ENABLE );
+		} catch ( err ) {
+			this.progressTracker.stepFailed( this.steps.ENABLE );
+			exit.withError( 'Failed to enable PhpMyAdmin' );
+		}
 
 		let url;
 		try {
+			this.progressTracker.stepRunning( this.steps.GENERATE );
 			url = await generatePhpMyAdminAccess( this.env.id );
+			this.progressTracker.stepSuccess( this.steps.GENERATE );
 		} catch ( err ) {
+			this.progressTracker.stepFailed( this.steps.GENERATE );
 			const error = err as Error & {
 				graphQLErrors?: GraphQLFormattedError[];
 			};
@@ -96,7 +209,9 @@ export class PhpMyAdminCommand {
 			} );
 			exit.withError( `Failed to generate PhpMyAdmin URL: ${ error.message }` );
 		}
+
 		void this.openUrl( url );
+		this.stopProgressTracker();
 		this.log( 'PhpMyAdmin is opened in your default browser.' );
 	}
 }


### PR DESCRIPTION
## Description

In this PR, we are adding a step to enable PHPMyAdmin if not already enabled for this site. Concerned command: `vip db phpmyadmin`

## Pull request checklist

- [ ] Update [SETUP.md](https://github.com/Automattic/vip-cli/blob/trunk/docs/SETUP.md#list-of-environmental-variables) with any new environmental variables.
- [ ] Update [the documentation](https://github.com/Automattic/vip-cli/blob/trunk/docs).
- [ ] [Manually test](https://github.com/Automattic/vip-cli/blob/trunk/docs/TESTING.md#manual-testing) the relevant changes.
- [ ] Follow the [pull request checklist](https://github.com/Automattic/vip-cli/blob/trunk/docs/RELEASING.md#new-pull-requests)
- [ ] Add/update [automated tests](https://github.com/Automattic/vip-cli/blob/trunk/docs/TESTING.md#automated-testing) as needed.

## New release checklist

- [ ] [Automated tests](https://github.com/Automattic/vip-cli/blob/trunk/docs/TESTING.md#automated-testing) pass.
- [ ] The [Preparing for release checklist](https://github.com/Automattic/vip-cli/blob/trunk/docs/RELEASING.md#preparing-for-release) is completed.

## Steps to Test

Outline the steps to test and verify the PR here.

Example:

1. Check out PR.
1. Run `rm -rf dist && npm run build && npm link`
1. Run `node ./dist/bin/vip db phpmyadmin @app.env`
2. Browser should open PHPMyAdmin page for the site.

