### PR TITLE
feat(dev-env): track versions of `docker` and `docker-compose`

### DIFF
--- a/src/bin/vip-dev-env-start.js
+++ b/src/bin/vip-dev-env-start.js
@@ -46,8 +46,12 @@ command()
 
 		const startProcessing = new Date();
 
+		const versions = await lando.engine.daemon.getVersions();
 		const trackingInfo = getEnvTrackingInfo( slug );
 		trackingInfo.vscode = Boolean( opt.vscode );
+		trackingInfo.docker = versions.engine;
+		trackingInfo.docker_compose = versions.compose;
+
 		await trackEvent( 'dev_env_start_command_execute', trackingInfo );
 
 		debug( 'Args: ', arg, 'Options: ', opt );


### PR DESCRIPTION
## Description

This PR adds tracking of `docker` and `docker-compose` versions for `vip dev-env start`.

## Pull request checklist

- [ ] Update [SETUP.md](https://github.com/Automattic/vip-cli/blob/trunk/docs/SETUP.md#list-of-environmental-variables) with any new environmental variables.
- [ ] Update [the documentation](https://github.com/Automattic/vip-cli/blob/trunk/docs).
- [x] [Manually test](https://github.com/Automattic/vip-cli/blob/trunk/docs/TESTING.md#manual-testing) the relevant changes.
- [x] Follow the [pull request checklist](https://github.com/Automattic/vip-cli/blob/trunk/docs/RELEASING.md#new-pull-requests)
- [ ] Add/update [automated tests](https://github.com/Automattic/vip-cli/blob/trunk/docs/TESTING.md#automated-testing) as needed.

## New release checklist

- [ ] [Automated tests](https://github.com/Automattic/vip-cli/blob/trunk/docs/TESTING.md#automated-testing) pass.
- [ ] The [Preparing for release checklist](https://github.com/Automattic/vip-cli/blob/trunk/docs/RELEASING.md#preparing-for-release) is completed.

## Steps to Test

1. `npm run build`
2. `DEBUG=* vip dev-env start`
3. Tracking info should have `docker` and `docker_compose` keys.
