### PR TITLE
fix(phpmyadmin): Add step to wait for PhpMyAdmin readiness. 

### DIFF
--- a/src/bin/vip-db-phpmyadmin.ts
+++ b/src/bin/vip-db-phpmyadmin.ts
@@ -28,6 +28,9 @@ const appQuery = `
 		name
 		type
 		uniqueLabel
+		primaryDomain {
+			name
+		}
 	}
 `;
 

--- a/src/commands/phpmyadmin.ts
+++ b/src/commands/phpmyadmin.ts
@@ -164,7 +164,6 @@ export class PhpMyAdminCommand {
 	async readyToServe(): Promise< boolean > {
 		const url = `https://${ this.env.primaryDomain?.name }/.wpvip/pma/auth`;
 
-		// Specify proxy
 		const resp = await fetch( url, {
 			method: 'GET',
 			redirect: 'manual',

--- a/src/commands/phpmyadmin.ts
+++ b/src/commands/phpmyadmin.ts
@@ -189,7 +189,15 @@ export class PhpMyAdminCommand {
 			await enablePhpMyAdmin( this.env.id as number );
 			await pollUntil( this.getStatus.bind( this ), 1000, ( sts: string ) => sts === 'running' );
 		}
+
+		const timeout = setTimeout( () => {
+			this.progressTracker.updateMessage(
+				'Enabling PHPMyAdmin for this environment. This step may take a while. We appreciate your patience.'
+			);
+		}, 30000 );
+
 		await pollUntil( this.readyToServe.bind( this ), 5000 );
+		clearTimeout( timeout );
 	}
 
 	async run( silent = false ): Promise< void > {

--- a/src/commands/phpmyadmin.ts
+++ b/src/commands/phpmyadmin.ts
@@ -126,7 +126,7 @@ export class PhpMyAdminCommand {
 	track: CommandTracker;
 	steps = {
 		ENABLE: 'enable',
-		PROCESSING: 'Processing',
+		PROCESSING: 'processing',
 		GENERATE: 'generate',
 	};
 	private progressTracker: ProgressTracker;

--- a/src/commands/phpmyadmin.ts
+++ b/src/commands/phpmyadmin.ts
@@ -10,6 +10,7 @@ import {
 import chalk from 'chalk';
 import { DocumentNode, GraphQLFormattedError } from 'graphql';
 import gql from 'graphql-tag';
+import fetch from 'node-fetch';
 
 /**
  * Internal dependencies
@@ -21,6 +22,7 @@ import API, {
 } from '../lib/api';
 import * as exit from '../lib/cli/exit';
 import { ProgressTracker } from '../lib/cli/progress';
+import { createProxyAgent } from '../lib/http/proxy-agent';
 import { CommandTracker } from '../lib/tracker';
 import { pollUntil } from '../lib/utils';
 
@@ -164,9 +166,11 @@ export class PhpMyAdminCommand {
 	async readyToServe(): Promise< boolean > {
 		const url = `https://${ this.env.primaryDomain?.name }/.wpvip/pma/auth`;
 
+		const agent = createProxyAgent( url );
 		const resp = await fetch( url, {
 			method: 'GET',
 			redirect: 'manual',
+			agent: agent ?? undefined,
 		} );
 
 		// If we get 401, the domain is hidden behind a login wall, so we cannot access it

--- a/src/commands/phpmyadmin.ts
+++ b/src/commands/phpmyadmin.ts
@@ -126,7 +126,7 @@ export class PhpMyAdminCommand {
 	track: CommandTracker;
 	steps = {
 		ENABLE: 'enable',
-		LB_DELAY: 'lb_delay',
+		PROCESSING: 'Processing',
 		GENERATE: 'generate',
 	};
 	private progressTracker: ProgressTracker;
@@ -137,7 +137,7 @@ export class PhpMyAdminCommand {
 		this.track = trackerFn;
 		this.progressTracker = new ProgressTracker( [
 			{ id: this.steps.ENABLE, name: 'Enabling PHPMyAdmin for this environment' },
-			{ id: this.steps.LB_DELAY, name: 'Waiting for PHPMyAdmin to be ready' },
+			{ id: this.steps.PROCESSING, name: 'Processing' },
 			{ id: this.steps.GENERATE, name: 'Generating access link' },
 		] );
 	}
@@ -233,14 +233,14 @@ export class PhpMyAdminCommand {
 			);
 		}
 
-		this.progressTracker.stepRunning( this.steps.LB_DELAY );
+		this.progressTracker.stepRunning( this.steps.PROCESSING );
 		try {
-			await pollUntil( this.readyToServe.bind( this ), 5000 );
-			this.progressTracker.stepSuccess( this.steps.LB_DELAY );
+			await pollUntil( this.readyToServe.bind( this ), 5000, undefined, 300000 );
+			this.progressTracker.stepSuccess( this.steps.PROCESSING );
 		} catch ( err ) {
 			const error = err as Error;
 			this.progressTracker.updateMessage( `Skipped: ${ error.message }` );
-			this.progressTracker.stepSkipped( this.steps.LB_DELAY );
+			this.progressTracker.stepSkipped( this.steps.PROCESSING );
 		}
 
 		let url;

--- a/src/commands/phpmyadmin.ts
+++ b/src/commands/phpmyadmin.ts
@@ -126,7 +126,7 @@ export class PhpMyAdminCommand {
 	track: CommandTracker;
 	steps = {
 		ENABLE: 'enable',
-		PROCESSING: 'processing',
+		PREPARING: 'preparing',
 		GENERATE: 'generate',
 	};
 	private progressTracker: ProgressTracker;
@@ -137,7 +137,7 @@ export class PhpMyAdminCommand {
 		this.track = trackerFn;
 		this.progressTracker = new ProgressTracker( [
 			{ id: this.steps.ENABLE, name: 'Enabling PHPMyAdmin for this environment' },
-			{ id: this.steps.PROCESSING, name: 'Processing' },
+			{ id: this.steps.PREPARING, name: 'Preparing' },
 			{ id: this.steps.GENERATE, name: 'Generating access link' },
 		] );
 	}
@@ -236,14 +236,14 @@ export class PhpMyAdminCommand {
 			);
 		}
 
-		this.progressTracker.stepRunning( this.steps.PROCESSING );
+		this.progressTracker.stepRunning( this.steps.PREPARING );
 		try {
 			await pollUntil( this.readyToServe.bind( this ), 5000 );
-			this.progressTracker.stepSuccess( this.steps.PROCESSING );
+			this.progressTracker.stepSuccess( this.steps.PREPARING );
 		} catch ( err ) {
 			const error = err as Error;
 			this.progressTracker.updateMessage( `Skipped: ${ error.message }` );
-			this.progressTracker.stepSkipped( this.steps.PROCESSING );
+			this.progressTracker.stepSkipped( this.steps.PREPARING );
 		}
 
 		let url;

--- a/src/lib/cli/progress.ts
+++ b/src/lib/cli/progress.ts
@@ -95,6 +95,15 @@ export class ProgressTracker {
 		this.stepsFromCaller.set( step.id, { ...step, progress } );
 	}
 
+	updateMessage( message: string ) {
+		const step = this.getCurrentStep();
+		if ( ! step ) {
+			return;
+		}
+
+		this.stepsFromCaller.set( step.id, { ...step, name: message } );
+	}
+
 	setStepsFromServer( steps: StepFromServer[] ) {
 		const formattedSteps: Step[] = steps.map( ( { name, status }, index ) => ( {
 			id: `server-${ index }-${ name }`,

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -11,20 +11,20 @@ const debug = debugLib( '@automattic/vip:lib:utils' );
  *
  * @param {Function} fn       A function to poll
  * @param {number}   interval Poll interval in milliseconds
- * @param {Function} isDone   A function that accepts the return of `fn`. Stops the polling if it returns true
+ * @param {Function} isDone   A function that accepts the return of `fn`. Stops the polling if it returns true. If not provided, the polling stops when `fn` returns a truthy value.
  * @return {Promise}          A promise which resolves when the polling is done
  * @throws {Error}            If the fn throws an error
  */
 export async function pollUntil< T >(
 	fn: () => Promise< T >,
 	interval: number,
-	isDone: ( v: T ) => boolean
+	isDone?: ( v: T ) => boolean
 ): Promise< void > {
 	let done = false;
 	while ( ! done ) {
 		// eslint-disable-next-line no-await-in-loop
 		const result = await fn();
-		done = isDone( result );
+		done = isDone?.( result ) || Boolean( result );
 		if ( ! done ) {
 			// eslint-disable-next-line no-await-in-loop
 			await setTimeout( interval );


### PR DESCRIPTION
## Description

After spinning up the necessary pod to run PhpMyAdmin, we have to wait for the LB to be propagated, so that the requests to the PhpMyAdmin link are served the by PhpMyAdmin pod. In this PR, we are adding a step to wait to see the LB routing is happening before we generate an access.

## Pull request checklist

- [ ] Update [SETUP.md](https://github.com/Automattic/vip-cli/blob/trunk/docs/SETUP.md#list-of-environmental-variables) with any new environmental variables.
- [ ] Update [the documentation](https://github.com/Automattic/vip-cli/blob/trunk/docs).
- [ ] [Manually test](https://github.com/Automattic/vip-cli/blob/trunk/docs/TESTING.md#manual-testing) the relevant changes.
- [ ] Follow the [pull request checklist](https://github.com/Automattic/vip-cli/blob/trunk/docs/RELEASING.md#new-pull-requests)
- [ ] Add/update [automated tests](https://github.com/Automattic/vip-cli/blob/trunk/docs/TESTING.md#automated-testing) as needed.

## Steps to Test

1. Check out PR.
1. Run `npm run build`
1. Run `node ./dist/bin/vip db phpmyadmin @<app>.<env>`. This should be run on an environment for which PMA is not enabled yet.
1. Ensure that a browser page opened, and it did not end up with an error.
