### PR TITLE
Remove querying `fileErrors` in Graphql API while fetching Media import status

### DIFF
--- a/src/graphqlTypes.d.ts
+++ b/src/graphqlTypes.d.ts
@@ -813,8 +813,6 @@ export type AppEnvironmentMediaImportStatusChange = {
 /** Media Import Failure details */
 export type AppEnvironmentMediaImportStatusFailureDetails = {
 	__typename?: 'AppEnvironmentMediaImportStatusFailureDetails';
-	/** List of errors per file */
-	fileErrors?: Maybe< Array< Maybe< AppEnvironmentMediaImportStatusFailureDetailsFileErrors > > >;
 	/** URL to download the media import error log */
 	fileErrorsUrl?: Maybe< Scalars[ 'String' ][ 'output' ] >;
 	/** List of global errors per import */


### PR DESCRIPTION
## Description

As we have completely moved to Media imports v2, this PR tries to remove the variables that are not required for the V2 flow. 

## Steps to Test

1. Check out PR.
1. Run `npm run build`
1. Run `node ./dist/bin/vip import media APP_ID status`
1. Verify the command executes properly
