### PR TITLE
Fix promptForBoolean to display the default initial value capitalized

### DIFF
--- a/src/lib/dev-environment/dev-environment-cli.ts
+++ b/src/lib/dev-environment/dev-environment-cli.ts
@@ -611,6 +611,7 @@ export function promptForBoolean( message: string, initial: boolean ): Promise< 
 	if ( isStdinTTY ) {
 		const confirm = new Confirm( {
 			message,
+			// eslint-disable-next-line @typescript-eslint/no-explicit-any,@typescript-eslint/no-unsafe-assignment
 			initial: initial as any, // TS definition is wrong, so we need to bypass it to show the correct hint.
 		} );
 

--- a/src/lib/dev-environment/dev-environment-cli.ts
+++ b/src/lib/dev-environment/dev-environment-cli.ts
@@ -611,7 +611,7 @@ export function promptForBoolean( message: string, initial: boolean ): Promise< 
 	if ( isStdinTTY ) {
 		const confirm = new Confirm( {
 			message,
-			initial: initial.toString(),
+			initial: initial as any, // TS definition is wrong, so we need to bypass it to show the correct hint.
 		} );
 
 		return confirm.run();


### PR DESCRIPTION
## Description
We should be passing in a boolean value into the `initial` property for `Confirm()`: https://github.com/enquirer/enquirer/blob/70bdb0fedc3ed355d9d8fe4f00ac9b3874f94f61/lib/prompts/confirm.js#L8
However, since we convert it to a string, it will always evaluate to true and display `Y/n` for everything: https://github.com/Automattic/vip-cli/blob/36ec1265e498e28c769980db10fc3556a5c2607b/src/lib/dev-environment/dev-environment-cli.ts#L614

This is because `ConfirmQuestionOptions` expects a string for `initial` (it inherits from https://github.com/Automattic/vip-cli/blob/36ec1265e498e28c769980db10fc3556a5c2607b/types/enquirer/index.d.ts#L770). Looks like we are using an experimental version of the types definitions @ https://github.com/enquirer/enquirer/pull/307. Kind of hacky, but I think it's ok for now if we want to keep things in sync with the PR?

If we want to fix it in the Types definition, I think we need to change `initial?: T | ( () => Promise< T > | T );` to `initial?: T | ( () => Promise< T > | T ) | boolean | ( () => Promise< boolean > | boolean );` under `export type Question< T extends types.Answer = string, P extends Prompt< T > = Prompt< T > > = {`
^ Happy to go about this way too and leave a comment in the PR

## Pull request checklist

- [ ] Update [SETUP.md](https://github.com/Automattic/vip-cli/blob/trunk/docs/SETUP.md#list-of-environmental-variables) with any new environmental variables.
- [ ] Update [the documentation](https://github.com/Automattic/vip-cli/blob/trunk/docs).
- [x] [Manually test](https://github.com/Automattic/vip-cli/blob/trunk/docs/TESTING.md#manual-testing) the relevant changes.
- [ ] Follow the [pull request checklist](https://github.com/Automattic/vip-cli/blob/trunk/docs/RELEASING.md#new-pull-requests)
- [ ] Add/update [automated tests](https://github.com/Automattic/vip-cli/blob/trunk/docs/TESTING.md#automated-testing) as needed.

## New release checklist

- [ ] [Automated tests](https://github.com/Automattic/vip-cli/blob/trunk/docs/TESTING.md#automated-testing) pass.
- [ ] The [Preparing for release checklist](https://github.com/Automattic/vip-cli/blob/trunk/docs/RELEASING.md#preparing-for-release) is completed.

## Steps to Test

Outline the steps to test and verify the PR here.

Example:

1. Check out PR.
1. Run `npm run build`
1. Do `vip dev-env create` and expect to display as `Enable Elasticsearch (needed by Enterprise Search)? (y/N)`
