### PR TITLE
Fix triggering publish docs workflow on tag push

### DIFF
--- a/.github/workflows/publish-docs.yml
+++ b/.github/workflows/publish-docs.yml
@@ -3,7 +3,7 @@ name: Publish docs
 on:
   push:
     tags:
-      - "*.*.*"
+      - '*.*.*'
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/publish-docs.yml
+++ b/.github/workflows/publish-docs.yml
@@ -1,8 +1,9 @@
 name: Publish docs
 
 on:
-  release:
-    types: [published]
+  push:
+    tags:
+      - "*.*.*"
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
## Description

Trigger the publish docs workflow when a new tag is pushed.

Previously, the trigger was set to when a release was published. However, to my understanding, this doesn't work as expected because the releases are created/published on _release branches_ instead of the `default` branch.

For example: https://github.com/Automattic/vip-cli/pull/1712 

Triggering our workflow when a new tag is pushed should meet the requirements of keeping the [VIP-CLI command documentation](https://docs.wpvip.com/vip-cli/commands/) always up-to-date automatically.