### PR TITLE
fix(dev-env): plugin loading when using yarn to install VIP CLI

### DIFF
--- a/src/lib/dev-environment/dev-environment-lando.ts
+++ b/src/lib/dev-environment/dev-environment-lando.ts
@@ -8,7 +8,7 @@ import landoBuildTask from 'lando/plugins/lando-tooling/lib/build';
 import { lookup } from 'node:dns/promises';
 import { mkdir, rename } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
-import path from 'node:path';
+import path, { dirname } from 'node:path';
 import xdgBasedir from 'xdg-basedir';
 
 import {
@@ -33,9 +33,10 @@ const debug = debugLib( DEBUG_KEY );
  * @return {Promise<LandoConfig>} Lando configuration
  */
 async function getLandoConfig(): Promise< LandoConfig > {
-	const nodeModulesPath = path.join( __dirname, '..', '..', '..', 'node_modules' );
-	const landoPath = path.join( nodeModulesPath, 'lando' );
-	const atLandoPath = path.join( nodeModulesPath, '@lando' );
+	// The path will be smth like `yarn/global/node_modules/lando/lib/lando.js`; we need the path up to `lando` (inclusive)
+	const landoPath = dirname( dirname( require.resolve( 'lando' ) ) );
+	// The path will be smth like `yarn/global/node_modules/@lando/compose/index.js`; we need the path up to `@lando` (inclusive)
+	const atLandoPath = dirname( dirname( require.resolve( '@lando/compose' ) ) );
 
 	debug( `Getting Lando config, using paths '${ landoPath }' and '${ atLandoPath }' for plugins` );
 


### PR DESCRIPTION
## Description

`yarn global add @automattic/vip` installs the VIP CLI differently from `npm`, which causes issues with locating Lando plugins.

This PR tries to work around this issue using the logic based on `resolve.require()` and knowledge of Lando internals.

## Pull request checklist

- [ ] Update [SETUP.md](https://github.com/Automattic/vip-cli/blob/trunk/docs/SETUP.md#list-of-environmental-variables) with any new environmental variables.
- [ ] Update [the documentation](https://github.com/Automattic/vip-cli/blob/trunk/docs).
- [x] [Manually test](https://github.com/Automattic/vip-cli/blob/trunk/docs/TESTING.md#manual-testing) the relevant changes.
- [ ] Follow the [pull request checklist](https://github.com/Automattic/vip-cli/blob/trunk/docs/RELEASING.md#new-pull-requests)
- [ ] Add/update [automated tests](https://github.com/Automattic/vip-cli/blob/trunk/docs/TESTING.md#automated-testing) as needed.

## New release checklist

- [ ] [Automated tests](https://github.com/Automattic/vip-cli/blob/trunk/docs/TESTING.md#automated-testing) pass.
- [ ] The [Preparing for release checklist](https://github.com/Automattic/vip-cli/blob/trunk/docs/RELEASING.md#preparing-for-release) is completed.

## Steps to Test

E2E tests should pass.
