### PR TITLE
fix(dev-env): `vip dev-env info --all` should not ask for a slug

### DIFF
--- a/src/bin/vip-dev-env-info.js
+++ b/src/bin/vip-dev-env-info.js
@@ -37,12 +37,19 @@ command()
 	.option( 'extended', 'Show extended information about the dev environment' )
 	.examples( examples )
 	.argv( process.argv, async ( arg, opt ) => {
-		const slug = await getEnvironmentName( opt );
-
+		let trackingInfo;
+		let slug;
 		const lando = await bootstrapLando();
-		await validateDependencies( lando, slug );
 
-		const trackingInfo = opt.all ? { all: true } : getEnvTrackingInfo( slug );
+		if ( opt.all ) {
+			trackingInfo = { all: true };
+			slug = '';
+		} else {
+			slug = await getEnvironmentName( opt );
+			trackingInfo = getEnvTrackingInfo( slug );
+		}
+
+		await validateDependencies( lando, slug );
 		await trackEvent( 'dev_env_info_command_execute', trackingInfo );
 
 		debug( 'Args: ', arg, 'Options: ', opt );


### PR DESCRIPTION
## Description

This PR fixes the bug when `vip dev-env info --all` asks for a slug when more than one environment is available.

## Pull request checklist

- [ ] Update [SETUP.md](https://github.com/Automattic/vip-cli/blob/trunk/docs/SETUP.md#list-of-environmental-variables) with any new environmental variables.
- [ ] Update [the documentation](https://github.com/Automattic/vip-cli/blob/trunk/docs).
- [x] [Manually test](https://github.com/Automattic/vip-cli/blob/trunk/docs/TESTING.md#manual-testing) the relevant changes.
- [x] Follow the [pull request checklist](https://github.com/Automattic/vip-cli/blob/trunk/docs/RELEASING.md#new-pull-requests)
- [ ] Add/update [automated tests](https://github.com/Automattic/vip-cli/blob/trunk/docs/TESTING.md#automated-testing) as needed.

## New release checklist

- [ ] [Automated tests](https://github.com/Automattic/vip-cli/blob/trunk/docs/TESTING.md#automated-testing) pass.
- [ ] The [Preparing for release checklist](https://github.com/Automattic/vip-cli/blob/trunk/docs/RELEASING.md#preparing-for-release) is completed.

## Steps to Test

1. `vip dev-env create -s test1 < /dev/null`
2. `vip dev-env create -s test2 < /dev/null`
3. `vip dev-env info --all`
4. The last command should fail with something like "Error:  More than one environment found: test1, test2. Please re-run command with the --slug parameter for the targeted environment."
5. Apply the patch, run `npm run build`, `npm link`.
6. `vip dev-env info --all` should succeed now.
