### PR TITLE
Remove unnecessary y/N choice for confirmations

### DIFF
--- a/src/bin/vip-config-envvar-delete.js
+++ b/src/bin/vip-config-envvar-delete.js
@@ -56,9 +56,7 @@ export async function deleteEnvVarCommand( arg, opt ) {
 			cancel();
 		} );
 
-		if (
-			! ( await confirm( `Are you sure? ${ chalk.bold.red( 'Deletion is permanent' ) }` ) )
-		) {
+		if ( ! ( await confirm( `Are you sure? ${ chalk.bold.red( 'Deletion is permanent' ) }` ) ) ) {
 			await trackEvent( 'envvar_delete_user_cancelled_confirmation', trackingParams );
 			cancel();
 		}

--- a/src/bin/vip-config-envvar-delete.js
+++ b/src/bin/vip-config-envvar-delete.js
@@ -57,7 +57,7 @@ export async function deleteEnvVarCommand( arg, opt ) {
 		} );
 
 		if (
-			! ( await confirm( `Are you sure? ${ chalk.bold.red( 'Deletion is permanent' ) } (y/N)` ) )
+			! ( await confirm( `Are you sure? ${ chalk.bold.red( 'Deletion is permanent' ) }` ) )
 		) {
 			await trackEvent( 'envvar_delete_user_cancelled_confirmation', trackingParams );
 			cancel();

--- a/src/bin/vip-config-envvar-set.js
+++ b/src/bin/vip-config-envvar-set.js
@@ -86,7 +86,7 @@ export async function setEnvVarCommand( arg, opt ) {
 		}
 
 		if (
-			! ( await confirm( `Please ${ chalk.bold( 'confirm' ) } the input value above (y/N)` ) )
+			! ( await confirm( `Please ${ chalk.bold( 'confirm' ) } the input value above` ) )
 		) {
 			await trackEvent( 'envvar_set_user_cancelled_confirmation', trackingParams );
 			cancel();

--- a/src/bin/vip-config-envvar-set.js
+++ b/src/bin/vip-config-envvar-set.js
@@ -85,9 +85,7 @@ export async function setEnvVarCommand( arg, opt ) {
 			console.log();
 		}
 
-		if (
-			! ( await confirm( `Please ${ chalk.bold( 'confirm' ) } the input value above` ) )
-		) {
+		if ( ! ( await confirm( `Please ${ chalk.bold( 'confirm' ) } the input value above` ) ) ) {
 			await trackEvent( 'envvar_set_user_cancelled_confirmation', trackingParams );
 			cancel();
 		}


### PR DESCRIPTION
## Description

Let's fix this double-confirmation:

```bash
$ vip config envvar set ABC

✔ Enter the value for ABC: example
✔ Please confirm the input value above (y/N) (y/N)
```

## Pull request checklist

- [ ] Update [SETUP.md](https://github.com/Automattic/vip-cli/blob/trunk/docs/SETUP.md#list-of-environmental-variables) with any new environmental variables.
- [ ] Update [the documentation](https://github.com/Automattic/vip-cli/blob/trunk/docs).
- [ ] [Manually test](https://github.com/Automattic/vip-cli/blob/trunk/docs/TESTING.md#manual-testing) the relevant changes.
- [ ] Follow the [pull request checklist](https://github.com/Automattic/vip-cli/blob/trunk/docs/RELEASING.md#new-pull-requests)
- [ ] Add/update [automated tests](https://github.com/Automattic/vip-cli/blob/trunk/docs/TESTING.md#automated-testing) as needed.

## New release checklist

- [ ] [Automated tests](https://github.com/Automattic/vip-cli/blob/trunk/docs/TESTING.md#automated-testing) pass.
- [ ] The [Preparing for release checklist](https://github.com/Automattic/vip-cli/blob/trunk/docs/RELEASING.md#preparing-for-release) is completed.

## Steps to Test

Outline the steps to test and verify the PR here.

Example:

1. Check out PR.
1. Run `npm run build`
1. Run `./dist/bin/vip-cookies.js nom`
1. Verify cookies are delicious.
