### PR TITLE
Support default OrbStack Docker socket path

### DIFF
--- a/src/lib/dev-environment/docker-utils.ts
+++ b/src/lib/dev-environment/docker-utils.ts
@@ -59,8 +59,9 @@ export async function getDockerSocket(): Promise< string | null > {
 
 		// Try the default location
 		paths.push( '/var/run/docker.sock' );
-		// Try an alternative location
+		// Try alternative locations
 		paths.push( join( homedir(), '.docker', 'run', 'docker.sock' ) );
+		paths.push( join( homedir(), '.orbstack', 'run', 'docker.sock' ) );
 
 		for ( const socketPath of paths ) {
 			try {


### PR DESCRIPTION
## Description

Support default OrbStack Docker socket path (`~/.orbstack/run/docker.sock`). Verified resulting dev-env works well under OrbStack.

## Pull request checklist

- [x] Update [SETUP.md](https://github.com/Automattic/vip-cli/blob/trunk/docs/SETUP.md#list-of-environmental-variables) with any new environmental variables.
- [x] Update [the documentation](https://github.com/Automattic/vip-cli/blob/trunk/docs).
- [x] [Manually test](https://github.com/Automattic/vip-cli/blob/trunk/docs/TESTING.md#manual-testing) the relevant changes.
- [x] Follow the [pull request checklist](https://github.com/Automattic/vip-cli/blob/trunk/docs/RELEASING.md#new-pull-requests)
- [x] Add/update [automated tests](https://github.com/Automattic/vip-cli/blob/trunk/docs/TESTING.md#automated-testing) as needed.

## Steps to Test

1. Check out PR.
1. Run `npm run build`
1. Run `node ./dist/bin/vip-dev-env-create.js`

