### PR TITLE
vip app deploy: Deprecate force and add skip-confirmation

### DIFF
--- a/src/bin/vip-app-deploy.ts
+++ b/src/bin/vip-app-deploy.ts
@@ -105,9 +105,9 @@ export async function appDeployCmd( arg: string[] = [], opts: Record< string, un
 	fileMeta.basename = `${ datePrefix }-${ fileMeta.basename }`;
 
 	const deployMessage = ( opts.message as string ) ?? '';
-	const forceDeploy = opts.force;
+	const skipConfirm = opts.force || opts.skipConfirmation;
 
-	if ( ! forceDeploy ) {
+	if ( ! skipConfirm ) {
 		const promptParams: PromptToContinueParams = {
 			launched: Boolean( validatedArgs.launched ),
 			formattedEnvironment: formatEnvironment( validatedArgs.envType ),
@@ -260,7 +260,7 @@ const examples = [
 		description: 'Deploy the given compressed file to your site',
 	},
 	{
-		usage: 'vip app @mysite.develop deploy file.zip --force',
+		usage: 'vip app @mysite.develop deploy file.zip --skip-confirmation',
 		description: 'Deploy the given compressed file to your site without prompting',
 	},
 ];
@@ -270,7 +270,8 @@ void command( {
 } )
 	.examples( examples )
 	.option( 'message', 'Custom message for deploy' )
-	.option( 'force', 'Skip prompt' )
+	.option( 'skip-confirmation', 'Skip confirmation prompt' )
+	.option( 'force', 'Skip confirmation prompt (deprecated)' )
 	.option( 'app', 'The application name or ID' )
 	.option( 'env', 'The environment name or ID' )
 	.argv( process.argv, appDeployCmd );


### PR DESCRIPTION
## Description

This adds `--skip-confirmation` and marks `--force` as deprecated in the help menu. However, no functionality will change, it will be truly deprecated a few versions down.

## Pull request checklist

- [ ] Update [SETUP.md](https://github.com/Automattic/vip-cli/blob/trunk/docs/SETUP.md#list-of-environmental-variables) with any new environmental variables.
- [ ] Update [the documentation](https://github.com/Automattic/vip-cli/blob/trunk/docs).
- [x] [Manually test](https://github.com/Automattic/vip-cli/blob/trunk/docs/TESTING.md#manual-testing) the relevant changes.
- [ ] Follow the [pull request checklist](https://github.com/Automattic/vip-cli/blob/trunk/docs/RELEASING.md#new-pull-requests)
- [ ] Add/update [automated tests](https://github.com/Automattic/vip-cli/blob/trunk/docs/TESTING.md#automated-testing) as needed.

## New release checklist

- [ ] [Automated tests](https://github.com/Automattic/vip-cli/blob/trunk/docs/TESTING.md#automated-testing) pass.
- [ ] The [Preparing for release checklist](https://github.com/Automattic/vip-cli/blob/trunk/docs/RELEASING.md#preparing-for-release) is completed.

## Steps to Test

```
WPVIP_DEPLOY_TOKEN=<token> vip @<id>.production app deploy ~/Desktop/vip-go-skele
ton.zip --skip-confirmation
```
Ensure no prompts arise. Test the same with `--force` to ensure it still works as expected.