### PR TITLE
fix(dev-env): make sure wildcard subdomains work with SSL/TLS

### DIFF
--- a/assets/dev-env.lando.template.yml.ejs
+++ b/assets/dev-env.lando.template.yml.ejs
@@ -38,7 +38,6 @@ services:
       image: ghcr.io/automattic/vip-container-images/nginx:latest
       command: nginx -g "daemon off;"
       environment:
-        LANDO_NO_SCRIPTS: 1
         LANDO_NEEDS_EXEC: 1
       volumes:
         - ./nginx/extra.conf:/etc/nginx/conf.extra/extra.conf
@@ -226,7 +225,6 @@ services:
         - ":8025"
       environment:
         LANDO_NO_USER_PERMS: 1
-        LANDO_NO_SCRIPTS: 1
         LANDO_NEEDS_EXEC: 1
 <% } %>
 


### PR DESCRIPTION
## Description

Accessing a subdomain of a network WordPress site (like `https://xxx.vip-local.vipdev.lndo.site/`) generates an SSL error (`SSL_ERROR_BAD_CERT_DOMAIN`).

This PR fixes that.

## Pull request checklist

- [ ] Update [SETUP.md](https://github.com/Automattic/vip-cli/blob/trunk/docs/SETUP.md#list-of-environmental-variables) with any new environmental variables.
- [ ] Update [the documentation](https://github.com/Automattic/vip-cli/blob/trunk/docs).
- [x] [Manually test](https://github.com/Automattic/vip-cli/blob/trunk/docs/TESTING.md#manual-testing) the relevant changes.
- [x] Follow the [pull request checklist](https://github.com/Automattic/vip-cli/blob/trunk/docs/RELEASING.md#new-pull-requests)
- [ ] Add/update [automated tests](https://github.com/Automattic/vip-cli/blob/trunk/docs/TESTING.md#automated-testing) as needed.

## New release checklist

- [ ] [Automated tests](https://github.com/Automattic/vip-cli/blob/trunk/docs/TESTING.md#automated-testing) pass.
- [ ] The [Preparing for release checklist](https://github.com/Automattic/vip-cli/blob/trunk/docs/RELEASING.md#preparing-for-release) is completed.

## Steps to Test

1. `vip dev-env create --multisite < /dev/null`
2. Log in and create a subsite.
3. Verify that the newly created subdomain opened and does not generate SSL errors.
