### PR TITLE
fix(validate-files): Update file-validation logic to add mimetype validation

### DIFF
--- a/__tests__/lib/vip-import-validate-files.js
+++ b/__tests__/lib/vip-import-validate-files.js
@@ -10,7 +10,7 @@ import {
 	findNestedDirectories,
 } from '../../src/lib/vip-import-validate-files';
 
-global.console = { log: jest.fn(), error: jest.fn() };
+global.console = { log: jest.fn(), error: jest.fn(), warn: jest.fn() };
 
 describe( 'lib/vip-import-validate-files', () => {
 	describe( 'folderStructureValidation', () => {
@@ -74,8 +74,6 @@ describe( 'lib/vip-import-validate-files', () => {
 				.spyOn( fs.promises, 'stat' )
 				.mockResolvedValue( { isDirectory: () => false, size: 4000 } );
 			jest.spyOn( fs, 'statSync' ).mockReturnValue( { size: 10 } );
-			jest.spyOn( cp, 'execFileSync' ).mockReturnValueOnce( 'text/plain' );
-			jest.spyOn( cp, 'execFileSync' ).mockReturnValueOnce( 'application/octet-stream' );
 
 			const result = await validateFiles( [ 'file1.txt', 'file2.exe' ], mediaImportConfig );
 			expect( result.errorFileTypes ).toEqual( [ 'file1.txt', 'file2.exe' ] );
@@ -84,7 +82,9 @@ describe( 'lib/vip-import-validate-files', () => {
 		it( 'should detect valid file types and invalid file sizes', async () => {
 			jest.spyOn( fs.promises, 'stat' ).mockResolvedValue( { isDirectory: () => false } );
 			jest.spyOn( fs, 'statSync' ).mockReturnValue( { size: 6000000 } );
+			jest.spyOn( cp, 'execFileSync' ).mockReturnValueOnce( 'file-5.41' );
 			jest.spyOn( cp, 'execFileSync' ).mockReturnValueOnce( 'image/jpeg' );
+			jest.spyOn( cp, 'execFileSync' ).mockReturnValueOnce( 'file-5.41' );
 			jest.spyOn( cp, 'execFileSync' ).mockReturnValueOnce( 'image/png' );
 
 			const result = await validateFiles( [ 'file1.jpg', 'file2.png' ], mediaImportConfig );
@@ -94,7 +94,9 @@ describe( 'lib/vip-import-validate-files', () => {
 		it( 'should detect valid file types and valid file sizes', async () => {
 			jest.spyOn( fs.promises, 'stat' ).mockResolvedValue( { isDirectory: () => false } );
 			jest.spyOn( fs, 'statSync' ).mockReturnValue( { size: 4000 } );
+			jest.spyOn( cp, 'execFileSync' ).mockReturnValueOnce( 'file-5.41' );
 			jest.spyOn( cp, 'execFileSync' ).mockReturnValueOnce( 'image/jpeg' );
+			jest.spyOn( cp, 'execFileSync' ).mockReturnValueOnce( 'file-5.41' );
 			jest.spyOn( cp, 'execFileSync' ).mockReturnValueOnce( 'image/png' );
 
 			const result = await validateFiles( [ 'file1.jpg', 'file2.png' ], mediaImportConfig );
@@ -105,7 +107,9 @@ describe( 'lib/vip-import-validate-files', () => {
 		it( 'should detect files with invalid filenames', async () => {
 			jest.spyOn( fs.promises, 'stat' ).mockResolvedValue( { isDirectory: () => false } );
 			jest.spyOn( fs, 'statSync' ).mockReturnValue( { size: 4000 } );
+			jest.spyOn( cp, 'execFileSync' ).mockReturnValueOnce( 'file-5.41' );
 			jest.spyOn( cp, 'execFileSync' ).mockReturnValueOnce( 'image/jpeg' );
+			jest.spyOn( cp, 'execFileSync' ).mockReturnValueOnce( 'file-5.41' );
 			jest.spyOn( cp, 'execFileSync' ).mockReturnValueOnce( 'image/png' );
 
 			const result = await validateFiles(
@@ -118,6 +122,7 @@ describe( 'lib/vip-import-validate-files', () => {
 		it( 'should detect files with filenames exceeding character count limit', async () => {
 			jest.spyOn( fs.promises, 'stat' ).mockResolvedValue( { isDirectory: () => false } );
 			jest.spyOn( fs, 'statSync' ).mockReturnValue( { size: 4000 } );
+			jest.spyOn( cp, 'execFileSync' ).mockReturnValueOnce( 'file-5.41' );
 			jest.spyOn( cp, 'execFileSync' ).mockReturnValueOnce( 'image/jpeg' );
 
 			const longFileName = 'a'.repeat( 256 ) + '.jpg';
@@ -129,6 +134,7 @@ describe( 'lib/vip-import-validate-files', () => {
 			jest.spyOn( fs.promises, 'stat' ).mockResolvedValue( { isDirectory: () => false } );
 			jest.spyOn( fs, 'existsSync' ).mockReturnValue( true );
 			jest.spyOn( fs, 'statSync' ).mockReturnValue( { size: 4000 } );
+			jest.spyOn( cp, 'execFileSync' ).mockReturnValueOnce( 'file-5.41' );
 			jest.spyOn( cp, 'execFileSync' ).mockReturnValueOnce( 'image/jpeg' );
 
 			const result = await validateFiles( [ 'image-4000x6000.jpg' ], mediaImportConfig );
@@ -139,31 +145,32 @@ describe( 'lib/vip-import-validate-files', () => {
 			jest.spyOn( fs.promises, 'stat' ).mockResolvedValue( { isDirectory: () => false } );
 			jest.spyOn( fs, 'statSync' ).mockReturnValue( { size: 60000 } );
 
+			jest.spyOn( cp, 'execFileSync' ).mockReturnValueOnce( 'file-5.41' );
 			jest.spyOn( cp, 'execFileSync' ).mockReturnValueOnce( 'application/octet-stream' );
-			const result = await validateFiles( [ 'file1.txt' ], mediaImportConfig );
-			expect( result.errorFileTypes ).toEqual( [ 'file1.txt' ] );
-
+			jest.spyOn( cp, 'execFileSync' ).mockReturnValueOnce( 'file-5.41' );
 			jest.spyOn( cp, 'execFileSync' ).mockReturnValueOnce( 'application/octet-stream' );
-			const result2 = await validateFiles( [ 'file1.mp3' ], mediaImportConfig );
-			expect( result2.errorFileTypes ).toEqual( [] );
+			const result = await validateFiles( [ 'file1.jpg', 'file2.mp3' ], mediaImportConfig );
+			expect( result.errorFileTypes ).toEqual( [ 'file1.jpg' ] );
 		} );
 
 		it( 'should check mime for audio/video', async () => {
 			jest.spyOn( fs.promises, 'stat' ).mockResolvedValue( { isDirectory: () => false } );
 			jest.spyOn( fs, 'statSync' ).mockReturnValue( { size: 60000 } );
+			jest.spyOn( cp, 'execFileSync' ).mockReturnValueOnce( 'file-5.41' );
+			jest.spyOn( cp, 'execFileSync' ).mockReturnValueOnce( 'audio/mpeg' );
+			jest.spyOn( cp, 'execFileSync' ).mockReturnValueOnce( 'file-5.41' );
 			jest.spyOn( cp, 'execFileSync' ).mockReturnValueOnce( 'audio/mpeg' );
 
-			const result = await validateFiles( [ 'file1.txt' ], mediaImportConfig );
-			expect( result.errorFileTypes ).toEqual( [ 'file1.txt' ] );
-
-			jest.spyOn( cp, 'execFileSync' ).mockReturnValueOnce( 'audio/mpeg' );
-			const result2 = await validateFiles( [ 'file1.mp3' ], mediaImportConfig );
-			expect( result2.errorFileTypes ).toEqual( [] );
+			const result = await validateFiles( [ 'file1.jpg', 'file2.mp3' ], mediaImportConfig );
+			expect( result.errorFileTypes ).toEqual( [ 'file1.jpg' ] );
 		} );
 
 		it( 'should check file extension for plain text', async () => {
 			jest.spyOn( fs.promises, 'stat' ).mockResolvedValue( { isDirectory: () => false } );
 			jest.spyOn( fs, 'statSync' ).mockReturnValue( { size: 60000 } );
+			jest.spyOn( cp, 'execFileSync' ).mockReturnValueOnce( 'file-5.41' );
+			jest.spyOn( cp, 'execFileSync' ).mockReturnValueOnce( 'text/plain' );
+			jest.spyOn( cp, 'execFileSync' ).mockReturnValueOnce( 'file-5.41' );
 			jest.spyOn( cp, 'execFileSync' ).mockReturnValueOnce( 'text/plain' );
 
 			const config = {
@@ -175,17 +182,16 @@ describe( 'lib/vip-import-validate-files', () => {
 					csv: 'text/csv',
 				},
 			};
-			const result = await validateFiles( [ 'file1.mp3' ], config );
+			const result = await validateFiles( [ 'file1.mp3', 'file2.csv' ], config );
 			expect( result.errorFileTypes ).toEqual( [ 'file1.mp3' ] );
-
-			jest.spyOn( cp, 'execFileSync' ).mockReturnValueOnce( 'text/plain' );
-			const resul2 = await validateFiles( [ 'file1.csv' ], config );
-			expect( resul2.errorFileTypes ).toEqual( [] );
 		} );
 
 		it( 'should check file extension for rich text', async () => {
 			jest.spyOn( fs.promises, 'stat' ).mockResolvedValue( { isDirectory: () => false } );
 			jest.spyOn( fs, 'statSync' ).mockReturnValue( { size: 60000 } );
+			jest.spyOn( cp, 'execFileSync' ).mockReturnValueOnce( 'file-5.41' );
+			jest.spyOn( cp, 'execFileSync' ).mockReturnValueOnce( 'text/rtf' );
+			jest.spyOn( cp, 'execFileSync' ).mockReturnValueOnce( 'file-5.41' );
 			jest.spyOn( cp, 'execFileSync' ).mockReturnValueOnce( 'text/rtf' );
 
 			const config = {
@@ -197,12 +203,8 @@ describe( 'lib/vip-import-validate-files', () => {
 					rtf: 'ext/rtf',
 				},
 			};
-			const result = await validateFiles( [ 'file1.mp3' ], config );
+			const result = await validateFiles( [ 'file1.mp3', 'file2.rtf' ], config );
 			expect( result.errorFileTypes ).toEqual( [ 'file1.mp3' ] );
-
-			jest.spyOn( cp, 'execFileSync' ).mockReturnValueOnce( 'text/rtf' );
-			const resul2 = await validateFiles( [ 'file1.rtf' ], config );
-			expect( resul2.errorFileTypes ).toEqual( [] );
 		} );
 	} );
 

--- a/src/lib/constants/file-type.ts
+++ b/src/lib/constants/file-type.ts
@@ -1,0 +1,16 @@
+export const GENERIC_BIN_TYPES = [
+	'application/octet-stream',
+	'application/encrypted',
+	'application/CDFV2-encrypted',
+	'application/zip',
+];
+
+export const GENERIC_TEXT_TYPES = [
+	'text/plain',
+	'text/csv',
+	'application/csv',
+	'text/richtext',
+	'text/tsv',
+	'text/vtt',
+	'text/css',
+];

--- a/src/lib/validations/utils.ts
+++ b/src/lib/validations/utils.ts
@@ -42,6 +42,13 @@ export function getMultilineStatement( statementRegex: RegExp ): ( line: string 
 }
 
 export function getFileType( filepath: string ): string {
+	// Check if the computer has the file command installed
+	try {
+		cp.execFileSync( '/usr/bin/file', [ '-v' ] );
+	} catch ( err ) {
+		throw new Error( '/usr/bin/file does not exist this computer' );
+	}
+
 	const regex = new RegExp( /^\w+\/[-+.\w]+/g );
 
 	let result;

--- a/src/lib/validations/utils.ts
+++ b/src/lib/validations/utils.ts
@@ -1,3 +1,5 @@
+import { execFileSync } from 'child_process';
+
 /**
  * Get SQL statements matching a supplied pattern from a file stream
  *
@@ -34,4 +36,27 @@ export function getMultilineStatement( statementRegex: RegExp ): ( line: string 
 
 		return matchingStatements;
 	};
+}
+
+export function getFileType( filepath: string ): string {
+	const regex = new RegExp( /^\w+\/[-+.\w]+/g );
+
+	let errMsg: string;
+	try {
+		const result = execFileSync( '/usr/bin/file', [ '-b', '--mime-type', filepath ] );
+
+		// execFileSync returns a Buffer so we need to convert it to a string
+		const resultStr = result.toString().trim();
+
+		// If it doesn't look like a MIME type string than it's probably an error
+		if ( ! regex.test( resultStr ) ) {
+			errMsg = `Error encountered while trying to find mime type for ${ filepath }: ${ resultStr }`;
+			throw new Error( errMsg );
+		}
+
+		return resultStr;
+	} catch ( err ) {
+		errMsg = `Failed to run command to find mime type for ${ filepath }: ${ err as string }`;
+		throw new Error( errMsg );
+	}
 }

--- a/src/lib/validations/utils.ts
+++ b/src/lib/validations/utils.ts
@@ -1,4 +1,7 @@
-import { execFileSync } from 'child_process';
+/**
+ * External dependencies
+ */
+import cp from 'child_process';
 
 /**
  * Get SQL statements matching a supplied pattern from a file stream
@@ -41,22 +44,23 @@ export function getMultilineStatement( statementRegex: RegExp ): ( line: string 
 export function getFileType( filepath: string ): string {
 	const regex = new RegExp( /^\w+\/[-+.\w]+/g );
 
-	let errMsg: string;
+	let result;
+
 	try {
-		const result = execFileSync( '/usr/bin/file', [ '-b', '--mime-type', filepath ] );
-
-		// execFileSync returns a Buffer so we need to convert it to a string
-		const resultStr = result.toString().trim();
-
-		// If it doesn't look like a MIME type string than it's probably an error
-		if ( ! regex.test( resultStr ) ) {
-			errMsg = `Error encountered while trying to find mime type for ${ filepath }: ${ resultStr }`;
-			throw new Error( errMsg );
-		}
-
-		return resultStr;
+		result = cp.execFileSync( '/usr/bin/file', [ '-b', '--mime-type', filepath ] );
 	} catch ( err ) {
-		errMsg = `Failed to run command to find mime type for ${ filepath }: ${ err as string }`;
+		const errMsg = `Failed to find mime type for ${ filepath }: ${ err as string }`;
 		throw new Error( errMsg );
 	}
+
+	// execFileSync returns a Buffer so we need to convert it to a string
+	const resultStr = result.toString().trim();
+
+	// If it doesn't look like a MIME type string than it's probably an error
+	if ( ! regex.test( resultStr ) ) {
+		const errMsg = `Error encountered while trying to find mime type for ${ filepath }: ${ resultStr }`;
+		throw new Error( errMsg );
+	}
+
+	return resultStr;
 }

--- a/src/lib/vip-import-validate-files.ts
+++ b/src/lib/vip-import-validate-files.ts
@@ -70,18 +70,13 @@ export async function validateFiles(
 			<MediaImportAllowedFileTypes>mediaImportConfig.allowedFileTypes
 		);
 
-		if ( isInvalidFile( fileExtType, isFolder ) ) {
-			validationResult.errorFileTypes.push( file );
-		}
-
 		const realMimeType = getFileType( file );
 		const realMimeSplit = realMimeType.split( '/' );
-
-		console.log( fileExtType, realMimeType );
-
 		const typeSplit = fileExtType.type?.map( type => type.split( '/' )[ 0 ] ) || [];
 
-		if ( GENERIC_BIN_TYPES.includes( realMimeType ) ) {
+		if ( isInvalidFile( fileExtType, isFolder ) ) {
+			validationResult.errorFileTypes.push( file );
+		} else if ( GENERIC_BIN_TYPES.includes( realMimeType ) ) {
 			// `file` sometimes will return a file as a generic binary type. In which case we will need to check it
 			// against the expected MIME type. We only allow the file to be uploaded if the expected MIME types are
 			// one of `application`, `video` or `audio` which are expected to be binary files.
@@ -137,6 +132,7 @@ export async function validateFiles(
 	} );
 
 	await Promise.all( fileValidationPromises );
+
 	return validationResult;
 }
 
@@ -168,7 +164,7 @@ const getExtAndType = (
 		const regex = new RegExp( `(?:\\.)(${ key })$`, 'i' );
 		const matches = regex.exec( filePath );
 		if ( matches ) {
-			extType.type = value as string[];
+			extType.type = typeof value === 'string' ? [ value ] : ( value as string[] );
 			extType.ext = matches[ 1 ];
 			break;
 		}

--- a/src/lib/vip-import-validate-files.ts
+++ b/src/lib/vip-import-validate-files.ts
@@ -119,8 +119,6 @@ export async function validateFiles(
 			<MediaImportAllowedFileTypes>mediaImportConfig.allowedFileTypes
 		);
 
-		console.log( fileExtType );
-
 		if ( isInvalidFile( fileExtType, isFolder ) || ! hasValidMimetype( file, fileExtType ) ) {
 			validationResult.errorFileTypes.push( file );
 		}


### PR DESCRIPTION
## Description

In the `vip import validate-files` command, we currently do not parse and check the mimetype of the file itself. In this PR, we are adding that logic. 

## Pull request checklist

- [ ] Update [SETUP.md](https://github.com/Automattic/vip-cli/blob/trunk/docs/SETUP.md#list-of-environmental-variables) with any new environmental variables.
- [ ] Update [the documentation](https://github.com/Automattic/vip-cli/blob/trunk/docs).
- [ ] [Manually test](https://github.com/Automattic/vip-cli/blob/trunk/docs/TESTING.md#manual-testing) the relevant changes.
- [ ] Follow the [pull request checklist](https://github.com/Automattic/vip-cli/blob/trunk/docs/RELEASING.md#new-pull-requests)
- [ ] Add/update [automated tests](https://github.com/Automattic/vip-cli/blob/trunk/docs/TESTING.md#automated-testing) as needed.

## Steps to Test

1. Check out PR.
1. Run `npm run build`
1. Run `./dist/bin/vip-import-validate-files.js <your-dir-path>`
1. Check the verification messages to see if they are correct.
