### PR TITLE
fix: underscore is allowed in environment name

### DIFF
--- a/__tests__/lib/cli/envAlias.js
+++ b/__tests__/lib/cli/envAlias.js
@@ -17,6 +17,7 @@ describe( 'utils/cli/envAlias', () => {
 			'@1',
 			'@1.env',
 			'@2.MixedCaseEnv',
+			'@xxx.production_test',
 		] )( 'should identify valid aliases - %p', alias => {
 			expect( isAlias( alias ) ).toBe( true );
 		} );

--- a/src/lib/cli/envAlias.ts
+++ b/src/lib/cli/envAlias.ts
@@ -1,5 +1,5 @@
 export function isAlias( alias: string ): boolean {
-	return /^@[A-Za-z0-9.-]+$/.test( alias );
+	return /^@[A-Za-z0-9._-]+$/.test( alias );
 }
 
 export function parseEnvAlias( alias: string ) {


### PR DESCRIPTION
## Description

This PR adds `_` to the list of the allowed characters for the environment name.

Please have a look at BB8-11225 for the full description.

## Pull request checklist

- [ ] Update [SETUP.md](https://github.com/Automattic/vip-cli/blob/trunk/docs/SETUP.md#list-of-environmental-variables) with any new environmental variables.
- [ ] Update [the documentation](https://github.com/Automattic/vip-cli/blob/trunk/docs).
- [x] [Manually test](https://github.com/Automattic/vip-cli/blob/trunk/docs/TESTING.md#manual-testing) the relevant changes.
- [ ] Follow the [pull request checklist](https://github.com/Automattic/vip-cli/blob/trunk/docs/RELEASING.md#new-pull-requests)
- [x] Add/update [automated tests](https://github.com/Automattic/vip-cli/blob/trunk/docs/TESTING.md#automated-testing) as needed.

## New release checklist

- [ ] [Automated tests](https://github.com/Automattic/vip-cli/blob/trunk/docs/TESTING.md#automated-testing) pass.
- [ ] The [Preparing for release checklist](https://github.com/Automattic/vip-cli/blob/trunk/docs/RELEASING.md#preparing-for-release) is completed.

## Steps to Test

I have added a unit test for this case; CI must pass.
