### PR TITLE
Track errors encounted at get-status

### DIFF
--- a/src/commands/phpmyadmin.ts
+++ b/src/commands/phpmyadmin.ts
@@ -156,13 +156,7 @@ export class PhpMyAdminCommand {
 	}
 
 	async getStatus(): Promise< string > {
-		try {
-			return await getPhpMyAdminStatus( this.app.id as number, this.env.id as number );
-		} catch ( err ) {
-			exit.withError(
-				'Failed to get PhpMyAdmin status. Please try again. If the problem persists, please contact support.'
-			);
-		}
+		return await getPhpMyAdminStatus( this.app.id as number, this.env.id as number );
 	}
 
 	async maybeEnablePhpMyAdmin(): Promise< void > {
@@ -207,7 +201,9 @@ export class PhpMyAdminCommand {
 				stack: error.stack,
 			} );
 			this.stopProgressTracker();
-			exit.withError( 'Failed to enable PhpMyAdmin' );
+			exit.withError(
+				'Failed to enable PhpMyAdmin. Please try again. If the problem persists, please contact support.'
+			);
 		}
 
 		let url;


### PR DESCRIPTION
## Description

We are `try-catch`ing inside `getStatus`, as a result the error was not bubbling up outside that function to be tracked in pendo. We are fixing it here by removing the try-catch.

