### PR TITLE
fix(dev-env): allow for unsetting media redirect domain

### DIFF
--- a/__tests__/lib/dev-environment/dev-environment-cli.js
+++ b/__tests__/lib/dev-environment/dev-environment-cli.js
@@ -397,7 +397,7 @@ describe( 'lib/dev-environment/dev-environment-cli', () => {
 			prompt.mockResolvedValue( { input: input.default.title } );
 			selectRunMock.mockResolvedValue( '' );
 
-			const result = await promptForArguments( input.preselected, input.default );
+			const result = await promptForArguments( input.preselected, input.default, false, true );
 
 			if ( input.preselected.title ) {
 				expect( prompt ).toHaveBeenCalledTimes( 1 );
@@ -463,7 +463,7 @@ describe( 'lib/dev-environment/dev-environment-cli', () => {
 			confirmRunMock.mockResolvedValue( input.default.multisite );
 			selectRunMock.mockResolvedValue( '' );
 
-			const result = await promptForArguments( input.preselected, input.default );
+			const result = await promptForArguments( input.preselected, input.default, false, true );
 
 			if ( 'multisite' in input.preselected ) {
 				expect( prompt ).toHaveBeenCalledTimes( 0 );
@@ -503,7 +503,7 @@ describe( 'lib/dev-environment/dev-environment-cli', () => {
 			confirmRunMock.mockResolvedValue( input.default.mediaRedirectDomain );
 			selectRunMock.mockResolvedValue( '' );
 
-			const result = await promptForArguments( input.preselected, input.default );
+			const result = await promptForArguments( input.preselected, input.default, false, true );
 
 			if ( input.preselected.mediaRedirectDomain ) {
 				expect( confirmRunMock ).toHaveBeenCalledTimes( 5 );
@@ -541,7 +541,7 @@ describe( 'lib/dev-environment/dev-environment-cli', () => {
 		] )( 'should handle mariadb', async input => {
 			selectRunMock.mockResolvedValue( '' );
 
-			const result = await promptForArguments( input.preselected, input.default );
+			const result = await promptForArguments( input.preselected, input.default, false, true );
 
 			const expectedMaria = input.preselected.mariadb
 				? input.preselected.mariadb

--- a/src/bin/vip-dev-env-create.js
+++ b/src/bin/vip-dev-env-create.js
@@ -150,7 +150,8 @@ cmd.argv( process.argv, async ( arg, opt ) => {
 	const instanceData = await promptForArguments(
 		preselectedOptions,
 		defaultOptions,
-		suppressPrompts
+		suppressPrompts,
+		true
 	);
 	instanceData.siteSlug = slug;
 

--- a/src/bin/vip-dev-env-update.js
+++ b/src/bin/vip-dev-env-update.js
@@ -124,7 +124,8 @@ cmd.argv( process.argv, async ( arg, opt ) => {
 		const instanceData = await promptForArguments(
 			finalPreselectedOptions,
 			defaultOptions,
-			suppressPrompts
+			suppressPrompts,
+			false
 		);
 		instanceData.siteSlug = slug;
 

--- a/src/lib/dev-environment/dev-environment-cli.ts
+++ b/src/lib/dev-environment/dev-environment-cli.ts
@@ -285,7 +285,8 @@ export function getOptionsFromAppInfo( appInfo: AppInfo ): InstanceOptions {
 export async function promptForArguments(
 	preselectedOptions: InstanceOptions,
 	defaultOptions: InstanceOptions,
-	suppressPrompts: boolean = false
+	suppressPrompts: boolean,
+	create: boolean
 ): Promise< InstanceData > {
 	debug( 'Provided preselected', preselectedOptions, 'and default', defaultOptions );
 
@@ -349,7 +350,7 @@ export async function promptForArguments(
 		photon: 'Photon',
 	};
 
-	if ( ! instanceData.mediaRedirectDomain && defaultOptions.mediaRedirectDomain ) {
+	if ( create && ! instanceData.mediaRedirectDomain && defaultOptions.mediaRedirectDomain ) {
 		const mediaRedirectPromptText = `Would you like to redirect to ${ defaultOptions.mediaRedirectDomain } for missing media files?`;
 		const setMediaRedirectDomain = await promptForBoolean( mediaRedirectPromptText, true );
 		if ( setMediaRedirectDomain ) {
@@ -784,13 +785,40 @@ export async function promptForComponent(
 const FALSE_OPTIONS = [ 'false', 'no', 'n', '0' ] as const;
 const TRUE_OPTIONS = [ 'true', 'yes', 'y', '1' ] as const;
 
+declare global {
+	// eslint-disable-next-line @typescript-eslint/no-unused-vars
+	interface ReadonlyArray< T > {
+		/**
+		 * Determines whether an array includes a certain element, returning true or false as appropriate.
+		 * @param searchElement The element to search for.
+		 * @param fromIndex The position in this array at which to begin searching for searchElement.
+		 */
+		includes( searchElement: unknown, fromIndex?: number ): boolean;
+	}
+}
+
 export function processBooleanOption( value: unknown ): boolean {
 	if ( ! value ) {
 		return false;
 	}
 
 	// eslint-disable-next-line @typescript-eslint/no-base-to-string
-	return ! ( FALSE_OPTIONS as readonly string[] ).includes( value.toString().toLowerCase() ); // NOSONAR
+	return ! FALSE_OPTIONS.includes( value.toString().toLowerCase() ); // NOSONAR
+}
+
+export function processMediaRedirectDomainOption( value: unknown ): string {
+	// eslint-disable-next-line @typescript-eslint/no-base-to-string
+	const val = ( value ?? '' ).toString();
+
+	if ( FALSE_OPTIONS.includes( val.toLowerCase() ) ) {
+		return '';
+	}
+
+	if ( TRUE_OPTIONS.includes( val.toLowerCase() ) ) {
+		throw new UserError( 'Media redirect domain must be a domain name or an URL' );
+	}
+
+	return val;
 }
 
 export function processStringOrBooleanOption( value: string | boolean ): string | boolean {
@@ -798,11 +826,11 @@ export function processStringOrBooleanOption( value: string | boolean ): string 
 		return value;
 	}
 
-	if ( ! value || ( FALSE_OPTIONS as readonly string[] ).includes( value.toLowerCase() ) ) {
+	if ( ! value || FALSE_OPTIONS.includes( value.toLowerCase() ) ) {
 		return false;
 	}
 
-	if ( ( TRUE_OPTIONS as readonly string[] ).includes( value.toLowerCase() ) ) {
+	if ( TRUE_OPTIONS.includes( value.toLowerCase() ) ) {
 		return true;
 	}
 
@@ -855,7 +883,9 @@ export function addDevEnvConfigurationOptions( command: Args ): Args {
 		)
 		.option(
 			[ 'r', 'media-redirect-domain' ],
-			'Domain to redirect for missing media files. This can be used to still have images without the need to import them locally.'
+			'Domain to redirect for missing media files. This can be used to still have images without the need to import them locally.',
+			undefined,
+			processMediaRedirectDomainOption
 		)
 		.option( 'php', 'Explicitly choose PHP version to use', undefined, processVersionOption )
 		.option(


### PR DESCRIPTION
## Description

Fixes: #1861

## Pull request checklist

- [ ] Update [SETUP.md](https://github.com/Automattic/vip-cli/blob/trunk/docs/SETUP.md#list-of-environmental-variables) with any new environmental variables.
- [ ] Update [the documentation](https://github.com/Automattic/vip-cli/blob/trunk/docs).
- [x] [Manually test](https://github.com/Automattic/vip-cli/blob/trunk/docs/TESTING.md#manual-testing) the relevant changes.
- [x] Follow the [pull request checklist](https://github.com/Automattic/vip-cli/blob/trunk/docs/RELEASING.md#new-pull-requests)
- [ ] Add/update [automated tests](https://github.com/Automattic/vip-cli/blob/trunk/docs/TESTING.md#automated-testing) as needed.

## New release checklist

- [ ] [Automated tests](https://github.com/Automattic/vip-cli/blob/trunk/docs/TESTING.md#automated-testing) pass.
- [ ] The [Preparing for release checklist](https://github.com/Automattic/vip-cli/blob/trunk/docs/RELEASING.md#preparing-for-release) is completed.

## Steps to Test

```sh
npm run build
vip dev-env create -r example.com < /dev/null
jq .mediaRedirectDomain ~/.local/share/vip/dev-environment/vip-local/instance_data.json
# "https://example.com"
vip dev-env update -r n < /dev/null
jq .mediaRedirectDomain ~/.local/share/vip/dev-environment/vip-local/instance_data.json
# "https://example.com" - without this patch
# "" - with this patch
```
