### PR TITLE
fix(import-media): Display success/total count even if all files fail to import

### DIFF
--- a/src/lib/media-import/progress.ts
+++ b/src/lib/media-import/progress.ts
@@ -63,7 +63,7 @@ export class MediaImportProgressTracker {
 
 		const statusIcon = getGlyphForStatus( this.status.status ?? '', this.runningSprite );
 		let logs;
-		if ( this.status.filesProcessed && this.status.filesTotal ) {
+		if ( typeof this.status.filesProcessed === 'number' && this.status.filesTotal ) {
 			const progressPercentage = Math.floor(
 				( this.status.filesProcessed / this.status.filesTotal ) * 100
 			);

--- a/src/lib/media-import/status.ts
+++ b/src/lib/media-import/status.ts
@@ -337,7 +337,7 @@ Downloading errors details from ${ fileErrorsUrl }
 	function printFileErrorsReportLinkExpiredError( results: AppEnvironmentMediaImportStatus ) {
 		if (
 			results.filesTotal &&
-			results.filesProcessed &&
+			typeof results.filesProcessed === 'number' &&
 			results.filesTotal !== results.filesProcessed
 		) {
 			const errorsFound = results.filesTotal - results.filesProcessed;


### PR DESCRIPTION
## Issue

https://github.com/Automattic/vip-cli/issues/2005

## Description

In the `vip import media` command, when all files in the archive fails/errors while importing, the import does not show the success/total count in the end. This is because of a bug in the null-check filter where the case of `filesProcessed = 0` is being consumed by the null check.



## Pull request checklist

- [ ] Update [SETUP.md](https://github.com/Automattic/vip-cli/blob/trunk/docs/SETUP.md#list-of-environmental-variables) with any new environmental variables.
- [ ] Update [the documentation](https://github.com/Automattic/vip-cli/blob/trunk/docs).
- [ ] [Manually test](https://github.com/Automattic/vip-cli/blob/trunk/docs/TESTING.md#manual-testing) the relevant changes.
- [ ] Follow the [pull request checklist](https://github.com/Automattic/vip-cli/blob/trunk/docs/RELEASING.md#new-pull-requests)
- [ ] Add/update [automated tests](https://github.com/Automattic/vip-cli/blob/trunk/docs/TESTING.md#automated-testing) as needed.

## Steps to Test

1. Check out PR.
1. Run `npm run build`
1. Run `node ./dist/bin/vip import media @<app>.<env> https://getsamplefiles.com/download/zip/sample-1.zip` twice. In the second run, all the files should fail to import as they are already imported. When that happens, make sure that the `Imported Files: 0/4 - 0% ✓` line is present in the output.
