### PR TITLE
fix(dev-env): force pull images on environment version update

### DIFF
--- a/src/lib/dev-environment/dev-environment-core.ts
+++ b/src/lib/dev-environment/dev-environment-core.ts
@@ -821,6 +821,7 @@ async function maybeUpdateVersion( lando: Lando, slug: string ): Promise< boolea
 
 	console.log( 'Current local environment version is: ' + chalk.yellow( currentVersion ) );
 	if ( ! currentVersion || semver.lt( currentVersion, DEV_ENVIRONMENT_VERSION ) ) {
+		envData.pullAfter = undefined;
 		await updateEnvironment( lando, envData );
 		console.log(
 			'Local environment version updated to: ' + chalk.green( DEV_ENVIRONMENT_VERSION )


### PR DESCRIPTION
## Description

When we update the version of the dev environment, we need to make Lando pull images because our changes to `.lando.yml` may include image versions.

This fixes the bug seen in #1816: because `pullAfter` was not updated, Lando did not pull the `mysql` image, although its version changed from `8` to `8.4`.

Fixes: #1814

## Pull request checklist

- [ ] Update [SETUP.md](https://github.com/Automattic/vip-cli/blob/trunk/docs/SETUP.md#list-of-environmental-variables) with any new environmental variables.
- [ ] Update [the documentation](https://github.com/Automattic/vip-cli/blob/trunk/docs).
- [x] [Manually test](https://github.com/Automattic/vip-cli/blob/trunk/docs/TESTING.md#manual-testing) the relevant changes.
- [x] Follow the [pull request checklist](https://github.com/Automattic/vip-cli/blob/trunk/docs/RELEASING.md#new-pull-requests)
- [ ] Add/update [automated tests](https://github.com/Automattic/vip-cli/blob/trunk/docs/TESTING.md#automated-testing) as needed.

## New release checklist

- [ ] [Automated tests](https://github.com/Automattic/vip-cli/blob/trunk/docs/TESTING.md#automated-testing) pass.
- [ ] The [Preparing for release checklist](https://github.com/Automattic/vip-cli/blob/trunk/docs/RELEASING.md#preparing-for-release) is completed.

## Steps to Test

1. Install `@automattic/vip@2.39.3`, create and start an environment. It will not start because of the authentication issue with MySQL.
2. Apply the patch, `npm run build && npm link`, restart the environment.
3. Observe that Lando pulls (or attempts to pull) the new version of the image.
4. The environment won't start anyway ("The privilege system failed to initialize correctly"), but that's a different issue that has to be solved on the image level.
