### PR TITLE
Dev-env: Upgrade WordPress upgrade prompt to "yes" and pre-select latest version not trunk

### DIFF
--- a/src/lib/dev-environment/dev-environment-cli.ts
+++ b/src/lib/dev-environment/dev-environment-cli.ts
@@ -695,7 +695,7 @@ export async function promptForPhpVersion( initialValue: string ): Promise< stri
 }
 
 export async function promptForWordPress(
-	defaultObject: WordPressConfig | null
+	defaultObject: WordPressConfig | string | null
 ): Promise< WordPressConfig > {
 	debug( `Prompting for wordpress with default:`, defaultObject );
 	const componentDisplayName = componentDisplayNames.wordpress;
@@ -704,7 +704,17 @@ export async function promptForWordPress(
 
 	// image with selection
 	const tagChoices = await getTagChoices();
-	let option = defaultObject?.tag ?? tagChoices[ 0 ].value;
+
+	if (
+		typeof defaultObject === 'string' &&
+		! tagChoices.find( choice => choice.value === defaultObject )
+	) {
+		throw new Error( `Unknown or unsupported WordPress version: ${ defaultObject }.` );
+	}
+
+	let option =
+		typeof defaultObject === 'string' ? defaultObject : defaultObject?.tag ?? tagChoices[ 0 ].value;
+
 	if ( isStdinTTY ) {
 		const message = `${ messagePrefix }Which version would you like`;
 		const selectTag = new Select( {

--- a/src/lib/dev-environment/dev-environment-core.ts
+++ b/src/lib/dev-environment/dev-environment-core.ts
@@ -782,7 +782,7 @@ async function maybeUpdateWordPressImage( lando: Lando, slug: string ): Promise<
 		type: 'select',
 		name: 'upgrade',
 		message: 'Would you like to upgrade WordPress? ',
-		choices: [ 'no', 'yes', "no (don't ask anymore)" ],
+		choices: [ 'yes', 'no', "no (don't ask anymore)" ],
 	} );
 
 	// If the user takes the new WP version path

--- a/src/lib/dev-environment/dev-environment-core.ts
+++ b/src/lib/dev-environment/dev-environment-core.ts
@@ -790,7 +790,7 @@ async function maybeUpdateWordPressImage( lando: Lando, slug: string ): Promise<
 		console.log( 'Upgrading from: ' + chalk.yellow( currentWordPressTag ) + ' to:' );
 
 		// Select a new image
-		const choice: WordPressConfig = await promptForWordPress( null );
+		const choice: WordPressConfig = await promptForWordPress( newestWordPressImage?.tag ?? null );
 		const version: WordPressTag | undefined = versions.find(
 			( { tag } ) => tag.trim() === choice.tag.trim()
 		);


### PR DESCRIPTION
## Description

This PR upgrades the WordPress upgrade prompt to default to "yes" and also pre-selects the latest non-trunk version in WP version listing when user selects "yes" for upgrade
<img width="390" alt="Screenshot 2024-06-20 at 2 46 26 PM" src="https://github.com/Automattic/vip-cli/assets/16962021/d00a09d4-922d-4b61-a7fb-0c9b0a550569">
<img width="526" alt="Screenshot 2024-06-20 at 2 46 36 PM" src="https://github.com/Automattic/vip-cli/assets/16962021/d2b498b7-0e94-4a0f-9823-df1559c6cde2">



## Pull request checklist

- [ ] Update [SETUP.md](https://github.com/Automattic/vip-cli/blob/trunk/docs/SETUP.md#list-of-environmental-variables) with any new environmental variables.
- [ ] Update [the documentation](https://github.com/Automattic/vip-cli/blob/trunk/docs).
- [x] [Manually test](https://github.com/Automattic/vip-cli/blob/trunk/docs/TESTING.md#manual-testing) the relevant changes.
- [ ] Follow the [pull request checklist](https://github.com/Automattic/vip-cli/blob/trunk/docs/RELEASING.md#new-pull-requests)
- [ ] Add/update [automated tests](https://github.com/Automattic/vip-cli/blob/trunk/docs/TESTING.md#automated-testing) as needed.

## New release checklist

- [ ] [Automated tests](https://github.com/Automattic/vip-cli/blob/trunk/docs/TESTING.md#automated-testing) pass.
- [ ] The [Preparing for release checklist](https://github.com/Automattic/vip-cli/blob/trunk/docs/RELEASING.md#preparing-for-release) is completed.

## Steps to Test

Outline the steps to test and verify the PR here.

Example:

1. Check out PR.
1. Run `npm link`
1. Pick a dev-env running an out of date WP version
2. `vip dev-env start` and follow the flows
