### PR TITLE
refactor(dev-env): migrate from `@lando/phpmyadmin` to `phpmyadmin` Docker image

### DIFF
--- a/assets/dev-env.lando.template.yml.ejs
+++ b/assets/dev-env.lando.template.yml.ejs
@@ -124,12 +124,25 @@ services:
 
 <% if ( phpmyadmin ) { %>
   phpmyadmin:
-    type: phpmyadmin
-    hosts:
-      - database
-    overrides:
+    type: compose
+    services:
+      image: phpmyadmin:5
+      command: /docker-entrypoint.sh apache2-foreground
       environment:
+        MYSQL_ROOT_PASSWORD: ''
+        PMA_HOSTS: database
+        PMA_PORT: 3306
+        PMA_USER: root
+        PMA_PASSWORD: ''
         UPLOAD_LIMIT: 4G
+        LANDO_NO_USER_PERMS: 1
+        LANDO_NEEDS_EXEC: 1
+      ports:
+        - 127.0.0.1::80
+      volumes:
+        - pma_www:/var/www/html
+    volumes:
+      pma_www:
 <% } %>
 
 <% if ( elasticsearch ) { %>

--- a/src/lib/constants/dev-environment.ts
+++ b/src/lib/constants/dev-environment.ts
@@ -45,4 +45,4 @@ export const DEV_ENVIRONMENT_DEFAULTS = {
 	phpVersion: Object.keys( DEV_ENVIRONMENT_PHP_VERSIONS )[ 0 ],
 } as const;
 
-export const DEV_ENVIRONMENT_VERSION = '2.0.3';
+export const DEV_ENVIRONMENT_VERSION = '2.1.0';

--- a/src/lib/dev-environment/dev-environment-lando.ts
+++ b/src/lib/dev-environment/dev-environment-lando.ts
@@ -77,7 +77,7 @@ async function getLandoConfig(): Promise< LandoConfig > {
 				namespace: '@lando',
 			},
 		],
-		disablePlugins: [ '@lando/argv', '@lando/mailhog' ],
+		disablePlugins: [ '@lando/argv', '@lando/mailhog', '@lando/phpmyadmin' ],
 		proxyName: 'vip-dev-env-proxy',
 		userConfRoot: landoDir,
 		home: fakeHomeDir,


### PR DESCRIPTION
## Description

The `@lando/phpmyadmin` plugin uses the old Docker image, `phpmyadmin/phpmyadmin`. That image is only built for the `linux/amd64` architecture and does not work on AEM CPUs (Mac Mx chips).

We replace the plugin in this PR with the newer multiplatform `phpmyadmin` image.

Ref: 188043-z
Ref: https://hub.docker.com/r/phpmyadmin/phpmyadmin (the image used by Lando)
Ref: https://hub.docker.com/_/phpmyadmin (the multiplatform image)

## Pull request checklist

- [ ] Update [SETUP.md](https://github.com/Automattic/vip-cli/blob/trunk/docs/SETUP.md#list-of-environmental-variables) with any new environmental variables.
- [ ] Update [the documentation](https://github.com/Automattic/vip-cli/blob/trunk/docs).
- [x] [Manually test](https://github.com/Automattic/vip-cli/blob/trunk/docs/TESTING.md#manual-testing) the relevant changes.
- [x] Follow the [pull request checklist](https://github.com/Automattic/vip-cli/blob/trunk/docs/RELEASING.md#new-pull-requests)
- [ ] Add/update [automated tests](https://github.com/Automattic/vip-cli/blob/trunk/docs/TESTING.md#automated-testing) as needed.

## New release checklist

- [ ] [Automated tests](https://github.com/Automattic/vip-cli/blob/trunk/docs/TESTING.md#automated-testing) pass.
- [ ] The [Preparing for release checklist](https://github.com/Automattic/vip-cli/blob/trunk/docs/RELEASING.md#preparing-for-release) is completed.

## Steps to Test

Create a dev environment with phpMyAdmin enabled, start it, and ensure that it works and that Docker does not complain about the wrong architecture.
