### PR TITLE
Add new lines after error file URLs

### DIFF
--- a/src/lib/media-import/status.ts
+++ b/src/lib/media-import/status.ts
@@ -312,7 +312,8 @@ Downloading errors details from ${ fileErrorsUrl }...
 		const failureDetails = await prompt( {
 			type: 'confirm',
 			name: 'download',
-			message: 'Download file import errors report now?',
+			message:
+				'Download file import errors report now? (Report will be downloadable for up to 7 days from the completion of the import)',
 		} );
 
 		if ( ! failureDetails.download ) {
@@ -320,7 +321,7 @@ Downloading errors details from ${ fileErrorsUrl }...
 				`⚠️  Click on the following link to download the file import errors report`
 			) }`;
 			progressTracker.suffix += `\n${ chalk.italic.yellow(
-				'(The link will be valid for the next 15 minutes & the data is retained for 7 days since the completion of the import)'
+				'(The link will be valid for the next 15 minutes & the report will be downloadable for up to 7 days from the completion of the import)'
 			) } `;
 			progressTracker.suffix += `\n\n${ chalk.bold.yellow( fileErrorsUrl ) }\n`;
 			progressTracker.print( { clearAfter: true } );

--- a/src/lib/media-import/status.ts
+++ b/src/lib/media-import/status.ts
@@ -283,7 +283,7 @@ ${ maybeExitPrompt }
 		try {
 			await writeFile( errorsFile, formattedData );
 			progressTracker.suffix += `${ chalk.yellow(
-				`⚠️  All errors have been exported to ${ chalk.bold( resolve( errorsFile ) ) }`
+				`⚠️  All errors have been exported to ${ chalk.bold( resolve( errorsFile ) ) }\n`
 			) }`;
 		} catch ( writeFileErr ) {
 			progressTracker.suffix += `${ chalk.red(
@@ -322,7 +322,7 @@ Downloading errors details from ${ fileErrorsUrl }...
 			progressTracker.suffix += `\n${ chalk.italic.yellow(
 				'(The link will be valid for the next 15 minutes & the data is retained for 7 days since the completion of the import)'
 			) } `;
-			progressTracker.suffix += `\n\n${ chalk.bold.yellow( fileErrorsUrl ) }`;
+			progressTracker.suffix += `\n\n${ chalk.bold.yellow( fileErrorsUrl ) }\n`;
 			progressTracker.print( { clearAfter: true } );
 			return;
 		}


### PR DESCRIPTION
## Description

Adds new lines after the error file URL and paths. Currently they are not clickable (in iTerm2 at least).

## Pull request checklist

- [ ] Update [SETUP.md](https://github.com/Automattic/vip-cli/blob/trunk/docs/SETUP.md#list-of-environmental-variables) with any new environmental variables.
- [ ] Update [the documentation](https://github.com/Automattic/vip-cli/blob/trunk/docs).
- [ ] [Manually test](https://github.com/Automattic/vip-cli/blob/trunk/docs/TESTING.md#manual-testing) the relevant changes.
- [ ] Follow the [pull request checklist](https://github.com/Automattic/vip-cli/blob/trunk/docs/RELEASING.md#new-pull-requests)
- [ ] Add/update [automated tests](https://github.com/Automattic/vip-cli/blob/trunk/docs/TESTING.md#automated-testing) as needed.

## New release checklist

- [ ] [Automated tests](https://github.com/Automattic/vip-cli/blob/trunk/docs/TESTING.md#automated-testing) pass.
- [ ] The [Preparing for release checklist](https://github.com/Automattic/vip-cli/blob/trunk/docs/RELEASING.md#preparing-for-release) is completed.

## Steps to Test

1. Check out PR.
1. Run `npm run build`
1. Run `./dist/bin/vip-import-media-status.js @<site_id>.production`
1. Respond `n` to the prompt `Download file import errors report now?`
1. Command + click (or the equivalent in your terminal) to verify the link is clickable
