### PR TITLE
Add gql tag to software fragment on AppEnvironmentSoftwareSettingsSoftware

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -90,6 +90,12 @@ used.
    dependencies without updating `package.json`
 3. Run `npm run typescript:codegen:generate` - this will regenerate the types.
 
+#### Throubleshooting
+
+- You might encounter an error message saying GraphQL Document Validation failed with 4 errors;
+  Error 0: Unknown fragment "Software". - This is because the codegen script is looking for fragments in the schema.
+  You can skip this by adding the tag `gql` in the const appQueryFragments declaration (`export const appQueryFragments = gql(...)`.
+
 ## Alerting
 
 There are no alerts.

--- a/src/lib/config/software.ts
+++ b/src/lib/config/software.ts
@@ -40,7 +40,10 @@ export const appQuery = `
 		}
 	}`;
 
-export const appQueryFragments = gql`
+// $FlowFixMe: gql template is not supported by flow
+// This causes a GraphQL Document Validation failure in the codegen.ts file
+// To fix this, we need to add the tag to the gql template
+export const appQueryFragments = `
 	fragment Software on AppEnvironmentSoftwareSettingsSoftware {
 		name
 		slug

--- a/src/lib/config/software.ts
+++ b/src/lib/config/software.ts
@@ -40,27 +40,28 @@ export const appQuery = `
 		}
 	}`;
 
-export const appQueryFragments = `fragment Software on AppEnvironmentSoftwareSettingsSoftware {
+export const appQueryFragments = gql`
+	fragment Software on AppEnvironmentSoftwareSettingsSoftware {
 		name
 		slug
 		pinned
 		current {
-		  version
-		  default
-		  deprecated
-		  unstable
-		  compatible
-		  latestRelease
-		  private
+			version
+			default
+			deprecated
+			unstable
+			compatible
+			latestRelease
+			private
 		}
 		options {
-		  version
-		  default
-		  deprecated
-		  unstable
-		  compatible
-		  latestRelease
-		  private
+			version
+			default
+			deprecated
+			unstable
+			compatible
+			latestRelease
+			private
 		}
 	}
 `;


### PR DESCRIPTION
## Description

Add missing `gql` tag to the fragment Software on AppEnvironmentSoftwareSettingsSoftware. 

When generating type - by running `npm run typescript:codegen:generate ` (as per step 3 on how to [generate types documentation](https://github.com/Automattic/vip-cli/blob/71fe3d610f8ec79c979b77940802a596778e6bfd/docs/ARCHITECTURE.md#generating-the-types) 

The developer would experience the following error:

```
✔ Parse Configuration
⚠ Generate outputs
  ✔ Generate to ./src/graphqlTypes.d.ts
  ❯ Generate to ./src/
    ✔ Load GraphQL schemas
    ✔ Load GraphQL documents
    ✖ GraphQL Document Validation failed with 4 errors;
      Error 0: Unknown fragment "Software".
      at /my-user-dir/vip-cli/src/lib/config/software.ts:17:8
      Error 1: Unknown fragment "Software".
      at /my-user-dir/vip-cli/src/lib/config/software.ts:20:8
      Error 2: Unknown fragment "Software".
      at /my-path/Projects/vip-cli/src/lib/config/software.ts:23:8
      Error 3: Unknown fragment "Software".
      at /my-user-dir/vip-cli/src/lib/config/software.ts:26:8
```

## Pull request checklist

- [ ] Update [SETUP.md](https://github.com/Automattic/vip-cli/blob/trunk/docs/SETUP.md#list-of-environmental-variables) with any new environmental variables.
- [ ] Update [the documentation](https://github.com/Automattic/vip-cli/blob/trunk/docs).
- [ ] [Manually test](https://github.com/Automattic/vip-cli/blob/trunk/docs/TESTING.md#manual-testing) the relevant changes.
- [ ] Follow the [pull request checklist](https://github.com/Automattic/vip-cli/blob/trunk/docs/RELEASING.md#new-pull-requests)
- [ ] Add/update [automated tests](https://github.com/Automattic/vip-cli/blob/trunk/docs/TESTING.md#automated-testing) as needed.

## New release checklist

- [ ] [Automated tests](https://github.com/Automattic/vip-cli/blob/trunk/docs/TESTING.md#automated-testing) pass.
- [ ] The [Preparing for release checklist](https://github.com/Automattic/vip-cli/blob/trunk/docs/RELEASING.md#preparing-for-release) is completed.

## Steps to Test

Outline the steps to test and verify the PR here.

Example:

1. Check out PR.
1. Run `npm run build`
1. Follow the [generating types steps](https://github.com/Automattic/vip-cli/blob/71fe3d610f8ec79c979b77940802a596778e6bfd/docs/ARCHITECTURE.md#generating-the-types):
>If you're an employee of Automattic, you can follow these steps to regenerate the GraphQL types used.
>
> 1. Get a hold of schema.gql and paste it in project root - this is the schema of the endpoint that we communicate with.
> 2. Run npm run typescript:codegen:install-dependencies - this will install the codegen dependencies without updating > package.json
> 3. Run npm run typescript:codegen:generate - this will regenerate the types.

4. Types should be regenerated without throwing errors due to fragment software.


