### PR TITLE
Remove Kubernetes-specific checks for job existence in SQL import status

### DIFF
--- a/src/lib/site-import/status.ts
+++ b/src/lib/site-import/status.ts
@@ -95,10 +95,6 @@ async function getStatus(
 	const environment = environments[ 0 ] ?? {};
 	const { importStatus, jobs, launched } = environment;
 
-	if ( ! environment.isK8sResident && ! jobs?.length ) {
-		return {};
-	}
-
 	const [ importJob ] = jobs ?? [];
 
 	return {
@@ -271,7 +267,7 @@ ${ maybeExitPrompt }
 
 				let jobStatus;
 				let jobSteps = [];
-				if ( env.isK8sResident && ! isMissingImportJobAndShouldReturnFast ) {
+				if ( ! isMissingImportJobAndShouldReturnFast ) {
 					// in the future the API may provide this in k8s jobs so account for that.
 					// Until then we need to create the importJob from the status object.
 					if ( ! importJob ) {


### PR DESCRIPTION
## Description

Remove Kubernetes-specific checks for job existence in SQL import status.

- Removed the check for `isK8sResident` when determining if jobs exist in the environment.
- Simplified the condition to check for job existence regardless of Kubernetes residency.

## Pull request checklist

- [x] Update [SETUP.md](https://github.com/Automattic/vip-cli/blob/trunk/docs/SETUP.md#list-of-environmental-variables) with any new environmental variables.
- [x] Update [the documentation](https://github.com/Automattic/vip-cli/blob/trunk/docs).
- [x] [Manually test](https://github.com/Automattic/vip-cli/blob/trunk/docs/TESTING.md#manual-testing) the relevant changes.
- [x] Follow the [pull request checklist](https://github.com/Automattic/vip-cli/blob/trunk/docs/RELEASING.md#new-pull-requests)
- [x] Add/update [automated tests](https://github.com/Automattic/vip-cli/blob/trunk/docs/TESTING.md#automated-testing) as needed.

## New release checklist

- [x] [Automated tests](https://github.com/Automattic/vip-cli/blob/trunk/docs/TESTING.md#automated-testing) pass.
- [x] The [Preparing for release checklist](https://github.com/Automattic/vip-cli/blob/trunk/docs/RELEASING.md#preparing-for-release) is completed.

## Steps to Test

Outline the steps to test and verify the PR here.

Example:

1. Check out PR.
1. Run `npm run build`
1. Run `./dist/bin/vip-cookies.js nom`
1. Verify cookies are delicious.
