### PR TITLE
Update publish docs request parameters

### DIFF
--- a/.github/workflows/publish-docs.yml
+++ b/.github/workflows/publish-docs.yml
@@ -19,8 +19,8 @@ jobs:
         env:
           DOCS_SECRET_TOKEN: ${{ secrets.DOCS_SECRET_TOKEN }}
         run: |
-          curl -X POST -v \
+          curl -X PUT -v \
             -H "Authorization: Bearer $DOCS_SECRET_TOKEN" \
             -H "Content-Type: application/json" \
             --data "@/tmp/docs.json" \
-            https://develop-docs.wpvip.com/wp-json/vip/v1/vip-cli
+            https://docs.wpvip.com/wp-json/cli-command-reference/v1/ingest/vip-cli


### PR DESCRIPTION
## Description

Our improved VIP-CLI command reference library is now live on [docs.wpvip.com](https://docs.wpvip.com/vip-cli/commands/), so we need to update this workflow's curl parameters to target the correct ingest endpoint.

Note – The request method was explicitly changed to `PUT` as we're replacing the entirety of commands with the updated payload generated by `helpers/generate-docs.js`.

I see that this existing workflow has yet to be triggered in recent releases. Would that be because GitHub Actions was not used to publish recent releases? Would a note in [/docs/RELEASING.md#alternative-methods-of-releasing](https://github.com/Automattic/vip-cli/blob/trunk/docs/RELEASING.md#alternative-methods-of-releasing) be a suitable place to document manually running this workflow when using an alternative method?

We ultimately want to ensure our public documentation is always in sync with releases.

## Pull request checklist

- [x] Update [SETUP.md](https://github.com/Automattic/vip-cli/blob/trunk/docs/SETUP.md#list-of-environmental-variables) with any new environmental variables.
- [ ] Update [the documentation](https://github.com/Automattic/vip-cli/blob/trunk/docs).
- [x] [Manually test](https://github.com/Automattic/vip-cli/blob/trunk/docs/TESTING.md#manual-testing) the relevant changes.
- [x] Follow the [pull request checklist](https://github.com/Automattic/vip-cli/blob/trunk/docs/RELEASING.md#new-pull-requests)
- [x] Add/update [automated tests](https://github.com/Automattic/vip-cli/blob/trunk/docs/TESTING.md#automated-testing) as needed.