### PR TITLE
SQL Import: Switch to wpSitesSDS query

### DIFF
--- a/src/bin/vip-import-sql.js
+++ b/src/bin/vip-import-sql.js
@@ -56,7 +56,7 @@ const appQuery = `
 			dbOperationInProgress
 			importInProgress
 		}
-		wpSites {
+		wpSitesSDS {
 			nodes {
 				homeUrl
 				id
@@ -319,7 +319,7 @@ const displayPlaybook = ( {
 		const selectedEnvironmentObj = app?.environments?.find(
 			env => unformattedEnvironment === env.type
 		);
-		siteArray = selectedEnvironmentObj?.wpSites?.nodes;
+		siteArray = selectedEnvironmentObj?.wpSitesSDS?.nodes;
 	}
 
 	if ( ! tableNames.length ) {


### PR DESCRIPTION
The wpSites query is the legacy one which relies on WP REST API + Jetpack-based lookups and can fail more often than not. When it does fail, it fails to kick off the import as the API returns a partial error and the CLI takes that as a complete failure.

```
{
	"errors": [
		{
			"message": "Not Found",
			"locations": [
				{
					"line": 24,
					"column": 5
				}
			],
			"path": [
				"apps",
				"edges",
				0,
				"environments",
				2,
				"wpSites"
			],
			"extensions": {
				"code": "wpsites-error"
			},
```

The SDS one uses the newer and more reliable Site Details Service data. They're interchangeable so no other changes are necessary.

## Pull request checklist

- [ ] [Manually test](https://github.com/Automattic/vip-cli/blob/trunk/docs/TESTING.md#manual-testing) the relevant changes.
- [ ] Add/update [automated tests](https://github.com/Automattic/vip-cli/blob/trunk/docs/TESTING.md#automated-testing) as needed.

## New release checklist

- [ ] [Automated tests](https://github.com/Automattic/vip-cli/blob/trunk/docs/TESTING.md#automated-testing) pass.
- [ ] The [Preparing for release checklist](https://github.com/Automattic/vip-cli/blob/trunk/docs/RELEASING.md#preparing-for-release) is completed.

## Steps to Test

1. Check out PR.
1. Run `npm run build`
1. Run `./dist/bin/vip-import-sql.js 309 file.sql`
1. Verify import runs without issue.
