### PR TITLE
feat(dev-env): add support for cron

### DIFF
--- a/__tests__/devenv-e2e/001-create.spec.js
+++ b/__tests__/devenv-e2e/001-create.spec.js
@@ -75,6 +75,7 @@ describe( 'vip dev-env create', () => {
 		const expectedXDebug = false;
 		const expectedMailpit = false;
 		const expectedPhoton = false;
+		const expectedCron = false;
 
 		expect( await checkEnvExists( slug ) ).toBe( false );
 
@@ -102,6 +103,7 @@ describe( 'vip dev-env create', () => {
 			xdebug: expectedXDebug,
 			mailpit: expectedMailpit,
 			photon: expectedPhoton,
+			cron: expectedCron,
 		} );
 	} );
 
@@ -116,6 +118,7 @@ describe( 'vip dev-env create', () => {
 		const expectedXDebug = true;
 		const expectedMailpit = true;
 		const expectedPhoton = true;
+		const expectedCron = true;
 
 		expect( await checkEnvExists( slug ) ).toBe( false );
 
@@ -135,6 +138,7 @@ describe( 'vip dev-env create', () => {
 			'-x', `${ expectedXDebug }`,
 			'-A', `${ expectedMailpit }`,
 			'-H', `${ expectedPhoton }`,
+			'-c', `${ expectedCron }`,
 		], { env }, true );
 
 		expect( result.rc ).toBe( 0 );
@@ -156,6 +160,7 @@ describe( 'vip dev-env create', () => {
 			xdebug: expectedXDebug,
 			mailpit: expectedMailpit,
 			photon: expectedPhoton,
+			cron: expectedCron,
 		} );
 	} );
 } );

--- a/__tests__/devenv-e2e/005-update.spec.js
+++ b/__tests__/devenv-e2e/005-update.spec.js
@@ -76,6 +76,7 @@ describe( 'vip dev-env update', () => {
 		const expectedXDebug = false;
 		const expectedMailpit = false;
 		const expectedPhoton = false;
+		const expectedCron = false;
 
 		expect( await checkEnvExists( slug ) ).toBe( false );
 
@@ -95,6 +96,7 @@ describe( 'vip dev-env update', () => {
 			xdebug: expectedXDebug,
 			mailpit: expectedMailpit,
 			photon: expectedPhoton,
+			cron: expectedCron,
 		} );
 
 		// prettier-ignore
@@ -106,6 +108,7 @@ describe( 'vip dev-env update', () => {
 			'-x', `${ ! expectedXDebug }`,
 			'-A', `${ ! expectedMailpit }`,
 			'-H', `${ ! expectedPhoton }`,
+			'-c', `${ ! expectedCron }`,
 		], { env }, true );
 
 		expect( result.rc ).toBe( 0 );
@@ -119,6 +122,7 @@ describe( 'vip dev-env update', () => {
 			xdebug: ! expectedXDebug,
 			mailpit: ! expectedMailpit,
 			photon: ! expectedPhoton,
+			cron: ! expectedCron,
 		} );
 	} );
 

