### PR TITLE
Add environment name to PHPMyAdmin AppQuery

### DIFF
--- a/src/bin/vip-db-phpmyadmin.ts
+++ b/src/bin/vip-db-phpmyadmin.ts
@@ -24,6 +24,7 @@ const appQuery = `
 	environments{
 		id
 		appId
+		name
 		type
 		uniqueLabel
 	}


### PR DESCRIPTION
## Description

Add environment name to PHPMyAdmin AppQuery. This is necessary to disambiguate environments with the same type but distinct names.

## Changelog Description

Fix a bug in the `vip db phpmyadmin` command that resulted in failure for applications with multiple environments of the same type (e.g., multiple `develop` environments).

## Pull request checklist

- [x] Update [SETUP.md](https://github.com/Automattic/vip-cli/blob/trunk/docs/SETUP.md#list-of-environmental-variables) with any new environmental variables.
- [x] Update [the documentation](https://github.com/Automattic/vip-cli/blob/trunk/docs).
- [x] [Manually test](https://github.com/Automattic/vip-cli/blob/trunk/docs/TESTING.md#manual-testing) the relevant changes.
- [x] Follow the [pull request checklist](https://github.com/Automattic/vip-cli/blob/trunk/docs/RELEASING.md#new-pull-requests)
- [x] Add/update [automated tests](https://github.com/Automattic/vip-cli/blob/trunk/docs/TESTING.md#automated-testing) as needed.

