### PR TITLE
fix: remove unused `cancelCommand`

### DIFF
--- a/src/bin/vip-wp.js
+++ b/src/bin/vip-wp.js
@@ -107,27 +107,6 @@ const getTokenForCommand = async ( appId, envId, command ) => {
 	} );
 };
 
-// eslint-disable-next-line @typescript-eslint/no-unused-vars
-const cancelCommand = async guid => {
-	const api = API();
-	return api.mutate( {
-		mutation: gql`
-			mutation cancelWPCLICommand($input: CancelWPCLICommandInput) {
-				cancelWPCLICommand(input: $input) {
-					command {
-						id
-					}
-				}
-			}
-		`,
-		variables: {
-			input: {
-				guid,
-			},
-		},
-	} );
-};
-
 const launchCommandAndGetStreams = async ( { socket, guid, inputToken, offset = 0 } ) => {
 	const stdoutStream = IOStream.createStream();
 	const stdinStream = IOStream.createStream();


### PR DESCRIPTION
## Description

This PR addresses the [CodeQL warning](https://github.com/Automattic/vip-cli/security/code-scanning/32) by removing the unused code.

Fixes: #1775 

## Pull request checklist

- [ ] Update [SETUP.md](https://github.com/Automattic/vip-cli/blob/trunk/docs/SETUP.md#list-of-environmental-variables) with any new environmental variables.
- [ ] Update [the documentation](https://github.com/Automattic/vip-cli/blob/trunk/docs).
- [ ] [Manually test](https://github.com/Automattic/vip-cli/blob/trunk/docs/TESTING.md#manual-testing) the relevant changes.
- [x] Follow the [pull request checklist](https://github.com/Automattic/vip-cli/blob/trunk/docs/RELEASING.md#new-pull-requests)
- [ ] Add/update [automated tests](https://github.com/Automattic/vip-cli/blob/trunk/docs/TESTING.md#automated-testing) as needed.

## New release checklist

- [ ] [Automated tests](https://github.com/Automattic/vip-cli/blob/trunk/docs/TESTING.md#automated-testing) pass.
- [ ] The [Preparing for release checklist](https://github.com/Automattic/vip-cli/blob/trunk/docs/RELEASING.md#preparing-for-release) is completed.

## Steps to Test

N/A
