### PR TITLE
chore: update lando to 77dad3a

### DIFF
--- a/__tests__/lib/dev-environment/dev-environment-core.js
+++ b/__tests__/lib/dev-environment/dev-environment-core.js
@@ -49,7 +49,7 @@ describe( 'lib/dev-environment/dev-environment-core', () => {
 			if ( /docker-compose/.test( command ) ) {
 				callback( null, '2.12.2', '' );
 			} else if ( /docker/.test( command ) ) {
-				callback( null, '23.0.4', '' );
+				callback( null, '{"ServerVersion": "25.0.2"}', '' );
 			} else {
 				callback( new Error(), '', '' );
 			}

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -31,7 +31,7 @@
         "ini": "4.1.3",
         "js-yaml": "^4.1.0",
         "jwt-decode": "4.0.0",
-        "lando": "github:automattic/lando-cli.git#1c45a75",
+        "lando": "github:automattic/lando-cli.git#1b25a3b",
         "node-fetch": "^2.6.1",
         "open": "^10.0.0",
         "proxy-from-env": "^1.1.0",
@@ -5525,6 +5525,14 @@
         "node": ">=8"
       }
     },
+    "node_modules/clone": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/clone/-/clone-2.1.2.tgz",
+      "integrity": "sha512-3Pe/CF1Nn94hyhIYpjtiLhdCoEoz0DqQ+988E9gmeEdQZlojxnOb74wctFyuwWQHzqyf9X7C7MG8juUpqBJT8w==",
+      "engines": {
+        "node": ">=0.8"
+      }
+    },
     "node_modules/co": {
       "version": "4.6.0",
       "resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
@@ -9780,9 +9788,12 @@
       "dev": true
     },
     "node_modules/jsonfile": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-2.4.0.tgz",
-      "integrity": "sha512-PKllAqbgLgxHaj8TElYymKCAgrASebJrWpTnEkOaTowt23VKXXN0sUeriJ+eh7y6ufb/CC5ap11pz71/cM0hUw==",
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.1.0.tgz",
+      "integrity": "sha512-5dgndWOriYSm5cnYaJNhalLNDKOqFwyDB/rr1E9ZsGciGvKPs8R2xYGCacuf3z6K1YKDz182fd+fY3cn3pMqXQ==",
+      "dependencies": {
+        "universalify": "^2.0.0"
+      },
       "optionalDependencies": {
         "graceful-fs": "^4.1.6"
       }