--- a/__tests__/devenv-e2e/013-configuration-file.spec.js
+++ b/__tests__/devenv-e2e/013-configuration-file.spec.js
@@ -207,6 +207,7 @@ describe( 'vip dev-env configuration file', () => {
 		const expectedXDebug = true;
 		const expectedMailpit = true;
 		const expectedPhoton = true;
+		const expectedCron = true;
 
 		expect( await checkEnvExists( expectedSlug ) ).toBe( false );
 
@@ -222,6 +223,7 @@ describe( 'vip dev-env configuration file', () => {
 			xdebug: expectedXDebug,
 			mailpit: expectedMailpit,
 			photon: expectedPhoton,
+			cron: expectedCron,
 			'mu-plugins': 'image',
 			'app-code': 'image',
 		} );
@@ -256,6 +258,7 @@ describe( 'vip dev-env configuration file', () => {
 			xdebug: expectedXDebug,
 			mailpit: expectedMailpit,
 			photon: expectedPhoton,
+			cron: expectedCron,
 		} );
 
 		return expect( checkEnvExists( expectedSlug ) ).resolves.toBe( true );
@@ -268,6 +271,7 @@ describe( 'vip dev-env configuration file', () => {
 		const expectedXDebug = false;
 		const expectedMailpit = false;
 		const expectedPhoton = false;
+		const expectedCron = false;
 
 		expect( await checkEnvExists( slug ) ).toBe( false );
 
@@ -280,6 +284,7 @@ describe( 'vip dev-env configuration file', () => {
 			xdebug: expectedXDebug,
 			mailpit: expectedMailpit,
 			photon: expectedPhoton,
+			cron: expectedCron,
 		} );
 
 		const spawnOptions = {
@@ -299,6 +304,7 @@ describe( 'vip dev-env configuration file', () => {
 			xdebug: expectedXDebug,
 			mailpit: expectedMailpit,
 			photon: expectedPhoton,
+			cron: expectedCron,
 		} );
 
 		// Update environment from changed configuration file
@@ -310,6 +316,7 @@ describe( 'vip dev-env configuration file', () => {
 			xdebug: ! expectedXDebug,
 			mailpit: ! expectedMailpit,
 			photon: ! expectedPhoton,
+			cron: ! expectedCron,
 		} );
 
 		result = await cliTest.spawn( [ process.argv[ 0 ], vipDevEnvUpdate ], spawnOptions, true );
@@ -324,6 +331,7 @@ describe( 'vip dev-env configuration file', () => {
 			xdebug: ! expectedXDebug,
 			mailpit: ! expectedMailpit,
 			photon: ! expectedPhoton,
+			cron: ! expectedCron,
 		} );
 	} );
 } );

--- a/__tests__/lib/dev-environment/dev-environment-cli.js
+++ b/__tests__/lib/dev-environment/dev-environment-cli.js
@@ -469,7 +469,7 @@ describe( 'lib/dev-environment/dev-environment-cli', () => {
 				expect( prompt ).toHaveBeenCalledTimes( 0 );
 			} else {
 				expect( prompt ).toHaveBeenCalledTimes( 1 );
-				expect( confirmRunMock ).toHaveBeenCalledTimes( 5 );
+				expect( confirmRunMock ).toHaveBeenCalledTimes( 6 );
 			}
 
 			const expectedValue =
@@ -506,9 +506,9 @@ describe( 'lib/dev-environment/dev-environment-cli', () => {
 			const result = await promptForArguments( input.preselected, input.default, false, true );
 
 			if ( input.preselected.mediaRedirectDomain ) {
-				expect( confirmRunMock ).toHaveBeenCalledTimes( 5 );
-			} else {
 				expect( confirmRunMock ).toHaveBeenCalledTimes( 6 );
+			} else {
+				expect( confirmRunMock ).toHaveBeenCalledTimes( 7 );
 			}
 
 			const expectedValue = input.preselected.mediaRedirectDomain

--- a/assets/dev-env.lando.template.yml.ejs
+++ b/assets/dev-env.lando.template.yml.ejs
@@ -59,6 +59,9 @@ services:
 <% if ( autologinKey ) { %>
         VIP_DEV_AUTOLOGIN_KEY: "<%= autologinKey %>"
 <% } %>
+<% if ( cron ) { %>
+        ENABLE_CRON: 1
+<% } %>
         LANDO_NO_USER_PERMS: 'enable'
         LANDO_NEEDS_EXEC: 1
       volumes:
@@ -83,6 +86,7 @@ services:
         --domain "http://<%= siteSlug %>.<%= domain %>/"
         --title "<%= wpTitle %>"
         <% if ( multisite ) { %>--ms-domain "<%= siteSlug %>.<%= domain %>" <% if ( multisite === true || multisite === 'subdomain' ) { %>--subdomain <% } %> <% } %>
+
   database:
     type: compose
     services:

--- a/src/lib/dev-environment/dev-environment-cli.ts
+++ b/src/lib/dev-environment/dev-environment-cli.ts
@@ -339,6 +339,7 @@ export async function promptForArguments(
 		siteSlug: '',
 		mailpit: false,
 		photon: false,
+		cron: false,
 	};
 
 	const promptLabels = {
@@ -346,6 +347,7 @@ export async function promptForArguments(
 		phpmyadmin: 'phpMyAdmin',
 		mailpit: 'Mailpit',
 		photon: 'Photon',
+		cron: 'Cron',
 	};
 
 	if ( create && ! instanceData.mediaRedirectDomain && defaultOptions.mediaRedirectDomain ) {
@@ -380,7 +382,7 @@ export async function promptForArguments(
 		);
 	}
 
-	const services = [ 'phpmyadmin', 'xdebug', 'mailpit', 'photon' ] as const;
+	const services = [ 'phpmyadmin', 'xdebug', 'mailpit', 'photon', 'cron' ] as const;
 	for ( const service of services ) {
 		if ( service in instanceData ) {
 			const preselected = preselectedOptions[ service ];
@@ -920,6 +922,12 @@ export function addDevEnvConfigurationOptions( command: Args ): Args {
 			`Manage the version of PHP. Accepts a string value for minor versions: ${ phpVersionsSupported }`,
 			undefined,
 			processVersionOption
+		)
+		.option(
+			'cron',
+			'Enable or disable cron, disabled by default. Accepts "y" (default value) to enable or "n" to disable.',
+			undefined,
+			processBooleanOption
 		)
 		.option(
 			[ 'A', 'mailpit' ],

--- a/src/lib/dev-environment/dev-environment-configuration-file.ts
+++ b/src/lib/dev-environment/dev-environment-configuration-file.ts
@@ -115,6 +115,7 @@ function sanitizeConfiguration(
 		mailpit: stringToBooleanIfDefined( configuration.mailpit ),
 		'media-redirect-domain': configuration[ 'media-redirect-domain' ]?.toString(),
 		photon: stringToBooleanIfDefined( configuration.photon ),
+		cron: stringToBooleanIfDefined( configuration.cron ),
 		meta: configurationMeta,
 	};
 
@@ -169,6 +170,7 @@ export function mergeConfigurationFileOptions(
 		mailpit: configurationFileOptions.mailpit,
 		mediaRedirectDomain: configurationFileOptions[ 'media-redirect-domain' ],
 		photon: configurationFileOptions.photon,
+		cron: configurationFileOptions.cron,
 	};
 
 	const mergedOptions: InstanceOptions = {};
@@ -247,5 +249,6 @@ elasticsearch: false
 xdebug: false
 mailpit: false
 photon: false
+cron: false
 `;
 }

--- a/src/lib/dev-environment/dev-environment-core.ts
+++ b/src/lib/dev-environment/dev-environment-core.ts
@@ -226,6 +226,10 @@ function preProcessInstanceData( instanceData: InstanceData ): InstanceData {
 		newInstanceData.photon = false;
 	}
 
+	if ( ! newInstanceData.cron ) {
+		newInstanceData.cron = false;
+	}
+
 	// Mailpit migration
 	newInstanceData.mailpit ??= false;
 

--- a/src/lib/dev-environment/types.ts
+++ b/src/lib/dev-environment/types.ts
@@ -15,6 +15,7 @@ export interface InstanceOptions {
 	xdebugConfig?: string;
 	mailpit?: boolean;
 	photon?: boolean;
+	cron?: boolean;
 
 	[ index: string ]: unknown;
 }
@@ -71,6 +72,7 @@ export interface ConfigurationFileOptions {
 	mailpit?: boolean;
 	'media-redirect-domain'?: string;
 	photon?: boolean;
+	cron?: boolean;
 
 	meta?: ConfigurationFileMeta;
 	[ index: string ]: unknown;
@@ -97,6 +99,7 @@ export interface InstanceData {
 	elasticsearch?: string | boolean;
 	mailpit: boolean;
 	photon: boolean;
+	cron: boolean;
 	pullAfter?: number;
 	autologinKey?: string;
 	version?: string;


### PR DESCRIPTION
## Description

This PR adds support for cron (cron-control-runner) to the dev env.

~Depends on: Automattic/cron-control-runner#26~
~Depends on: Automattic/cron-control-runner#27~
~Depends on: Automattic/vip-container-images#783~

(it still can run without the PRs above; the only difference is that the system `cron` daemon will be used instead of `cron-control-runner`)

It introduces a new option to `vip dev-env create` and `vip dev-env update`:

```
    -c, --cron                    Enable or disable cron, disabled by default. Accepts "y" (default value) to enable or "n" to disable.
```

## Pull request checklist

- [ ] Update [SETUP.md](https://github.com/Automattic/vip-cli/blob/trunk/docs/SETUP.md#list-of-environmental-variables) with any new environmental variables.
- [ ] Update [the documentation](https://github.com/Automattic/vip-cli/blob/trunk/docs).
- [x] [Manually test](https://github.com/Automattic/vip-cli/blob/trunk/docs/TESTING.md#manual-testing) the relevant changes.
- [x] Follow the [pull request checklist](https://github.com/Automattic/vip-cli/blob/trunk/docs/RELEASING.md#new-pull-requests)
- [x] Add/update [automated tests](https://github.com/Automattic/vip-cli/blob/trunk/docs/TESTING.md#automated-testing) as needed.

## New release checklist

- [ ] [Automated tests](https://github.com/Automattic/vip-cli/blob/trunk/docs/TESTING.md#automated-testing) pass.
- [ ] The [Preparing for release checklist](https://github.com/Automattic/vip-cli/blob/trunk/docs/RELEASING.md#preparing-for-release) is completed.

## Steps to Test

Outline the steps to test and verify the PR here.

Example:

1. `vip dev-env create --cron < /dev/null`
2. `vip dev-env start`
3. `vip dev-env shell`
4. `ps aux` and verify that there is either `cron` or `cron-control-runner` running.
