### PR TITLE
fix: case mismatch in environment identifier matcher

### DIFF
--- a/src/lib/cli/command.js
+++ b/src/lib/cli/command.js
@@ -276,7 +276,9 @@ args.argv = async function ( argv, cb ) {
 				exit.withError( 'Environment production is not allowed for this command' );
 			}
 
-			const env = options.app.environments.find( cur => getEnvIdentifier( cur ) === options.env );
+			const env = options.app.environments.find(
+				cur => getEnvIdentifier( cur ).toLowerCase() === options.env.toLowerCase()
+			);
 
 			if ( ! env ) {
 				await trackEvent( 'command_childcontext_param_error', {


### PR DESCRIPTION
## Description

This PR addresses a bug involving a case mismatch in the environment identifier comparison.

With this fix, a case-insensitive comparison is now used to handle situations where there is a case discrepancy between the environment name and the provided input.  

## Pull request checklist

- [ ] Update [SETUP.md](https://github.com/Automattic/vip-cli/blob/trunk/docs/SETUP.md#list-of-environmental-variables) with any new environmental variables.
- [ ] Update [the documentation](https://github.com/Automattic/vip-cli/blob/trunk/docs).
- [ ] [Manually test](https://github.com/Automattic/vip-cli/blob/trunk/docs/TESTING.md#manual-testing) the relevant changes.
- [ ] Follow the [pull request checklist](https://github.com/Automattic/vip-cli/blob/trunk/docs/RELEASING.md#new-pull-requests)
- [ ] Add/update [automated tests](https://github.com/Automattic/vip-cli/blob/trunk/docs/TESTING.md#automated-testing) as needed.

## New release checklist

- [ ] [Automated tests](https://github.com/Automattic/vip-cli/blob/trunk/docs/TESTING.md#automated-testing) pass.
- [ ] The [Preparing for release checklist](https://github.com/Automattic/vip-cli/blob/trunk/docs/RELEASING.md#preparing-for-release) is completed.

## Steps to Test

1. Check out PR.
2. Run `npm run build`
3. Run `./dist/bin/vip-logs.js @app.PrOdUcTiOn`
4. The logs should appear for the `production` enviroment.