@@ -9868,7 +9879,7 @@
     "node_modules/lando": {
       "name": "@lando/cli",
       "version": "3.6.5",
-      "resolved": "git+ssh://git@github.com/automattic/lando-cli.git#1c45a75a3ca921c145f9b927ad862d0f224b8537",
+      "resolved": "git+ssh://git@github.com/automattic/lando-cli.git#1b25a3b388e2b485dd2df9d46c186c437355a600",
       "dependencies": {
         "@lando/compose": "1.0.0",
         "@lando/mailhog": "0.8.0",
@@ -9883,9 +9894,9 @@
         "inquirer-autocomplete-prompt": "^1.0.1",
         "ip": "^1.1.9",
         "js-yaml": "^4.1.0",
-        "jsonfile": "^2.4.0",
+        "jsonfile": "^6.1.0",
         "lodash": "^4.17.21",
-        "node-cache": "^4.1.1",
+        "node-cache": "^5.1.2",
         "object-hash": "^1.1.8",
         "semver": "^7.3.8",
         "shelljs": "^0.8.4",
@@ -10382,23 +10393,14 @@
       "optional": true
     },
     "node_modules/node-cache": {
-      "version": "4.2.1",
-      "resolved": "https://registry.npmjs.org/node-cache/-/node-cache-4.2.1.tgz",
-      "integrity": "sha512-BOb67bWg2dTyax5kdef5WfU3X8xu4wPg+zHzkvls0Q/QpYycIFRLEEIdAx9Wma43DxG6Qzn4illdZoYseKWa4A==",
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/node-cache/-/node-cache-5.1.2.tgz",
+      "integrity": "sha512-t1QzWwnk4sjLWaQAS8CHgOJ+RAfmHpxFWmc36IWTiWHQfs0w5JDMBS1b1ZxQteo0vVVuWJvIUKHDkkeK7vIGCg==",
       "dependencies": {
-        "clone": "2.x",
-        "lodash": "^4.17.15"
+        "clone": "2.x"
       },
       "engines": {
-        "node": ">= 0.4.6"
-      }
-    },
-    "node_modules/node-cache/node_modules/clone": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/clone/-/clone-2.1.2.tgz",
-      "integrity": "sha512-3Pe/CF1Nn94hyhIYpjtiLhdCoEoz0DqQ+988E9gmeEdQZlojxnOb74wctFyuwWQHzqyf9X7C7MG8juUpqBJT8w==",
-      "engines": {
-        "node": ">=0.8"
+        "node": ">= 8.0.0"
       }
     },
     "node_modules/node-fetch": {
@@ -12662,6 +12664,14 @@
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/universal-user-agent/-/universal-user-agent-6.0.1.tgz",
       "integrity": "sha512-yCzhz6FN2wU1NiiQRogkTQszlQSlpWaw8SvVegAc+bDxbzHgh1vX8uIe8OYyMH6DwH+sdTJsgMl36+mSMdRJIQ=="
+    },
+    "node_modules/universalify": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.1.tgz",
+      "integrity": "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==",
+      "engines": {
+        "node": ">= 10.0.0"
+      }
     },
     "node_modules/update-browserslist-db": {
       "version": "1.0.13",
@@ -17383,6 +17393,11 @@
         }
       }
     },
+    "clone": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/clone/-/clone-2.1.2.tgz",
+      "integrity": "sha512-3Pe/CF1Nn94hyhIYpjtiLhdCoEoz0DqQ+988E9gmeEdQZlojxnOb74wctFyuwWQHzqyf9X7C7MG8juUpqBJT8w=="
+    },
     "co": {
       "version": "4.6.0",
       "resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
@@ -20468,11 +20483,12 @@
       "dev": true
     },
     "jsonfile": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-2.4.0.tgz",
