### PR TITLE
Fixes text so that it doesn't reference "the above tables" when tables are not displayed

### DIFF
--- a/src/bin/vip-import-sql.js
+++ b/src/bin/vip-import-sql.js
@@ -236,16 +236,16 @@ export const promptToContinue = async ( {
 	formattedEnvironment,
 	track,
 	domain,
+	isMultiSite,
 	tableNames,
 } ) => {
 	console.log();
 	const promptToMatch = domain.toUpperCase();
+	const source = ! isMultiSite && tableNames?.length ? 'the above tables' : 'the above file';
 	const promptResponse = await prompt( {
 		type: 'input',
 		name: 'confirmedDomain',
-		message: `You are about to import ${
-			tableNames && Array.isArray( tableNames ) && tableNames.length ? 'above tables' : ''
-		} into a ${
+		message: `You are about to import ${ source } into a ${
 			launched ? 'launched' : 'un-launched'
 		} ${ formattedEnvironment } site ${ chalk.yellow( domain ) }.\nType '${ chalk.yellow(
 			promptToMatch
@@ -467,6 +467,7 @@ void command( {
 			formattedEnvironment,
 			track,
 			domain,
+			isMultiSite,
 			tableNames,
 		} );
 


### PR DESCRIPTION
## Description

Fixes text so that it doesn't reference "the above tables" when tables are not displayed.

## Pull request checklist

- [ ] Update [SETUP.md](https://github.com/Automattic/vip-cli/blob/trunk/docs/SETUP.md#list-of-environmental-variables) with any new environmental variables.
- [ ] Update [the documentation](https://github.com/Automattic/vip-cli/blob/trunk/docs).
- [ ] [Manually test](https://github.com/Automattic/vip-cli/blob/trunk/docs/TESTING.md#manual-testing) the relevant changes.
- [ ] Follow the [pull request checklist](https://github.com/Automattic/vip-cli/blob/trunk/docs/RELEASING.md#new-pull-requests)
- [ ] Add/update [automated tests](https://github.com/Automattic/vip-cli/blob/trunk/docs/TESTING.md#automated-testing) as needed.

## New release checklist

- [ ] [Automated tests](https://github.com/Automattic/vip-cli/blob/trunk/docs/TESTING.md#automated-testing) pass.
- [ ] The [Preparing for release checklist](https://github.com/Automattic/vip-cli/blob/trunk/docs/RELEASING.md#preparing-for-release) is completed.

## Steps to Test

1. Check out PR.
1. Run `npm run build`
1. Run `./dist/bin/vip-import-sql.js -a 3800 sqlFile.sql -s` (multisite)
1. Run `./dist/bin/vip-import-sql.js -a 8758 sqlFile.sql -s` (multisite)
1. Verify the text output only mentions "above tables" when tables are actually listed
