### PR TITLE
fix(import-media): Bypass download-error prompt if --force option is set

### DIFF
--- a/src/bin/vip-import-media.js
+++ b/src/bin/vip-import-media.js
@@ -102,8 +102,14 @@ Are you sure you want to import the contents of the url?
 	.option( 'importIntermediateImages', 'Import intermediate image files', false )
 	.examples( examples )
 	.argv( process.argv, async ( args, opts ) => {
-		const { app, env, exportFileErrorsToJson, overwriteExistingFiles, importIntermediateImages } =
-			opts;
+		const {
+			app,
+			env,
+			exportFileErrorsToJson,
+			overwriteExistingFiles,
+			importIntermediateImages,
+			force,
+		} = opts;
 		const [ url ] = args;
 
 		if ( ! isSupportedUrl( url ) ) {
@@ -149,7 +155,7 @@ Importing Media into your App...
 				},
 			} );
 
-			await mediaImportCheckStatus( { app, env, progressTracker, exportFileErrorsToJson } );
+			await mediaImportCheckStatus( { app, env, progressTracker, exportFileErrorsToJson, force } );
 		} catch ( error ) {
 			if ( error.graphQLErrors ) {
 				for ( const err of error.graphQLErrors ) {

--- a/src/lib/media-import/status.ts
+++ b/src/lib/media-import/status.ts
@@ -55,6 +55,7 @@ export interface MediaImportCheckStatusInput {
 	env: AppEnvironment;
 	progressTracker: MediaImportProgressTracker;
 	exportFileErrorsToJson: boolean;
+	force?: boolean;
 }
 
 async function getStatus(
@@ -159,6 +160,7 @@ export async function mediaImportCheckStatus( {
 	env,
 	progressTracker,
 	exportFileErrorsToJson,
+	force,
 }: MediaImportCheckStatusInput ) {
 	// Stop printing so we can pass our callback
 	progressTracker.stopPrinting();
@@ -306,28 +308,30 @@ Downloading errors details from ${ fileErrorsUrl }
 	}
 
 	async function promptFailureDetailsDownload( fileErrorsUrl: string ) {
-		const failureDetails = await prompt( {
-			type: 'confirm',
-			name: 'download',
-			message:
-				'Download import errors report now? (Report will be downloadable for up to 7 days from the completion of the import)',
-		} );
+		if ( ! force ) {
+			const failureDetails = await prompt( {
+				type: 'confirm',
+				name: 'download',
+				message:
+					'Download import errors report now? (Report will be downloadable for up to 7 days from the completion of the import)',
+			} );
 
-		if ( ! failureDetails.download ) {
-			progressTracker.suffix += `${ chalk.yellow(
-				`⚠️  An error report file has been generated for this media import. Access it within the next 15 minutes by clicking on the URL below.`
-			) }`;
-			progressTracker.suffix += `\n${ chalk.yellow(
-				`Or, generate a new URL by running the ${ chalk.bgYellow(
-					'vip import media status'
-				) } command.`
-			) } `;
-			progressTracker.suffix += `\n${ chalk.yellow(
-				'The report will be downloadable for up to 7 days after the completion of the import or until a new media import is performed.'
-			) }`;
-			progressTracker.suffix += `\n\n${ chalk.underline( fileErrorsUrl ) }\n`;
-			progressTracker.print( { clearAfter: true } );
-			return;
+			if ( ! failureDetails.download ) {
+				progressTracker.suffix += `${ chalk.yellow(
+					`⚠️  An error report file has been generated for this media import. Access it within the next 15 minutes by clicking on the URL below.`
+				) }`;
+				progressTracker.suffix += `\n${ chalk.yellow(
+					`Or, generate a new URL by running the ${ chalk.bgYellow(
+						'vip import media status'
+					) } command.`
+				) } `;
+				progressTracker.suffix += `\n${ chalk.yellow(
+					'The report will be downloadable for up to 7 days after the completion of the import or until a new media import is performed.'
+				) }`;
+				progressTracker.suffix += `\n\n${ chalk.underline( fileErrorsUrl ) }\n`;
+				progressTracker.print( { clearAfter: true } );
+				return;
+			}
 		}
 
 		const failureDetailsErrors = await fetchFailureDetails( fileErrorsUrl );


### PR DESCRIPTION
## Issue

https://github.com/Automattic/vip-cli/issues/2004

## Description

Generally, `--force` flag in any command is supposed to bypass the prompts so that the command can be executed via a script, without any manual interaction. But `vip import media` command has a `download-errors?` prompt that can't be bypassed with the `--force` flag. In this PR, we are fixing that issue.


## Pull request checklist

- [ ] Update [SETUP.md](https://github.com/Automattic/vip-cli/blob/trunk/docs/SETUP.md#list-of-environmental-variables) with any new environmental variables.
- [ ] Update [the documentation](https://github.com/Automattic/vip-cli/blob/trunk/docs).
- [ ] [Manually test](https://github.com/Automattic/vip-cli/blob/trunk/docs/TESTING.md#manual-testing) the relevant changes.
- [ ] Follow the [pull request checklist](https://github.com/Automattic/vip-cli/blob/trunk/docs/RELEASING.md#new-pull-requests)
- [ ] Add/update [automated tests](https://github.com/Automattic/vip-cli/blob/trunk/docs/TESTING.md#automated-testing) as needed.


## Steps to Test

1. Check out PR.
1. Run `npm run build`
1. Run `node ./dist/bin/vip import media @<app>.<env> https://getsamplefiles.com/download/zip/sample-1.zip` 
2. Run the above command again. The reason we are running it twice is to ensure that some `file-already-exists` errors are generated. You should see that the `Download import errors report now?` prompt has appeared.
1. Now, run the same command again, but with the `--force` flag. This time, the above prompt should not be present, and the errors should be downloaded automatically.
