### PR TITLE
Make "importSQLCheckStatus" return immediately when called from the `vip import sql status` command and no import is running

### DIFF
--- a/src/bin/vip-import-sql-status.js
+++ b/src/bin/vip-import-sql-status.js
@@ -49,5 +49,10 @@ command( {
 Checking the SQL import status for your environment...
 `;
 
-	await importSqlCheckStatus( { app, env, progressTracker } );
+	await importSqlCheckStatus( {
+		app,
+		env,
+		progressTracker,
+		shouldReturnMissingJobImmediately: true,
+	} );
 } );


### PR DESCRIPTION
## Description

If we executed `vip import sql status` on a site with no old imports, it would be stuck forever in the `Checking...` status.

This PR changes this so that `vip import sql status` exits immediately if no import job is found. 
On the other hand, if an import is present, the old behavior is enforced, where the command will then wait for updates and complete only when the job has finished.

The `vip import sql` will keep the old behavior (waiting for the job to finish).

## Pull request checklist

- [ ] Update [SETUP.md](https://github.com/Automattic/vip-cli/blob/trunk/docs/SETUP.md#list-of-environmental-variables) with any new environmental variables.
- [ ] Update [the documentation](https://github.com/Automattic/vip-cli/blob/trunk/docs).
- [ ] [Manually test](https://github.com/Automattic/vip-cli/blob/trunk/docs/TESTING.md#manual-testing) the relevant changes.
- [ ] Follow the [pull request checklist](https://github.com/Automattic/vip-cli/blob/trunk/docs/RELEASING.md#new-pull-requests)
- [ ] Add/update [automated tests](https://github.com/Automattic/vip-cli/blob/trunk/docs/TESTING.md#automated-testing) as needed.

## New release checklist

- [ ] [Automated tests](https://github.com/Automattic/vip-cli/blob/trunk/docs/TESTING.md#automated-testing) pass.
- [ ] The [Preparing for release checklist](https://github.com/Automattic/vip-cli/blob/trunk/docs/RELEASING.md#preparing-for-release) is completed.

## Steps to Test



Example:

1. Check out PR.
1. Run `npm run build`
1. Run `node ./dist/bin/vip-import-sql-status.js   @<siteId>.<env>` on an app with no previous imports. It should now exit immediately with `No import job found`.
1. Run the same command on a different app with imports, it should return the import status.
1. If you run an SQL import and then exit with `Ctrl+C` and run the import status, the VIP-CLI should show the running status and wait until it's completed.