### PR TITLE
fix(dev-env): display cron status in `vip dev-env info --extended`

### DIFF
--- a/src/lib/dev-environment/dev-environment-core.ts
+++ b/src/lib/dev-environment/dev-environment-core.ts
@@ -377,6 +377,7 @@ export async function printEnvironmentInfo(
 			xdebug += ' (with additional configuration)';
 		}
 		appInfo.xdebug = xdebug;
+		appInfo.cron = environmentData.cron ? 'enabled' : 'disabled';
 
 		appInfo.wordpress = parseComponentForInfo( environmentData.wordpress );
 		appInfo[ 'Mu plugins' ] = parseComponentForInfo( environmentData.muPlugins );


### PR DESCRIPTION
## Description

This PR adds information about cron to `vip dev-env info --extended`:

![Screenshot_20240629_214358](https://github.com/Automattic/vip-cli/assets/7810770/b4528735-d009-4c09-ae21-9cb0a9fc4ba1)

## Pull request checklist

- [ ] Update [SETUP.md](https://github.com/Automattic/vip-cli/blob/trunk/docs/SETUP.md#list-of-environmental-variables) with any new environmental variables.
- [ ] Update [the documentation](https://github.com/Automattic/vip-cli/blob/trunk/docs).
- [x] [Manually test](https://github.com/Automattic/vip-cli/blob/trunk/docs/TESTING.md#manual-testing) the relevant changes.
- [x] Follow the [pull request checklist](https://github.com/Automattic/vip-cli/blob/trunk/docs/RELEASING.md#new-pull-requests)
- [ ] Add/update [automated tests](https://github.com/Automattic/vip-cli/blob/trunk/docs/TESTING.md#automated-testing) as needed.

## New release checklist

- [ ] [Automated tests](https://github.com/Automattic/vip-cli/blob/trunk/docs/TESTING.md#automated-testing) pass.
- [ ] The [Preparing for release checklist](https://github.com/Automattic/vip-cli/blob/trunk/docs/RELEASING.md#preparing-for-release) is completed.

## Steps to Test

Apply the patch, create an environment, run `vip dev-env info --extended`, and ensure the CRON status is displayed correctly.
