### PR TITLE
feat(dev-env): make `domain` configurable

### DIFF
--- a/__tests__/lib/dev-environment/dev-environment-core.js
+++ b/__tests__/lib/dev-environment/dev-environment-core.js
@@ -63,7 +63,7 @@ describe( 'lib/dev-environment/dev-environment-core', () => {
 			const slug = 'foo';
 			jest.spyOn( fs, 'existsSync' ).mockReturnValueOnce( true );
 
-			const promise = createEnvironment( { siteSlug: slug } );
+			const promise = createEnvironment( {}, { siteSlug: slug } );
 
 			return expect( promise ).rejects.toEqual( new Error( 'Environment already exists.' ) );
 		} );

--- a/assets/dev-env.lando.template.yml.ejs
+++ b/assets/dev-env.lando.template.yml.ejs
@@ -3,14 +3,14 @@ env_file:
   - .env
 proxy:
   nginx:
-    - <%= siteSlug %>.vipdev.lndo.site
+    - <%= siteSlug %>.<%= domain %>
 <% if ( multisite ) { %>
-    - '*.<%= siteSlug %>.vipdev.lndo.site'
+    - '*.<%= siteSlug %>.<%= domain %>'
 <% } %>
   phpmyadmin:
-    - <%= siteSlug %>-pma.vipdev.lndo.site
+    - <%= siteSlug %>-pma.<%= domain %>
   mailpit:
-    - <%= siteSlug %>-mailpit.vipdev.lndo.site:8025
+    - <%= siteSlug %>-mailpit.<%= domain %>:8025
 
 services:
   devtools:
@@ -79,9 +79,9 @@ services:
         sh /dev-tools/setup.sh
         --host database
         --user root
-        --domain "http://<%= siteSlug %>.vipdev.lndo.site/"
+        --domain "http://<%= siteSlug %>.<%= domain %>/"
         --title "<%= wpTitle %>"
-        <% if ( multisite ) { %>--ms-domain "<%= siteSlug %>.vipdev.lndo.site" <% if ( multisite === true || multisite === 'subdomain' ) { %>--subdomain <% } %> <% } %>
+        <% if ( multisite ) { %>--ms-domain "<%= siteSlug %>.<%= domain %>" <% if ( multisite === true || multisite === 'subdomain' ) { %>--subdomain <% } %> <% } %>
   database:
     type: compose
     services:

