### PR TITLE
fix(dev-env): demo code is displayed as `[demo-image]`

### DIFF
--- a/src/lib/dev-environment/dev-environment-cli.ts
+++ b/src/lib/dev-environment/dev-environment-cli.ts
@@ -231,7 +231,7 @@ interface LocalComponent {
 
 interface ImageComponent {
 	mode: 'image';
-	tag: string;
+	tag: string | undefined;
 }
 
 export function processComponentOptionInput(
@@ -258,7 +258,7 @@ export function processComponentOptionInput(
 
 	return {
 		mode: 'image',
-		tag: param,
+		tag: param === 'demo' ? undefined : param,
 	};
 }
 
@@ -412,10 +412,10 @@ async function processWordPress(
 	let result: WordPressConfig;
 	const allowLocal = false;
 	const defaultObject = defaultValue
-		? processComponentOptionInput( defaultValue, allowLocal )
+		? ( processComponentOptionInput( defaultValue, allowLocal ) as WordPressConfig )
 		: null;
 	if ( preselectedValue ) {
-		result = processComponentOptionInput( preselectedValue, allowLocal );
+		result = processComponentOptionInput( preselectedValue, allowLocal ) as WordPressConfig;
 	} else {
 		result = await promptForWordPress( defaultObject );
 	}

--- a/src/lib/dev-environment/dev-environment-core.ts
+++ b/src/lib/dev-environment/dev-environment-core.ts
@@ -305,6 +305,12 @@ function parseComponentForInfo( component: ComponentConfig | WordPressConfig ): 
 	if ( component.mode === 'local' ) {
 		return component.dir ?? '';
 	}
+
+	// Environments created by the old code will have `component.tag` set to `demo` instead of `undefined`.
+	if ( component.tag === 'demo' ) {
+		component.tag = undefined;
+	}
+
 	return component.tag ?? '[demo-image]';
 }
 


### PR DESCRIPTION
## Description

There was an inconsistency in how the demo code was displayed in `vip dev-env info --extended`.
For example, if we invoke `vip dev-env create -u demo < /dev/null`, both MU Plugins and the Application Code will use a demo image, but it will be displayed differently:

```
$ vip dev-env info --extended | grep -E 'PLUGINS|CODE'
 MU PLUGINS        demo                                                                                               
 APP CODE          [demo-image]                                                                                       
```

This PR makes this consistent: `[demo-image]`

## Pull request checklist

- [ ] Update [SETUP.md](https://github.com/Automattic/vip-cli/blob/trunk/docs/SETUP.md#list-of-environmental-variables) with any new environmental variables.
- [ ] Update [the documentation](https://github.com/Automattic/vip-cli/blob/trunk/docs).
- [x] [Manually test](https://github.com/Automattic/vip-cli/blob/trunk/docs/TESTING.md#manual-testing) the relevant changes.
- [x] Follow the [pull request checklist](https://github.com/Automattic/vip-cli/blob/trunk/docs/RELEASING.md#new-pull-requests)
- [ ] Add/update [automated tests](https://github.com/Automattic/vip-cli/blob/trunk/docs/TESTING.md#automated-testing) as needed.

## New release checklist

- [ ] [Automated tests](https://github.com/Automattic/vip-cli/blob/trunk/docs/TESTING.md#automated-testing) pass.
- [ ] The [Preparing for release checklist](https://github.com/Automattic/vip-cli/blob/trunk/docs/RELEASING.md#preparing-for-release) is completed.

## Steps to Test

See above.
