### PR TITLE
fix(dev-env): clean up data after `vip dev-env sync sql`

### DIFF
--- a/src/commands/dev-env-import-sql.ts
+++ b/src/commands/dev-env-import-sql.ts
@@ -16,6 +16,7 @@ import {
 } from '../lib/dev-environment/dev-environment-core';
 import {
 	addAdminUser,
+	dataCleanup,
 	flushCache,
 	reIndexSearch,
 } from '../lib/dev-environment/dev-environment-database';
@@ -134,6 +135,7 @@ export class DevEnvImportSQLCommand {
 		}
 
 		await addAdminUser( lando, this.slug );
+		await dataCleanup( lando, this.slug, this.options.quiet );
 	}
 
 	public getImportArgs( dumpDetails: SqlDumpDetails ) {

--- a/src/lib/dev-environment/dev-environment-database.ts
+++ b/src/lib/dev-environment/dev-environment-database.ts
@@ -1,6 +1,6 @@
-import Lando from 'lando';
-
 import { exec } from './dev-environment-core';
+
+import type Lando from 'lando';
 
 export const addAdminUser = async ( lando: Lando, slug: string, quiet?: boolean ) => {
 	const addUserArg = [
@@ -12,6 +12,19 @@ export const addAdminUser = async ( lando: Lando, slug: string, quiet?: boolean 
 		'--skip-themes',
 	].concat( quiet ? [ '--quiet' ] : [] );
 	await exec( lando, slug, addUserArg );
+};
+
+export const dataCleanup = async ( lando: Lando, slug: string, quiet?: boolean ) => {
+	const cleanupArg = [ 'wp', 'vip', 'data-cleanup', 'sql-import' ].concat(
+		quiet ? [ '--quiet' ] : []
+	);
+
+	try {
+		await exec( lando, slug, cleanupArg, { stdio: 'inherit' } );
+	} catch ( error ) {
+		// This must not be a fatal error
+		console.log( 'WARNING: data cleanup failed.' );
+	}
 };
 
 export const reIndexSearch = async ( lando: Lando, slug: string ) => {


### PR DESCRIPTION
## Description

Runs `wp vip data-cleanup sql-import` once the SQL import process is complete to match the behavior when [syncing data from a production environment to a non-production environment](https://docs.wpvip.com/databases/data-sync/).

Fixes: #1958

## Pull request checklist

- [ ] Update [SETUP.md](https://github.com/Automattic/vip-cli/blob/trunk/docs/SETUP.md#list-of-environmental-variables) with any new environmental variables.
- [ ] Update [the documentation](https://github.com/Automattic/vip-cli/blob/trunk/docs).
- [ ] [Manually test](https://github.com/Automattic/vip-cli/blob/trunk/docs/TESTING.md#manual-testing) the relevant changes.
- [x] Follow the [pull request checklist](https://github.com/Automattic/vip-cli/blob/trunk/docs/RELEASING.md#new-pull-requests)
- [ ] Add/update [automated tests](https://github.com/Automattic/vip-cli/blob/trunk/docs/TESTING.md#automated-testing) as needed.

## New release checklist

- [ ] [Automated tests](https://github.com/Automattic/vip-cli/blob/trunk/docs/TESTING.md#automated-testing) pass.
- [ ] The [Preparing for release checklist](https://github.com/Automattic/vip-cli/blob/trunk/docs/RELEASING.md#preparing-for-release) is completed.

## Steps to Test

CI must pass.
