### PR TITLE
BYOR: Pass in deploy token to StartCustomDeploy mutation and allow `getSignedUploadRequestData()` to accept another bearer token

### DIFF
--- a/src/bin/vip-app-deploy.ts
+++ b/src/bin/vip-app-deploy.ts
@@ -245,9 +245,15 @@ Processing the file for deployment to your environment...
 
 	// Start the deploy
 	try {
+		const WPVIP_DEPLOY_TOKEN = process.env.WPVIP_DEPLOY_TOKEN;
 		const startDeployResults = await api.mutate( {
 			mutation: START_DEPLOY_MUTATION,
 			variables: startDeployVariables,
+			context: {
+				headers: {
+					Authorization: `Bearer ${ WPVIP_DEPLOY_TOKEN }`,
+				},
+			},
 		} );
 
 		debug( { startDeployResults } );

--- a/src/lib/api/http.ts
+++ b/src/lib/api/http.ts
@@ -1,5 +1,10 @@
 import debugLib from 'debug';
-import fetch, { type BodyInit, type Response, type RequestInit } from 'node-fetch';
+import fetch, {
+	type BodyInit,
+	type Response,
+	type RequestInit,
+	type HeadersInit,
+} from 'node-fetch';
 
 import { API_HOST } from '../../lib/api';
 import env from '../../lib/env';
@@ -8,9 +13,10 @@ import Token from '../../lib/token';
 
 const debug = debugLib( '@automattic/vip:http' );
 
-type FetchOptions = Omit< RequestInit, 'body' > & {
+export type FetchOptions = Omit< RequestInit, 'body' > & {
 	// eslint-disable-next-line @typescript-eslint/no-redundant-type-constituents
 	body?: BodyInit | Record< string, unknown >;
+	headers?: HeadersInit | Record< string, string >;
 };
 
 /**

--- a/src/lib/client-file-uploader.ts
+++ b/src/lib/client-file-uploader.ts
@@ -11,7 +11,7 @@ import { PassThrough } from 'stream';
 import { Parser as XmlParser } from 'xml2js';
 import { createGunzip, createGzip, Gunzip, ZlibOptions } from 'zlib';
 
-import http from '../lib/api/http';
+import http, { type FetchOptions } from '../lib/api/http';
 import { MB_IN_BYTES } from '../lib/constants/file-size';
 
 // Need to use CommonJS imports here as the `fetch-retry` typedefs are messed up and throwing TypeJS errors when using `import`
@@ -413,10 +413,17 @@ async function getSignedUploadRequestData( {
 	uploadId = undefined,
 	partNumber = undefined,
 }: GetSignedUploadRequestDataArgs ): Promise< PresignedRequest > {
-	const response = await http( '/upload/site-import-presigned-url', {
+	const WPVIP_DEPLOY_TOKEN = process.env.WPVIP_DEPLOY_TOKEN;
+	const reqOptions = {
 		method: 'POST',
 		body: { action, appId, basename, envId, etagResults, partNumber, uploadId },
-	} );
+	} as FetchOptions;
+	if ( WPVIP_DEPLOY_TOKEN ) {
+		reqOptions.headers = {
+			Authorization: `Bearer ${ WPVIP_DEPLOY_TOKEN }`,
+		};
+	}
+	const response = await http( '/upload/site-import-presigned-url', reqOptions );
 
 	if ( response.status !== 200 ) {
 		throw new Error( ( await response.text() ) || response.statusText );


### PR DESCRIPTION
## Description

Missing some spots where the auth token should be properly passed into. This PR:
1) Passes the deploy token into the StartCustomDeploy mutation
2) Passes the deploy token into the `http()` call in `getSignedUploadRequestData`

## Pull request checklist

- [ ] Update [SETUP.md](https://github.com/Automattic/vip-cli/blob/trunk/docs/SETUP.md#list-of-environmental-variables) with any new environmental variables.
- [ ] Update [the documentation](https://github.com/Automattic/vip-cli/blob/trunk/docs).
- [x] [Manually test](https://github.com/Automattic/vip-cli/blob/trunk/docs/TESTING.md#manual-testing) the relevant changes.
- [ ] Follow the [pull request checklist](https://github.com/Automattic/vip-cli/blob/trunk/docs/RELEASING.md#new-pull-requests)
- [ ] Add/update [automated tests](https://github.com/Automattic/vip-cli/blob/trunk/docs/TESTING.md#automated-testing) as needed.

## New release checklist

- [x] [Automated tests](https://github.com/Automattic/vip-cli/blob/trunk/docs/TESTING.md#automated-testing) pass.
- [ ] The [Preparing for release checklist](https://github.com/Automattic/vip-cli/blob/trunk/docs/RELEASING.md#preparing-for-release) is completed.

## Steps to Test

Outline the steps to test and verify the PR here.

Example:

1. Check out PR.
1. Run `npm run build`
1. Run `./dist/bin/vip-cookies.js nom`
1. Verify cookies are delicious.
