### PR TITLE
Add saveErrorLog flag to import media command

### DIFF
--- a/src/bin/vip-import-media-status.js
+++ b/src/bin/vip-import-media-status.js
@@ -34,11 +34,7 @@ command( {
 		'Export any file errors encountered to a JSON file instead of a plain text file',
 		false
 	)
-	.option(
-		'saveErrorLog',
-		'Download file-error logs without prompting',
-		false
-	)
+	.option( 'saveErrorLog', 'Download file-error logs without prompting', 'prompt' )
 	.argv( process.argv, async ( arg, { app, env, exportFileErrorsToJson, saveErrorLog } ) => {
 		const { id: envId, appId } = env;
 		const track = trackEventWithEnv.bind( null, appId, envId );

--- a/src/bin/vip-import-media-status.js
+++ b/src/bin/vip-import-media-status.js
@@ -34,7 +34,12 @@ command( {
 		'Export any file errors encountered to a JSON file instead of a plain text file',
 		false
 	)
-	.argv( process.argv, async ( arg, { app, env, exportFileErrorsToJson } ) => {
+	.option(
+		'saveErrorLog',
+		'If errors were encountered, save the error log file without prompting',
+		false
+	)
+	.argv( process.argv, async ( arg, { app, env, exportFileErrorsToJson, saveErrorLog } ) => {
 		const { id: envId, appId } = env;
 		const track = trackEventWithEnv.bind( null, appId, envId );
 
@@ -53,5 +58,11 @@ command( {
 Checking the Media import status for your environment...
 `;
 
-		await mediaImportCheckStatus( { app, env, progressTracker, exportFileErrorsToJson } );
+		await mediaImportCheckStatus( {
+			app,
+			env,
+			progressTracker,
+			exportFileErrorsToJson,
+			saveErrorLog,
+		} );
 	} );

--- a/src/bin/vip-import-media-status.js
+++ b/src/bin/vip-import-media-status.js
@@ -36,7 +36,7 @@ command( {
 	)
 	.option(
 		'saveErrorLog',
-		'If errors were encountered, save the error log file without prompting',
+		'Download file-error logs without prompting',
 		false
 	)
 	.argv( process.argv, async ( arg, { app, env, exportFileErrorsToJson, saveErrorLog } ) => {

--- a/src/bin/vip-import-media.js
+++ b/src/bin/vip-import-media.js
@@ -100,7 +100,7 @@ Are you sure you want to import the contents of the url?
 	)
 	.option(
 		'saveErrorLog',
-		'If errors were encountered, save the error log file without prompting',
+		'Download file-error logs without prompting',
 		false
 	)
 	.option( 'overwriteExistingFiles', 'Overwrite any existing files', false )

--- a/src/bin/vip-import-media.js
+++ b/src/bin/vip-import-media.js
@@ -98,7 +98,7 @@ Are you sure you want to import the contents of the url?
 		'Export any file errors encountered to a JSON file instead of a plain text file',
 		false
 	)
-	.option( 'saveErrorLog', 'Download file-error logs without prompting', 'prompt' )
+	.option( 'saveErrorLog', 'Download file-error logs without prompting' )
 	.option( 'overwriteExistingFiles', 'Overwrite any existing files', false )
 	.option( 'importIntermediateImages', 'Import intermediate image files', false )
 	.examples( examples )

--- a/src/bin/vip-import-media.js
+++ b/src/bin/vip-import-media.js
@@ -98,18 +98,29 @@ Are you sure you want to import the contents of the url?
 		'Export any file errors encountered to a JSON file instead of a plain text file',
 		false
 	)
+	.option(
+		'saveErrorLog',
+		'If errors were encountered, save the error log file without prompting',
+		false
+	)
 	.option( 'overwriteExistingFiles', 'Overwrite any existing files', false )
 	.option( 'importIntermediateImages', 'Import intermediate image files', false )
 	.examples( examples )
 	.argv( process.argv, async ( args, opts ) => {
-		const { app, env, exportFileErrorsToJson, overwriteExistingFiles, importIntermediateImages } =
-			opts;
+		const {
+			app,
+			env,
+			exportFileErrorsToJson,
+			saveErrorLog,
+			overwriteExistingFiles,
+			importIntermediateImages,
+		} = opts;
 		const [ url ] = args;
 
 		if ( ! isSupportedUrl( url ) ) {
 			console.log(
 				chalk.red( `
-Error: 
+Error:
 	Invalid URL provided: ${ url }
 	Please make sure that it is a publicly accessible web URL containing an archive of the media files to import` )
 			);
@@ -149,7 +160,13 @@ Importing Media into your App...
 				},
 			} );
 
-			await mediaImportCheckStatus( { app, env, progressTracker, exportFileErrorsToJson } );
+			await mediaImportCheckStatus( {
+				app,
+				env,
+				progressTracker,
+				exportFileErrorsToJson,
+				saveErrorLog,
+			} );
 		} catch ( error ) {
 			if ( error.graphQLErrors ) {
 				for ( const err of error.graphQLErrors ) {

--- a/src/bin/vip-import-media.js
+++ b/src/bin/vip-import-media.js
@@ -98,11 +98,7 @@ Are you sure you want to import the contents of the url?
 		'Export any file errors encountered to a JSON file instead of a plain text file',
 		false
 	)
-	.option(
-		'saveErrorLog',
-		'Download file-error logs without prompting',
-		false
-	)
+	.option( 'saveErrorLog', 'Download file-error logs without prompting', 'prompt' )
 	.option( 'overwriteExistingFiles', 'Overwrite any existing files', false )
 	.option( 'importIntermediateImages', 'Import intermediate image files', false )
 	.examples( examples )

--- a/src/lib/cli/command.js
+++ b/src/lib/cli/command.js
@@ -475,6 +475,15 @@ args.argv = async function ( argv, cb ) {
 					key: 'Export any file errors encountered to a JSON file instead of a plain text file.',
 					value: options.exportFileErrorsToJson ? '✅ Yes' : `${ chalk.red( 'x' ) } No`,
 				} );
+
+				options.saveErrorLog =
+					Object.hasOwn( options, 'saveErrorLog' ) &&
+					Boolean( options.saveErrorLog ) &&
+					! [ 'false', 'no' ].includes( options.saveErrorLog );
+				info.push( {
+					key: 'If errors were encountered, save the error log file without prompting.',
+					value: options.saveErrorLog ? '✅ Yes' : `${ chalk.red( 'x' ) } No`,
+				} );
 				break;
 			default:
 		}

--- a/src/lib/cli/command.js
+++ b/src/lib/cli/command.js
@@ -476,14 +476,6 @@ args.argv = async function ( argv, cb ) {
 					value: options.exportFileErrorsToJson ? '✅ Yes' : `${ chalk.red( 'x' ) } No`,
 				} );
 
-				if ( Object.hasOwn( options, 'saveErrorLog' ) && 'prompt' !== options.saveErrorLog ) {
-					options.saveErrorLog =
-						Boolean( options.saveErrorLog ) && ! [ 'false', 'no' ].includes( options.saveErrorLog )
-							? 'true'
-							: 'false';
-				} else {
-					options.saveErrorLog = 'prompt';
-				}
 				info.push( {
 					key: 'Download file-error logs?',
 					value: options.saveErrorLog,

--- a/src/lib/cli/command.js
+++ b/src/lib/cli/command.js
@@ -476,13 +476,17 @@ args.argv = async function ( argv, cb ) {
 					value: options.exportFileErrorsToJson ? '✅ Yes' : `${ chalk.red( 'x' ) } No`,
 				} );
 
-				options.saveErrorLog =
-					Object.hasOwn( options, 'saveErrorLog' ) &&
-					Boolean( options.saveErrorLog ) &&
-					! [ 'false', 'no' ].includes( options.saveErrorLog );
+				if ( Object.hasOwn( options, 'saveErrorLog' ) && 'prompt' !== options.saveErrorLog ) {
+					options.saveErrorLog =
+						Boolean( options.saveErrorLog ) && ! [ 'false', 'no' ].includes( options.saveErrorLog )
+							? 'true'
+							: 'false';
+				} else {
+					options.saveErrorLog = 'prompt';
+				}
 				info.push( {
-					key: 'If errors were encountered, save the error log file without prompting.',
-					value: options.saveErrorLog ? '✅ Yes' : `${ chalk.red( 'x' ) } No`,
+					key: 'Download file-error logs?',
+					value: options.saveErrorLog,
 				} );
 				break;
 			default:

--- a/src/lib/cli/command.js
+++ b/src/lib/cli/command.js
@@ -349,6 +349,19 @@ args.argv = async function ( argv, cb ) {
 		}
 	}
 
+	// Negotiate flag values
+	switch ( _opts.module ) {
+		case 'import-media':
+			if ( [ true, 'true', 'yes' ].includes( options.saveErrorLog ) ) {
+				options.saveErrorLog = 'true';
+			} else if ( [ false, 'false', 'no' ].includes( options.saveErrorLog ) ) {
+				options.saveErrorLog = 'false';
+			} else {
+				options.saveErrorLog = 'prompt';
+			}
+			break;
+	}
+
 	// Prompt for confirmation if necessary
 	if ( _opts.requireConfirm && ! options.force ) {
 		/** @type {Tuple[]} */

--- a/src/lib/media-import/status.ts
+++ b/src/lib/media-import/status.ts
@@ -55,7 +55,7 @@ export interface MediaImportCheckStatusInput {
 	env: AppEnvironment;
 	progressTracker: MediaImportProgressTracker;
 	exportFileErrorsToJson: boolean;
-	saveErrorLog: boolean;
+	saveErrorLog: string;
 }
 
 async function getStatus(
@@ -308,16 +308,17 @@ Downloading errors details from ${ fileErrorsUrl }
 	}
 
 	async function promptFailureDetailsDownload( fileErrorsUrl: string ) {
-		const failureDetails = ! saveErrorLog
-			? await prompt( {
-					type: 'confirm',
-					name: 'download',
-					message:
-						'Download import errors report now? (Report will be downloadable for up to 7 days from the completion of the import)',
-			  } )
-			: {
-					download: true,
-			  };
+		const failureDetails =
+			'prompt' === saveErrorLog
+				? await prompt( {
+						type: 'confirm',
+						name: 'download',
+						message:
+							'Download import errors report now? (Report will be downloadable for up to 7 days from the completion of the import)',
+				  } )
+				: {
+						download: 'true' === saveErrorLog,
+				  };
 
 		if ( ! failureDetails.download ) {
 			progressTracker.suffix += `${ chalk.yellow(

--- a/src/lib/media-import/status.ts
+++ b/src/lib/media-import/status.ts
@@ -55,6 +55,7 @@ export interface MediaImportCheckStatusInput {
 	env: AppEnvironment;
 	progressTracker: MediaImportProgressTracker;
 	exportFileErrorsToJson: boolean;
+	saveErrorLog: boolean;
 }
 
 async function getStatus(
@@ -159,6 +160,7 @@ export async function mediaImportCheckStatus( {
 	env,
 	progressTracker,
 	exportFileErrorsToJson,
+	saveErrorLog,
 }: MediaImportCheckStatusInput ) {
 	// Stop printing so we can pass our callback
 	progressTracker.stopPrinting();
@@ -306,12 +308,16 @@ Downloading errors details from ${ fileErrorsUrl }
 	}
 
 	async function promptFailureDetailsDownload( fileErrorsUrl: string ) {
-		const failureDetails = await prompt( {
-			type: 'confirm',
-			name: 'download',
-			message:
-				'Download import errors report now? (Report will be downloadable for up to 7 days from the completion of the import)',
-		} );
+		const failureDetails = ! saveErrorLog
+			? await prompt( {
+					type: 'confirm',
+					name: 'download',
+					message:
+						'Download import errors report now? (Report will be downloadable for up to 7 days from the completion of the import)',
+			  } )
+			: {
+					download: true,
+			  };
 
 		if ( ! failureDetails.download ) {
 			progressTracker.suffix += `${ chalk.yellow(

--- a/src/lib/media-import/status.ts
+++ b/src/lib/media-import/status.ts
@@ -317,7 +317,7 @@ Downloading errors details from ${ fileErrorsUrl }
 							'Download import errors report now? (Report will be downloadable for up to 7 days from the completion of the import)',
 				  } )
 				: {
-						download: 'true' === saveErrorLog,
+						download: [ 'true', 'yes' ].includes( saveErrorLog ),
 				  };
 
 		if ( ! failureDetails.download ) {


### PR DESCRIPTION
## Description

Adds a `--saveErrorLog` flag to the `import media` command to allow the user to bypass the confirmation prompt for saving an error log if it is generated.

Fixes #2004 

## Pull request checklist

- [X] Update [SETUP.md](https://github.com/Automattic/vip-cli/blob/trunk/docs/SETUP.md#list-of-environmental-variables) with any new environmental variables.
- [X] Update [the documentation](https://github.com/Automattic/vip-cli/blob/trunk/docs).
- [X] [Manually test](https://github.com/Automattic/vip-cli/blob/trunk/docs/TESTING.md#manual-testing) the relevant changes.
- [X] Follow the [pull request checklist](https://github.com/Automattic/vip-cli/blob/trunk/docs/RELEASING.md#new-pull-requests)
- [X] Add/update [automated tests](https://github.com/Automattic/vip-cli/blob/trunk/docs/TESTING.md#automated-testing) as needed.

## New release checklist

- [ ] [Automated tests](https://github.com/Automattic/vip-cli/blob/trunk/docs/TESTING.md#automated-testing) pass.
- [ ] The [Preparing for release checklist](https://github.com/Automattic/vip-cli/blob/trunk/docs/RELEASING.md#preparing-for-release) is completed.

## Steps to Test

Note: I was not able to get the `vip` command to run locally in my tests - it was erroring with `Error: spawn vip.js-import ENOENT` and I'm not sure how to get around this. Hopefully an Automattician can help to test this change or provide me with instructions on how to test locally.

1. Check out PR.
1. Run `npm run build`
1. Run `./dist/bin/vip.js import media` with the new `--saveErrorLog` flag set targeting an archive that contains a file that will error.
1. Confirm that the error log is saved without user input.