-      "integrity": "sha512-PKllAqbgLgxHaj8TElYymKCAgrASebJrWpTnEkOaTowt23VKXXN0sUeriJ+eh7y6ufb/CC5ap11pz71/cM0hUw==",
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.1.0.tgz",
+      "integrity": "sha512-5dgndWOriYSm5cnYaJNhalLNDKOqFwyDB/rr1E9ZsGciGvKPs8R2xYGCacuf3z6K1YKDz182fd+fY3cn3pMqXQ==",
       "requires": {
-        "graceful-fs": "^4.1.6"
+        "graceful-fs": "^4.1.6",
+        "universalify": "^2.0.0"
       }
     },
     "jsonwebtoken": {
@@ -20541,8 +20557,8 @@
       "dev": true
     },
     "lando": {
-      "version": "git+ssh://git@github.com/automattic/lando-cli.git#1c45a75a3ca921c145f9b927ad862d0f224b8537",
-      "from": "lando@github:automattic/lando-cli.git#1c45a75",
+      "version": "git+ssh://git@github.com/automattic/lando-cli.git#1b25a3b388e2b485dd2df9d46c186c437355a600",
+      "from": "lando@github:automattic/lando-cli.git#1b25a3b",
       "requires": {
         "@lando/compose": "1.0.0",
         "@lando/mailhog": "0.8.0",
@@ -20557,9 +20573,9 @@
         "inquirer-autocomplete-prompt": "^1.0.1",
         "ip": "^1.1.9",
         "js-yaml": "^4.1.0",
-        "jsonfile": "^2.4.0",
+        "jsonfile": "^6.1.0",
         "lodash": "^4.17.21",
-        "node-cache": "^4.1.1",
+        "node-cache": "^5.1.2",
         "object-hash": "^1.1.8",
         "semver": "^7.3.8",
         "shelljs": "^0.8.4",
@@ -20958,19 +20974,11 @@
       "optional": true
     },
     "node-cache": {
-      "version": "4.2.1",
-      "resolved": "https://registry.npmjs.org/node-cache/-/node-cache-4.2.1.tgz",
-      "integrity": "sha512-BOb67bWg2dTyax5kdef5WfU3X8xu4wPg+zHzkvls0Q/QpYycIFRLEEIdAx9Wma43DxG6Qzn4illdZoYseKWa4A==",
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/node-cache/-/node-cache-5.1.2.tgz",
+      "integrity": "sha512-t1QzWwnk4sjLWaQAS8CHgOJ+RAfmHpxFWmc36IWTiWHQfs0w5JDMBS1b1ZxQteo0vVVuWJvIUKHDkkeK7vIGCg==",
       "requires": {
-        "clone": "2.x",
-        "lodash": "^4.17.15"
-      },
-      "dependencies": {
-        "clone": {
-          "version": "2.1.2",
-          "resolved": "https://registry.npmjs.org/clone/-/clone-2.1.2.tgz",
-          "integrity": "sha512-3Pe/CF1Nn94hyhIYpjtiLhdCoEoz0DqQ+988E9gmeEdQZlojxnOb74wctFyuwWQHzqyf9X7C7MG8juUpqBJT8w=="
-        }
+        "clone": "2.x"
       }
     },
     "node-fetch": {
@@ -22594,6 +22602,11 @@
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/universal-user-agent/-/universal-user-agent-6.0.1.tgz",
       "integrity": "sha512-yCzhz6FN2wU1NiiQRogkTQszlQSlpWaw8SvVegAc+bDxbzHgh1vX8uIe8OYyMH6DwH+sdTJsgMl36+mSMdRJIQ=="
+    },
+    "universalify": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.1.tgz",
+      "integrity": "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw=="
     },
     "update-browserslist-db": {
       "version": "1.0.13",

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -31,7 +31,7 @@
         "ini": "4.1.3",
         "js-yaml": "^4.1.0",
         "jwt-decode": "4.0.0",
-        "lando": "github:automattic/lando-cli.git#1b25a3b",
+        "lando": "github:automattic/lando-cli.git#77dad3a",
         "node-fetch": "^2.6.1",
         "open": "^10.0.0",
         "proxy-from-env": "^1.1.0",
@@ -4625,11 +4625,12 @@
       }
     },
     "node_modules/axios": {
-      "version": "1.6.2",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.6.2.tgz",
-      "integrity": "sha512-7i24Ri4pmDRfJTR7LDBhsOTtcm+9kjX5WiY1X3wIisx6G9So3pfMkEiU7emUBe46oceVImccTEM3k6C5dbVW8A==",
+      "version": "1.7.2",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.7.2.tgz",
+      "integrity": "sha512-2A8QhOMrbomlDuiLeK9XibIBzuHeRcqqNOHp0Cyp5EoJ1IFDh+XZH3A6BkXtv0K4gFGCI0Y4BM7B1wOEi0Rmgw==",
+      "license": "MIT",
       "dependencies": {
-        "follow-redirects": "^1.15.0",
+        "follow-redirects": "^1.15.6",
         "form-data": "^4.0.0",
         "proxy-from-env": "^1.1.0"
       }
@@ -9879,20 +9880,20 @@
     "node_modules/lando": {
       "name": "@lando/cli",
       "version": "3.6.5",
-      "resolved": "git+ssh://git@github.com/automattic/lando-cli.git#1b25a3b388e2b485dd2df9d46c186c437355a600",
+      "resolved": "git+ssh://git@github.com/automattic/lando-cli.git#77dad3a68e4765b9732d33fa9089a9a754f9eb12",
+      "license": "GPL-3.0",
       "dependencies": {
         "@lando/compose": "1.0.0",
         "@lando/mailhog": "0.8.0",
         "@lando/phpmyadmin": "0.5.0",
-        "axios": "^1.6.0",
+        "axios": "^1.7.2",
         "bluebird": "^3.4.1",
-        "cli-table3": "^0.6.4",
-        "copy-dir": "^0.4.0",
+        "cli-table3": "^0.6.5",
+        "copy-dir": "^1.3.0",
         "dockerode": "^4.0.0",
         "glob": "^7.1.3",
         "inquirer": "^6.2.1",
         "inquirer-autocomplete-prompt": "^1.0.1",
-        "ip": "^1.1.9",
         "js-yaml": "^4.1.0",
         "jsonfile": "^6.1.0",
         "lodash": "^4.17.21",
@@ -9923,6 +9924,12 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/lando/node_modules/copy-dir": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/copy-dir/-/copy-dir-1.3.0.tgz",
+      "integrity": "sha512-Q4+qBFnN4bwGwvtXXzbp4P/4iNk0MaiGAzvQ8OiMtlLjkIKjmNN689uVzShSM0908q7GoFHXIPx4zi75ocoaHw==",
+      "license": "MIT"
     },
     "node_modules/lando/node_modules/is-fullwidth-code-point": {
       "version": "3.0.0",
@@ -16767,11 +16774,11 @@
       "dev": true
     },
     "axios": {
-      "version": "1.6.2",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.6.2.tgz",
-      "integrity": "sha512-7i24Ri4pmDRfJTR7LDBhsOTtcm+9kjX5WiY1X3wIisx6G9So3pfMkEiU7emUBe46oceVImccTEM3k6C5dbVW8A==",
+      "version": "1.7.2",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.7.2.tgz",
+      "integrity": "sha512-2A8QhOMrbomlDuiLeK9XibIBzuHeRcqqNOHp0Cyp5EoJ1IFDh+XZH3A6BkXtv0K4gFGCI0Y4BM7B1wOEi0Rmgw==",
       "requires": {
-        "follow-redirects": "^1.15.0",
+        "follow-redirects": "^1.15.6",
         "form-data": "^4.0.0",
         "proxy-from-env": "^1.1.0"
       }
@@ -20557,21 +20564,20 @@
       "dev": true
     },
     "lando": {
-      "version": "git+ssh://git@github.com/automattic/lando-cli.git#1b25a3b388e2b485dd2df9d46c186c437355a600",
-      "from": "lando@github:automattic/lando-cli.git#1b25a3b",
+      "version": "git+ssh://git@github.com/automattic/lando-cli.git#77dad3a68e4765b9732d33fa9089a9a754f9eb12",
+      "from": "lando@github:automattic/lando-cli.git#77dad3a",
       "requires": {
         "@lando/compose": "1.0.0",
         "@lando/mailhog": "0.8.0",
         "@lando/phpmyadmin": "0.5.0",
-        "axios": "^1.6.0",
+        "axios": "^1.7.2",
         "bluebird": "^3.4.1",
-        "cli-table3": "^0.6.4",
-        "copy-dir": "^0.4.0",
+        "cli-table3": "^0.6.5",
+        "copy-dir": "^1.3.0",
         "dockerode": "^4.0.0",
         "glob": "^7.1.3",
         "inquirer": "^6.2.1",
         "inquirer-autocomplete-prompt": "^1.0.1",
-        "ip": "^1.1.9",
         "js-yaml": "^4.1.0",
         "jsonfile": "^6.1.0",
         "lodash": "^4.17.21",
@@ -20593,6 +20599,11 @@
           "version": "5.0.1",
           "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
           "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="
+        },
+        "copy-dir": {
+          "version": "1.3.0",
+          "resolved": "https://registry.npmjs.org/copy-dir/-/copy-dir-1.3.0.tgz",
+          "integrity": "sha512-Q4+qBFnN4bwGwvtXXzbp4P/4iNk0MaiGAzvQ8OiMtlLjkIKjmNN689uVzShSM0908q7GoFHXIPx4zi75ocoaHw=="
         },
         "is-fullwidth-code-point": {
           "version": "3.0.0",

--- a/package.json
+++ b/package.json
@@ -160,7 +160,7 @@
     "ini": "4.1.3",
     "js-yaml": "^4.1.0",
     "jwt-decode": "4.0.0",
-    "lando": "github:automattic/lando-cli.git#1c45a75",
+    "lando": "github:automattic/lando-cli.git#1b25a3b",
     "node-fetch": "^2.6.1",
     "open": "^10.0.0",
     "proxy-from-env": "^1.1.0",

--- a/package.json
+++ b/package.json
@@ -160,7 +160,7 @@
     "ini": "4.1.3",
     "js-yaml": "^4.1.0",
     "jwt-decode": "4.0.0",
-    "lando": "github:automattic/lando-cli.git#1b25a3b",
+    "lando": "github:automattic/lando-cli.git#77dad3a",
     "node-fetch": "^2.6.1",
     "open": "^10.0.0",
     "proxy-from-env": "^1.1.0",

--- a/src/bin/vip-dev-env-start.js
+++ b/src/bin/vip-dev-env-start.js
@@ -64,11 +64,11 @@ command( {
 
 		const startProcessing = new Date();
 
-		const versions = await lando.engine.daemon.getVersions();
 		const trackingInfo = getEnvTrackingInfo( slug );
 		trackingInfo.vscode = Boolean( opt.vscode );
-		trackingInfo.docker = versions.engine;
-		trackingInfo.docker_compose = versions.compose;
+		trackingInfo.docker = lando.config.versions.engine;
+		trackingInfo.docker_compose = lando.config.versions.compose;
+		trackingInfo.compose_plugin = lando.config.versions.composePlugin;
 
 		await trackEvent( 'dev_env_start_command_execute', trackingInfo );
 

--- a/src/lib/dev-environment/dev-environment-cli.ts
+++ b/src/lib/dev-environment/dev-environment-cli.ts
@@ -18,7 +18,7 @@ import {
 	getVersionList,
 	readEnvironmentData,
 } from './dev-environment-core';
-import { validateDockerInstalled, validateDockerAccess } from './dev-environment-lando';
+import { validateDockerInstalled } from './dev-environment-lando';
 import { Args } from '../cli/command';
 import {
 	DEV_ENVIRONMENT_FULL_COMMAND,
@@ -150,8 +150,6 @@ export const validateDependencies = async ( lando: Lando, slug: string ) => {
 	const now = new Date();
 
 	validateDockerInstalled( lando );
-	await validateDockerAccess( lando );
-
 	if ( slug ) {
 		await verifyDNSResolution( slug );
 	}

--- a/src/lib/dev-environment/dev-environment-lando.ts
+++ b/src/lib/dev-environment/dev-environment-lando.ts
@@ -706,7 +706,7 @@ export function validateDockerInstalled( lando: Lando ): void {
 	if ( ! engine ) {
 		if ( ! lando.config.dockerBin ) {
 			throw new UserError(
-				'docker could not be located! Please follow the following instructions to install it - https://docs.docker.com/engine/install/'
+				'docker binary could not be located! Please follow the following instructions to install it - https://docs.docker.com/engine/install/'
 			);
 		}
 
@@ -720,7 +720,7 @@ export function validateDockerInstalled( lando: Lando ): void {
 	if ( ! composePlugin ) {
 		if ( ! compose ) {
 			throw new Error(
-				'docker-compose could not be located! Please follow the following instructions to install it - https://docs.docker.com/compose/install/'
+				'docker-compose binary could not be located! Please follow the following instructions to install it - https://docs.docker.com/compose/install/'
 			);
 		}
 

--- a/src/lib/dev-environment/dev-environment-lando.ts
+++ b/src/lib/dev-environment/dev-environment-lando.ts
@@ -9,6 +9,7 @@ import { lookup } from 'node:dns/promises';
 import { mkdir, rename } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import path, { dirname } from 'node:path';
+import { satisfies } from 'semver';
 import xdgBasedir from 'xdg-basedir';
 
 import {
@@ -206,6 +207,7 @@ export async function bootstrapLando(): Promise< Lando > {
 			}
 
 			const pull = registryResolvable && ( instanceData.pullAfter ?? 0 ) < Date.now();
+			console.log( pull );
 			if (
 				Array.isArray( data.opts.pullable ) &&
 				Array.isArray( data.opts.local ) &&
@@ -216,6 +218,7 @@ export async function bootstrapLando(): Promise< Lando > {
 				// Note that if some of the images are not available, they will still be pulled by `docker-compose`.
 				data.opts.local = data.opts.pullable;
 				data.opts.pullable = [];
+				console.log( data.opts );
 			}
 
 			if ( pull || ! instanceData.pullAfter ) {
@@ -693,28 +696,38 @@ async function ensureNoOrphantProxyContainer( lando: Lando ): Promise< void > {
 }
 
 export function validateDockerInstalled( lando: Lando ): void {
-	lando.log.verbose( 'docker-engine exists: %s', lando.engine.dockerInstalled );
-	if ( ! lando.engine.dockerInstalled ) {
-		throw new UserError(
-			'docker could not be located! Please follow the following instructions to install it - https://docs.docker.com/engine/install/'
-		);
-	}
-	lando.log.verbose( 'docker-compose exists: %s', lando.engine.composeInstalled );
-	if ( ! lando.engine.composeInstalled ) {
-		throw Error(
-			'docker-compose could not be located! Please follow the following instructions to install it - https://docs.docker.com/compose/install/'
-		);
-	}
-}
+	const { engine, composePlugin, compose } = lando.config.versions as {
+		engine: string;
+		composePlugin: string;
+		compose: string;
+	};
 
-export async function validateDockerAccess( lando: Lando ): Promise< void > {
-	const docker = lando.engine.docker;
-	lando.log.verbose( 'Fetching docker info to verify Docker connection' );
-	try {
-		await docker.info();
-	} catch ( error ) {
+	lando.log.verbose( 'docker-engine version: %s', engine );
+	if ( ! engine ) {
+		if ( ! lando.config.dockerBin ) {
+			throw new UserError(
+				'docker could not be located! Please follow the following instructions to install it - https://docs.docker.com/engine/install/'
+			);
+		}
+
 		throw new UserError(
 			'Failed to connect to Docker. Please verify that Docker engine (service) is running and follow the troubleshooting instructions for your platform.'
 		);
+	}
+	lando.log.verbose( 'docker-compose version: %s', compose );
+	lando.log.verbose( 'compose plugin version: %s', composePlugin );
+
+	if ( ! composePlugin ) {
+		if ( ! compose ) {
+			throw new Error(
+				'docker-compose could not be located! Please follow the following instructions to install it - https://docs.docker.com/compose/install/'
+			);
+		}
+
+		if ( ! satisfies( compose, '^2.0.0' ) ) {
+			throw new Error(
+				`docker-compose version ${ compose } is not supported. Please upgrade to version 2.0.0 or higher - https://docs.docker.com/compose/install/`
+			);
+		}
 	}
 }


### PR DESCRIPTION
## Description

Update `lando` to Automattic/lando-cli@77dad3a

This removes support for docker-compose v1 and adds support for the compose plugin.

## Pull request checklist

- [ ] Update [SETUP.md](https://github.com/Automattic/vip-cli/blob/trunk/docs/SETUP.md#list-of-environmental-variables) with any new environmental variables.
- [ ] Update [the documentation](https://github.com/Automattic/vip-cli/blob/trunk/docs).
- [x] [Manually test](https://github.com/Automattic/vip-cli/blob/trunk/docs/TESTING.md#manual-testing) the relevant changes.
- [ ] Follow the [pull request checklist](https://github.com/Automattic/vip-cli/blob/trunk/docs/RELEASING.md#new-pull-requests)
- [ ] Add/update [automated tests](https://github.com/Automattic/vip-cli/blob/trunk/docs/TESTING.md#automated-testing) as needed.

## New release checklist

- [ ] [Automated tests](https://github.com/Automattic/vip-cli/blob/trunk/docs/TESTING.md#automated-testing) pass.
- [ ] The [Preparing for release checklist](https://github.com/Automattic/vip-cli/blob/trunk/docs/RELEASING.md#preparing-for-release) is completed.

## Steps to Test

E2E tests should pass.
