### PR TITLE
Dev Env: Remove the deprecated --mailhog option

### DIFF
--- a/src/lib/dev-environment/dev-environment-cli.ts
+++ b/src/lib/dev-environment/dev-environment-cli.ts
@@ -858,12 +858,6 @@ export function addDevEnvConfigurationOptions( command: Args ): Args {
 		)
 		.option( 'php', 'Explicitly choose PHP version to use', undefined, processVersionOption )
 		.option(
-			[ 'G', 'mailhog' ],
-			'Enable Mailpit. By default it is disabled (deprecated option, please use --mailpit instead)',
-			undefined,
-			processBooleanOption
-		)
-		.option(
 			[ 'A', 'mailpit' ],
 			'Enable Mailpit. By default it is disabled',
 			undefined,


### PR DESCRIPTION
## Description

We have had switched from Mailhog to Mailpit a year ago, it's time for the option to go.

NB: this keeps the migration routines in place


## Pull request checklist

- [ ] Update [SETUP.md](https://github.com/Automattic/vip-cli/blob/trunk/docs/SETUP.md#list-of-environmental-variables) with any new environmental variables.
- [ ] Update [the documentation](https://github.com/Automattic/vip-cli/blob/trunk/docs).
- [ ] [Manually test](https://github.com/Automattic/vip-cli/blob/trunk/docs/TESTING.md#manual-testing) the relevant changes.
- [ ] Follow the [pull request checklist](https://github.com/Automattic/vip-cli/blob/trunk/docs/RELEASING.md#new-pull-requests)
- [ ] Add/update [automated tests](https://github.com/Automattic/vip-cli/blob/trunk/docs/TESTING.md#automated-testing) as needed.

## New release checklist

- [ ] [Automated tests](https://github.com/Automattic/vip-cli/blob/trunk/docs/TESTING.md#automated-testing) pass.
- [ ] The [Preparing for release checklist](https://github.com/Automattic/vip-cli/blob/trunk/docs/RELEASING.md#preparing-for-release) is completed.

## Steps to Test

Outline the steps to test and verify the PR here.

Example:

1. Check out PR.
1. Run `npm run build`
1. Run `./dist/bin/vip-cookies.js nom`
1. Verify cookies are delicious.
