### PR TITLE
Change this.log to console.log for sql export command

### DIFF
--- a/src/commands/export-sql.js
+++ b/src/commands/export-sql.js
@@ -312,7 +312,7 @@ export class ExportSQLCommand {
 			'If a recent database backup does not exist, a new one will be generated for this environment. ';
 		noticeMessage +=
 			'Learn more about this: https://docs.wpvip.com/databases/backups/download-a-full-database-backup/ \n';
-		this.log( noticeMessage );
+		console.log( noticeMessage );
 
 		await cmd.run( false );
 	}


### PR DESCRIPTION
## Description
In #1484, some code was moved from another file into export-sql command which included a call to `this.log`. The definition of `log` just allows skipping `console.log` when the `silent` option is passed. That option was available in the command where the code used to be, but is not available in the export sql command. Since we just directly use `console.log` throughout the export sql command, I'm just changing this to `console.log`.

This prevents a crash when running `export sql --generate-backup`.

## Pull request checklist

- [x] Update [SETUP.md](https://github.com/Automattic/vip-cli/blob/trunk/docs/SETUP.md#list-of-environmental-variables) with any new environmental variables.
- [x] Update [the documentation](https://github.com/Automattic/vip-cli/blob/trunk/docs).
- [x] [Manually test](https://github.com/Automattic/vip-cli/blob/trunk/docs/TESTING.md#manual-testing) the relevant changes.
- [x] Follow the [pull request checklist](https://github.com/Automattic/vip-cli/blob/trunk/docs/RELEASING.md#new-pull-requests)
- [x] Add/update [automated tests](https://github.com/Automattic/vip-cli/blob/trunk/docs/TESTING.md#automated-testing) as needed.

## Changelog Description
Fixes a crash due to an undefined function when running `export sql` with the `--generate-backup` flag.

## New release checklist

- [x] [Automated tests](https://github.com/Automattic/vip-cli/blob/trunk/docs/TESTING.md#automated-testing) pass.
- [x] The [Preparing for release checklist](https://github.com/Automattic/vip-cli/blob/trunk/docs/RELEASING.md#preparing-for-release) is completed.

## Steps to Test

Run `vip @site export sql --generate-backup` on a test site -- it should not crash with an error about `this.log` being undefined. It will crash instantly before this PR.

Example of crashing:
```sh
vip @8614 export sql --generate-backup
✕ Please contact VIP Support with the following information:
TypeError: this.log is not a function
    at ExportSQLCommand.runBackupJob (/Users/noahallen/source/vip-cli/dist/commands/export-sql.js:318:10)
    at ExportSQLCommand.run (/Users/noahallen/source/vip-cli/dist/commands/export-sql.js:347:18)
    at /Users/noahallen/source/vip-cli/dist/bin/vip-export-sql.js:55:23
    at process.processTicksAndRejections (node:internal/process/task_queues:95:5)
    at async _args.default.argv (/Users/noahallen/source/vip-cli/dist/lib/cli/command.js:444:11)
Error:  Unexpected error
Debug:  VIP-CLI v2.39.1-dev.0, Node v18.18.2, darwin 23.4.0 arm64
```

Example of success:
```sh
vip @8614 export sql --generate-backup

NOTICE: If a recent database backup does not exist, a new one will be generated for this environment. Learn more about this: https://docs.wpvip.com/databases/backups/download-a-full-database-backup/
...etc...
```