--- a/src/bin/vip-dev-env-create.js
+++ b/src/bin/vip-dev-env-create.js
@@ -155,7 +155,7 @@ cmd.argv( process.argv, async ( arg, opt ) => {
 	instanceData.siteSlug = slug;
 
 	try {
-		await createEnvironment( instanceData );
+		await createEnvironment( lando, instanceData );
 
 		await printEnvironmentInfo( lando, slug, { extended: false, suppressWarnings: true } );
 

--- a/src/bin/vip-dev-env-update.js
+++ b/src/bin/vip-dev-env-update.js
@@ -128,7 +128,7 @@ cmd.argv( process.argv, async ( arg, opt ) => {
 		);
 		instanceData.siteSlug = slug;
 
-		await updateEnvironment( instanceData );
+		await updateEnvironment( lando, instanceData );
 
 		const message =
 			'\n' +

--- a/src/lib/dev-environment/dev-environment-core.ts
+++ b/src/lib/dev-environment/dev-environment-core.ts
@@ -113,9 +113,9 @@ export async function startEnvironment(
 
 	let updated = false;
 	if ( ! options.skipWpVersionsCheck ) {
-		updated = await maybeUpdateWordPressImage( slug );
+		updated = await maybeUpdateWordPressImage( lando, slug );
 	}
-	updated = updated || ( await maybeUpdateVersion( slug ) );
+	updated = updated || ( await maybeUpdateVersion( lando, slug ) );
 
 	if ( options.skipRebuild && ! updated ) {
 		await landoStart( lando, instancePath );
@@ -142,7 +142,10 @@ export async function stopEnvironment( lando: Lando, slug: string ): Promise< vo
 	await landoStop( lando, instancePath );
 }
 
-export async function createEnvironment( instanceData: InstanceData ): Promise< void > {
+export async function createEnvironment(
+	lando: Lando,
+	instanceData: InstanceData
+): Promise< void > {
 	const slug = instanceData.siteSlug;
 	debug( 'Will process an environment', slug, 'with instanceData for creation: ', instanceData );
 
@@ -159,10 +162,13 @@ export async function createEnvironment( instanceData: InstanceData ): Promise< 
 	const preProcessedInstanceData = preProcessInstanceData( instanceData );
 	debug( 'Will create an environment', slug, 'with instanceData: ', preProcessedInstanceData );
 
-	await prepareLandoEnv( preProcessedInstanceData, instancePath );
+	await prepareLandoEnv( lando, preProcessedInstanceData, instancePath );
 }
 
-export async function updateEnvironment( instanceData: InstanceData ): Promise< void > {
+export async function updateEnvironment(
+	lando: Lando,
+	instanceData: InstanceData
+): Promise< void > {
 	const slug = instanceData.siteSlug;
 	debug( 'Will process an environment', slug, 'with instanceData for updating: ', instanceData );
 
@@ -179,7 +185,7 @@ export async function updateEnvironment( instanceData: InstanceData ): Promise< 
 	const preProcessedInstanceData = preProcessInstanceData( instanceData );
 	debug( 'Will create an environment', slug, 'with instanceData: ', preProcessedInstanceData );
 
-	await prepareLandoEnv( preProcessedInstanceData, instancePath );
+	await prepareLandoEnv( lando, preProcessedInstanceData, instancePath );
 }
 
 function preProcessInstanceData( instanceData: InstanceData ): InstanceData {
@@ -470,11 +476,17 @@ export function writeEnvironmentData( slug: string, data: InstanceData ): Promis
 }
 
 async function prepareLandoEnv(
+	lando: Lando,
 	instanceData: InstanceData,
 	instancePath: string
 ): Promise< void > {
-	const landoFile = await ejs.renderFile( landoFileTemplatePath, instanceData );
-	const nginxFile = await ejs.renderFile( nginxFileTemplatePath, instanceData );
+	const templateData = {
+		...instanceData,
+		domain: lando.config.domain,
+	};
+
+	const landoFile = await ejs.renderFile( landoFileTemplatePath, templateData );
+	const nginxFile = await ejs.renderFile( nginxFileTemplatePath, templateData );
 	const instanceDataFile = JSON.stringify( instanceData );
 
 	const landoFileTargetPath = path.join( instancePath, landoFileName );
@@ -697,7 +709,7 @@ export async function importMediaPath( slug: string, filePath: string ) {
  * @param {string} slug slug
  * @return {boolean} boolean
  */
-async function maybeUpdateWordPressImage( slug: string ): Promise< boolean > {
+async function maybeUpdateWordPressImage( lando: Lando, slug: string ): Promise< boolean > {
 	const versions = await getVersionList();
 	if ( ! versions.length ) {
 		return false;
@@ -785,7 +797,7 @@ async function maybeUpdateWordPressImage( slug: string ): Promise< boolean > {
 		envData.wordpress.tag = version?.tag ?? '';
 		envData.wordpress.ref = version?.ref;
 
-		await updateEnvironment( envData );
+		await updateEnvironment( lando, envData );
 
 		return true;
 	}
@@ -794,19 +806,19 @@ async function maybeUpdateWordPressImage( slug: string ): Promise< boolean > {
 		envData.wordpress.doNotUpgrade = true;
 		console.log( "We won't ask about upgrading this environment anymore." );
 		console.log( `To manually upgrade please run: ${ chalk.yellow( updateCommand ) }` );
-		await updateEnvironment( envData );
+		await updateEnvironment( lando, envData );
 	}
 
 	return false;
 }
 
-async function maybeUpdateVersion( slug: string ): Promise< boolean > {
+async function maybeUpdateVersion( lando: Lando, slug: string ): Promise< boolean > {
 	const envData = readEnvironmentData( slug );
 	const currentVersion = envData.version;
 
 	console.log( 'Current local environment version is: ' + chalk.yellow( currentVersion ) );
 	if ( ! currentVersion || semver.lt( currentVersion, DEV_ENVIRONMENT_VERSION ) ) {
-		await updateEnvironment( envData );
+		await updateEnvironment( lando, envData );
 		console.log(
 			'Local environment version updated to: ' + chalk.green( DEV_ENVIRONMENT_VERSION )
 		);

--- a/src/lib/dev-environment/dev-environment-lando.ts
+++ b/src/lib/dev-environment/dev-environment-lando.ts
@@ -110,7 +110,7 @@ async function initLandoApplication( lando: Lando, instancePath: string ): Promi
 	return app;
 }
 
-async function regenerateLandofile( instancePath: string ): Promise< void > {
+async function regenerateLandofile( lando: Lando, instancePath: string ): Promise< void > {
 	const landoFile = path.join( instancePath, '.lando.yml' );
 
 	try {
@@ -125,14 +125,14 @@ async function regenerateLandofile( instancePath: string ): Promise< void > {
 	const slug = path.basename( instancePath );
 	const currentInstanceData = readEnvironmentData( slug );
 	currentInstanceData.pullAfter = 0;
-	await updateEnvironment( currentInstanceData );
+	await updateEnvironment( lando, currentInstanceData );
 }
 
 async function landoRecovery( lando: Lando, instancePath: string, error: unknown ): Promise< App > {
 	debug( 'Error initializing Lando app', error );
 	console.warn( chalk.yellow( 'There was an error initializing Lando, trying to recover...' ) );
 	try {
-		await regenerateLandofile( instancePath );
+		await regenerateLandofile( lando, instancePath );
 	} catch ( err ) {
 		console.error(
 			`${ chalk.bold.red(


### PR DESCRIPTION
## Description

It is possible to override the default domain (`vipdev.lndo.site`) by setting

```yaml
domain: my.custom.domain
```

in `~/.local/share/vip/lando/config.yml`.

However, the system is hardcoded to use `vipdev.lndo.site`, no matter what.

This PR fixes that.

Marking this PR as a "feature" because this is not documented: neither by us, nor by Lando.

## Pull request checklist

- [ ] Update [SETUP.md](https://github.com/Automattic/vip-cli/blob/trunk/docs/SETUP.md#list-of-environmental-variables) with any new environmental variables.
- [ ] Update [the documentation](https://github.com/Automattic/vip-cli/blob/trunk/docs).
- [x] [Manually test](https://github.com/Automattic/vip-cli/blob/trunk/docs/TESTING.md#manual-testing) the relevant changes.
- [x] Follow the [pull request checklist](https://github.com/Automattic/vip-cli/blob/trunk/docs/RELEASING.md#new-pull-requests)
- [ ] Add/update [automated tests](https://github.com/Automattic/vip-cli/blob/trunk/docs/TESTING.md#automated-testing) as needed.

## New release checklist

- [ ] [Automated tests](https://github.com/Automattic/vip-cli/blob/trunk/docs/TESTING.md#automated-testing) pass.
- [ ] The [Preparing for release checklist](https://github.com/Automattic/vip-cli/blob/trunk/docs/RELEASING.md#preparing-for-release) is completed.

## Steps to Test

1. `mkdir -p ~/.local/share/vip/lando; echo "domain: localtest.me" > ~/.local/share/vip/lando/config.yml`
2. `vip dev-env create < /dev/null`
3. The output should contain references to `localtest.me`, like this:

```
 SLUG              vip-local                                                                                           
 LOCATION          /home/volodymyr/.local/share/vip/dev-environment/vip-local                                          
 SERVICES          devtools, nginx, php, database, memcached, wordpress, vip-mu-plugins, demo-app-code                 
 NGINX URLS        http://vip-local.localtest.me:8000/                                                                 
                   https://vip-local.localtest.me/                                                                     
 STATUS            DOWN                                                                                                
 LOGIN URL         http://vip-local.localtest.me:8000/wp-admin/?vip-dev-autologin=e81ab483-12ff-41ba-a81c-d69175a61f3b 
 DEFAULT USERNAME  vipgo                                                                                               
 DEFAULT PASSWORD  password                                                                                            
 DOCUMENTATION     https://docs.wpvip.com/vip-local-development-environment/                                           
```

4. `vip dev-env start`
5. The output should contain something like this:
```
setupca 09:20:43.79 INFO  ==> Looks like you do not have a Lando CA yet! Let's set one up!
setupca 09:20:43.79 INFO  ==> Trying to setup root CA with...
setupca 09:20:43.79 INFO  ==> LANDO_CA_CERT: /lando/certs/localtest.me.pem
setupca 09:20:43.79 INFO  ==> LANDO_CA_KEY: /lando/certs/localtest.me.key
setupca 09:20:43.79 INFO  ==> /lando/certs/localtest.me.key not found... generating one
Generating RSA private key, 2048 bit long modulus (2 primes)
......+++++
................................................................+++++
e is 65537 (0x010001)
setupca 09:20:43.83 INFO  ==> /lando/certs/localtest.me.pem not found... generating one
setupca 09:20:43.84 INFO  ==> CA generated at /lando/certs/localtest.me.pem
```

and this:

```
 SLUG              vip-local                                                                                      
 LOCATION          /home/volodymyr/.local/share/vip/dev-environment/vip-local                                     
 SERVICES          devtools, nginx, php, database, memcached, wordpress, vip-mu-plugins, demo-app-code            
 NGINX URLS        http://vip-local.localtest.me/                                                                 
                   https://vip-local.localtest.me/                                                                
 DATABASE          127.0.0.1:32769                                                                                
 STATUS            UP                                                                                             
 LOGIN URL         http://vip-local.localtest.me/wp-admin/?vip-dev-autologin=e81ab483-12ff-41ba-a81c-d69175a61f3b 
 DEFAULT USERNAME  vipgo                                                                                          
 DEFAULT PASSWORD  password                                                                                       
 DOCUMENTATION     https://docs.wpvip.com/vip-local-development-environment/                                      
```
6. `http://vip-local.localtest.me/` should work.

**Caveat:** pre-existing environments may cease to work because they were configured with a diffeent domain. This is Lando's limitation. Only one domain is allowed.