### PR TITLE
chores (phpmyadmin): Add insufficient-permission message

### DIFF
--- a/src/commands/phpmyadmin.ts
+++ b/src/commands/phpmyadmin.ts
@@ -201,6 +201,13 @@ export class PhpMyAdminCommand {
 				stack: error.stack,
 			} );
 			this.stopProgressTracker();
+
+			if ( error.graphQLErrors?.find( e => e.message === 'Unauthorized' ) ) {
+				exit.withError(
+					'You do not have sufficient permission to access phpMyAdmin for this environment.'
+				);
+			}
+
 			exit.withError(
 				'Failed to enable PhpMyAdmin. Please try again. If the problem persists, please contact support.'
 			);


### PR DESCRIPTION
## Description

We are adding `insufficient permission` message so that user's without permission can know why they cannot access the feature.

```
$ node ./dist/bin/vip db phpmyadmin @5910.develop
Note: PHPMyAdmin sessions are read-only. If you run a query that writes to DB, it will fail.
✕ Enabling PHPMyAdmin for this environment
○ Generating access link
Error:  You do not have sufficient permission to access phpMyAdmin for this environment.
Debug:  VIP-CLI v2.38.1-dev.0, Node v20.11.0, darwin 23.3.0 arm64
```

## Pull request checklist

- [ ] Update [SETUP.md](https://github.com/Automattic/vip-cli/blob/trunk/docs/SETUP.md#list-of-environmental-variables) with any new environmental variables.
- [ ] Update [the documentation](https://github.com/Automattic/vip-cli/blob/trunk/docs).
- [ ] [Manually test](https://github.com/Automattic/vip-cli/blob/trunk/docs/TESTING.md#manual-testing) the relevant changes.
- [ ] Follow the [pull request checklist](https://github.com/Automattic/vip-cli/blob/trunk/docs/RELEASING.md#new-pull-requests)
- [ ] Add/update [automated tests](https://github.com/Automattic/vip-cli/blob/trunk/docs/TESTING.md#automated-testing) as needed.

## New release checklist

- [ ] [Automated tests](https://github.com/Automattic/vip-cli/blob/trunk/docs/TESTING.md#automated-testing) pass.
- [ ] The [Preparing for release checklist](https://github.com/Automattic/vip-cli/blob/trunk/docs/RELEASING.md#preparing-for-release) is completed.

## Steps to Test

Outline the steps to test and verify the PR here.

Example:

1. Check out PR.
1. Run `npm run build`
1. Run the command in the description, but with a user that do not have admin role to the organization.
1. Verify the error message.
