### PR TITLE
fix(dev-env): set the user/group for `nginx` container to `nginx:nginx`

### DIFF
--- a/assets/dev-env.lando.template.yml.ejs
+++ b/assets/dev-env.lando.template.yml.ejs
@@ -39,6 +39,8 @@ services:
       command: nginx -g "daemon off;"
       environment:
         LANDO_NEEDS_EXEC: 1
+        LANDO_WEBROOT_USER: nginx
+        LANDO_WEBROOT_GROUP: nginx
       volumes:
         - ./nginx/extra.conf:/etc/nginx/conf.extra/extra.conf
 <% wpVolumes() %>


### PR DESCRIPTION
## Description

With the current configuration, Lando complains when it starts nginx:

```
nginx-1  | 2024-06-20T22:53:31.552597246Z userperms 22:53:31.INFO  ==> This is a alpine container
nginx-1  | 2024-06-20T22:53:31.555307537Z userperms 22:53:31.INFO  ==> user-perms.sh kicking off as user uid=0(root) gid=0(root) groups=0(root),1(bin),2(daemon),3(sys),4(adm),6(disk),10(wheel),11(floppy),20(dialout),26(tape),27(video)
nginx-1  | 2024-06-20T22:53:31.558421974Z userperms 22:53:31.DEBUG ==> Lando ENVVARS set at
nginx-1  | 2024-06-20T22:53:31.558427378Z userperms 22:53:31.DEBUG ==> 
nginx-1  | 2024-06-20T22:53:31.558430769Z userperms 22:53:31.DEBUG ==> ========================================
nginx-1  | 2024-06-20T22:53:31.558434069Z userperms 22:53:31.DEBUG ==> LANDO_WEBROOT_USER      : www-data
nginx-1  | 2024-06-20T22:53:31.558821013Z userperms 22:53:31.DEBUG ==> LANDO_WEBROOT_GROUP     : www-data
nginx-1  | 2024-06-20T22:53:31.560828076Z userperms 22:53:31.DEBUG ==> LANDO_WEBROOT_UID       : 
nginx-1  | 2024-06-20T22:53:31.560835449Z userperms 22:53:31.DEBUG ==> LANDO_WEBROOT_GID       : 
nginx-1  | 2024-06-20T22:53:31.561221745Z userperms 22:53:31.DEBUG ==> LANDO_HOST_UID          : 1000
nginx-1  | 2024-06-20T22:53:31.562102405Z userperms 22:53:31.DEBUG ==> LANDO_HOST_GID          : 1000
nginx-1  | 2024-06-20T22:53:31.565114033Z userperms 22:53:31.DEBUG ==> ========================================
nginx-1  | 2024-06-20T22:53:31.565120074Z userperms 22:53:31.DEBUG ==> 
nginx-1  | 2024-06-20T22:53:31.565123021Z userperms 22:53:31.INFO  ==> Making sure correct user:group (www-data:www-data) exists...
nginx-1  | 2024-06-20T22:53:31.596847415Z userperms 22:53:31.INFO  ==> Remapping ownership to handle docker volume sharing...
nginx-1  | 2024-06-20T22:53:31.596852951Z userperms 22:53:31.INFO  ==> Resetting www-data:www-data from : to 1000:1000
nginx-1  | 2024-06-20T22:53:31.630547815Z id: unknown user www-data
nginx-1  | 2024-06-20T22:53:31.631216003Z userperms 22:53:31.WARN  ==> Looks like host/container user mapping was not possible! aborting...
```

This happens because `nginx` in Alpine is run under the `nginx` user, not `www-data`.

Although this warning does not affect anything, we fix it in order not to annoy the users :-) 

## Pull request checklist

- [ ] Update [SETUP.md](https://github.com/Automattic/vip-cli/blob/trunk/docs/SETUP.md#list-of-environmental-variables) with any new environmental variables.
- [ ] Update [the documentation](https://github.com/Automattic/vip-cli/blob/trunk/docs).
- [x] [Manually test](https://github.com/Automattic/vip-cli/blob/trunk/docs/TESTING.md#manual-testing) the relevant changes.
- [x] Follow the [pull request checklist](https://github.com/Automattic/vip-cli/blob/trunk/docs/RELEASING.md#new-pull-requests)
- [ ] Add/update [automated tests](https://github.com/Automattic/vip-cli/blob/trunk/docs/TESTING.md#automated-testing) as needed.

## New release checklist

- [ ] [Automated tests](https://github.com/Automattic/vip-cli/blob/trunk/docs/TESTING.md#automated-testing) pass.
- [ ] The [Preparing for release checklist](https://github.com/Automattic/vip-cli/blob/trunk/docs/RELEASING.md#preparing-for-release) is completed.

## Steps to Test

See above. With this patch, there will be something like this in the logs for new environments:

```
nginx-1  | 2024-06-20T22:54:46.830622876Z 
nginx-1  | 2024-06-20T22:54:46.838744176Z userperms 22:54:46.INFO  ==> This is a alpine container
nginx-1  | 2024-06-20T22:54:46.840274977Z userperms 22:54:46.INFO  ==> user-perms.sh kicking off as user uid=0(root) gid=0(root) groups=0(root),1(bin),2(daemon),3(sys),4(adm),6(disk),10(wheel),11(floppy),20(dialout),26(tape),27(video)
nginx-1  | 2024-06-20T22:54:46.841160371Z userperms 22:54:46.DEBUG ==> Lando ENVVARS set at
nginx-1  | 2024-06-20T22:54:46.841916406Z userperms 22:54:46.DEBUG ==> 
nginx-1  | 2024-06-20T22:54:46.845759992Z userperms 22:54:46.DEBUG ==> ========================================
nginx-1  | 2024-06-20T22:54:46.845774755Z userperms 22:54:46.DEBUG ==> LANDO_WEBROOT_USER      : nginx
nginx-1  | 2024-06-20T22:54:46.845778214Z userperms 22:54:46.DEBUG ==> LANDO_WEBROOT_GROUP     : nginx
nginx-1  | 2024-06-20T22:54:46.845781072Z userperms 22:54:46.DEBUG ==> LANDO_WEBROOT_UID       : 101
nginx-1  | 2024-06-20T22:54:46.856590241Z userperms 22:54:46.DEBUG ==> LANDO_WEBROOT_GID       : 101
nginx-1  | 2024-06-20T22:54:46.856614314Z userperms 22:54:46.DEBUG ==> LANDO_HOST_UID          : 1000
nginx-1  | 2024-06-20T22:54:46.856618007Z userperms 22:54:46.DEBUG ==> LANDO_HOST_GID          : 1000
nginx-1  | 2024-06-20T22:54:46.856620899Z userperms 22:54:46.DEBUG ==> ========================================
nginx-1  | 2024-06-20T22:54:46.856623737Z userperms 22:54:46.DEBUG ==> 
nginx-1  | 2024-06-20T22:54:46.856626474Z userperms 22:54:46.INFO  ==> Making sure correct user:group (nginx:nginx) exists...
nginx-1  | 2024-06-20T22:54:46.862505163Z userperms 22:54:46.INFO  ==> Remapping ownership to handle docker volume sharing...
nginx-1  | 2024-06-20T22:54:46.862526923Z userperms 22:54:46.INFO  ==> Resetting nginx:nginx from 101:101 to 1000:1000
nginx-1  | 2024-06-20T22:54:46.911664555Z usermod: no changes
nginx-1  | 2024-06-20T22:54:46.919839787Z userperms 22:54:46.INFO  ==> nginx:nginx is now running as uid=1000(nginx) gid=1000(nginx) groups=1000(nginx),1000(nginx)!
```
