### PR TITLE
fix(dev-env): retry healthcheck only on 502 and 504 status codes

### DIFF
--- a/src/lib/dev-environment/dev-environment-lando.ts
+++ b/src/lib/dev-environment/dev-environment-lando.ts
@@ -515,7 +515,9 @@ export async function checkEnvHealth(
 	}
 
 	if ( urlsToScan.length ) {
-		scanResults = scanResults.concat( await app.scanUrls( urlsToScan, { max: 1 } ) );
+		scanResults = scanResults.concat(
+			await app.scanUrls( urlsToScan, { max: 1, waitCodes: [ 502, 504 ] } )
+		);
 	}
 
 	const result: Record< string, boolean > = {};


### PR DESCRIPTION
## Description

Healthcheck fails if the server replies with a 404 error. However, it is possible to (mis)configure WordPress to reply with 404 when its home page is accessed.

This PR sets waitable codes to 502 (Bad gateway) and 504 (Gateway timeout) to avoid false negatives on whether the environment is down.

## Pull request checklist

- [ ] Update [SETUP.md](https://github.com/Automattic/vip-cli/blob/trunk/docs/SETUP.md#list-of-environmental-variables) with any new environmental variables.
- [ ] Update [the documentation](https://github.com/Automattic/vip-cli/blob/trunk/docs).
- [x] [Manually test](https://github.com/Automattic/vip-cli/blob/trunk/docs/TESTING.md#manual-testing) the relevant changes.
- [x] Follow the [pull request checklist](https://github.com/Automattic/vip-cli/blob/trunk/docs/RELEASING.md#new-pull-requests)
- [ ] Add/update [automated tests](https://github.com/Automattic/vip-cli/blob/trunk/docs/TESTING.md#automated-testing) as needed.

## New release checklist

- [ ] [Automated tests](https://github.com/Automattic/vip-cli/blob/trunk/docs/TESTING.md#automated-testing) pass.
- [ ] The [Preparing for release checklist](https://github.com/Automattic/vip-cli/blob/trunk/docs/RELEASING.md#preparing-for-release) is completed.

## Steps to Test

N/A
