### PR TITLE
BB8-11630: Add confirmation for production env vars setting/deleting

### DIFF
--- a/src/bin/vip-config-envvar-delete.js
+++ b/src/bin/vip-config-envvar-delete.js
@@ -3,6 +3,7 @@
 import chalk from 'chalk';
 
 import command from '../lib/cli/command';
+import { formatEnvironment } from '../lib/cli/format';
 import { appQuery, deleteEnvVar, validateNameWithMessage } from '../lib/envvar/api';
 import { cancel, confirm, promptForValue } from '../lib/envvar/input';
 import { debug, getEnvContext } from '../lib/envvar/logging';
@@ -36,6 +37,24 @@ export async function deleteEnvVarCommand( arg, opt ) {
 		skip_confirm: Boolean( opt.skipConfirmation ),
 		variable_name: name,
 	};
+
+	const envName = opt.env.type;
+	const appName = opt.app.name;
+
+	if ( ! opt.skipConfirmation && envName === 'production' ) {
+		const yes = await confirm(
+			`Are you sure you want to delete the environment variable ${ name } on ${ formatEnvironment(
+				envName
+			) } for site ${ appName }?`
+		);
+
+		if ( ! yes ) {
+			trackEvent( 'wpcli_confirm_cancel', trackingParams ).catch( () => {} );
+
+			console.log( 'Command cancelled' );
+			process.exit();
+		}
+	}
 
 	debug(
 		`Request: Delete environment variable ${ JSON.stringify( name ) } for ${ getEnvContext(

--- a/src/bin/vip-config-envvar-set.js
+++ b/src/bin/vip-config-envvar-set.js
@@ -3,6 +3,7 @@
 import chalk from 'chalk';
 
 import command from '../lib/cli/command';
+import { formatEnvironment } from '../lib/cli/format';
 import { appQuery, setEnvVar, validateNameWithMessage } from '../lib/envvar/api';
 import { cancel, confirm, promptForValue } from '../lib/envvar/input';
 import { debug, getEnvContext } from '../lib/envvar/logging';
@@ -41,6 +42,24 @@ export async function setEnvVarCommand( arg, opt ) {
 		skip_confirm: Boolean( opt.skipConfirmation ),
 		variable_name: name,
 	};
+
+	const envName = opt.env.type;
+	const appName = opt.app.name;
+
+	if ( ! opt.skipConfirmation && envName === 'production' ) {
+		const yes = await confirm(
+			`Are you sure you want to set the environment variable ${ name } on ${ formatEnvironment(
+				envName
+			) } for site ${ appName }?`
+		);
+
+		if ( ! yes ) {
+			trackEvent( 'wpcli_confirm_cancel', trackingParams ).catch( () => {} );
+
+			console.log( 'Command cancelled' );
+			process.exit();
+		}
+	}
 
 	debug(
 		`Request: Set environment variable ${ JSON.stringify( name ) } for ${ getEnvContext(


### PR DESCRIPTION
## Description

Adds a confirmation prompt when setting or deleting an env vars on production environments:

```
╰─$ vip @5190.production config envvar set EXAMPLE_ENV_VAR                                                                                                                            130 ↵
? Are you sure you want to set the environment variable EXAMPLE_ENV_VAR on PRODUCTION for site rebecca-testing-2? (y/N) › false
```
```
╰─$ vip @5190.production config envvar delete EXAMPLE_ENV_VAR
? Are you sure you want to delete the environment variable EXAMPLE_ENV_VAR on PRODUCTION for site rebecca-testing-2? (y/N) › false
```

## Pull request checklist

- [ ] Update [SETUP.md](https://github.com/Automattic/vip-cli/blob/trunk/docs/SETUP.md#list-of-environmental-variables) with any new environmental variables.
- [ ] Update [the documentation](https://github.com/Automattic/vip-cli/blob/trunk/docs).
- [ ] [Manually test](https://github.com/Automattic/vip-cli/blob/trunk/docs/TESTING.md#manual-testing) the relevant changes.
- [ ] Follow the [pull request checklist](https://github.com/Automattic/vip-cli/blob/trunk/docs/RELEASING.md#new-pull-requests)
- [ ] Add/update [automated tests](https://github.com/Automattic/vip-cli/blob/trunk/docs/TESTING.md#automated-testing) as needed.

## New release checklist

- [ ] [Automated tests](https://github.com/Automattic/vip-cli/blob/trunk/docs/TESTING.md#automated-testing) pass.
- [ ] The [Preparing for release checklist](https://github.com/Automattic/vip-cli/blob/trunk/docs/RELEASING.md#preparing-for-release) is completed.

## Steps to Test

Outline the steps to test and verify the PR here.

Example:

1. Check out PR.
1. Run `npm run build`
1. Run `vip @5190.production config envvar set EXAMPLE_ENV_VAR` and expect confirmation prompt
2. Run the previous step now with `--skip-confirmation` and expect no confirmation prompt