### PR TITLE
BB8-11725: SQL Import - Update multisite regex to match optional `IF NOT EXISTS`

### DIFF
--- a/__tests__/lib/validations/is-multi-site-sql-dump.js
+++ b/__tests__/lib/validations/is-multi-site-sql-dump.js
@@ -11,9 +11,11 @@ describe( 'is-multi-site-sql-dump', () => {
 			expect( sqlDumpLineIsMultiSite( 'CREATE TABLE wp_23_posts' ) ).toBe( true );
 			expect( sqlDumpLineIsMultiSite( 'CREATE TABLE wp_2345235_posts' ) ).toBe( true );
 			expect( sqlDumpLineIsMultiSite( 'CREATE TABLE wp_blogs' ) ).toBe( true );
+			expect( sqlDumpLineIsMultiSite( 'CREATE TABLE IF NOT EXISTS wp_2_posts' ) ).toBe( true );
 		} );
 		it( 'returns false for non-multi site table creations', () => {
 			expect( sqlDumpLineIsMultiSite( 'CREATE TABLE wp_posts' ) ).toBe( false );
+			expect( sqlDumpLineIsMultiSite( 'CREATE TABLE IF NOT EXISTS wp_posts' ) ).toBe( false );
 		} );
 		it( 'return true if a wp_users table has a spam or deleted column', () => {
 			expect( sqlDumpLineIsMultiSite( '`spam` tinyint(2) NOT NULL DEFAULT 0,' ) ).toBe( true );

--- a/src/lib/validations/is-multi-site-sql-dump.ts
+++ b/src/lib/validations/is-multi-site-sql-dump.ts
@@ -1,4 +1,5 @@
-const SQL_CREATE_TABLE_IS_MULTISITE_REGEX = /^CREATE TABLE `?(wp_\d+_[a-z0-9_]*|wp_blogs)/i;
+const SQL_CREATE_TABLE_IS_MULTISITE_REGEX =
+	/^CREATE TABLE(?: IF NOT EXISTS)? `?(wp_\d+_[a-z0-9_]*|wp_blogs)/i;
 const SQL_CONTAINS_MULTISITE_WP_USERS_REGEX = /`spam` tinyint\(2\)|`deleted` tinyint\(2\)/i;
 
 export function sqlDumpLineIsMultiSite( line: string ): boolean {

--- a/src/lib/validations/site-type.ts
+++ b/src/lib/validations/site-type.ts
@@ -57,7 +57,7 @@ export const siteTypeValidations = {
 				error_type: 'subsite-import-without-subsite-sql-dump',
 			} );
 			throw new Error(
-				'You have requested a subsite SQL import but have not provided a subsite compatiable SQL dump.'
+				'You have requested a subsite SQL import but have not provided a subsite compatible SQL dump.'
 			);
 		}
 


### PR DESCRIPTION
## Description

When importing SQL to a multisite environment, we check that the SQL file is from a multisite installation. One of the ways we do that is by checking the table name in `CREATE TABLE` statements are in a format like `wp_\d_posts`. However our regex doesn't currently match if the `IF NOT EXISTS` keyword is present, leading to a validation warning. This PR fixes that.

## Pull request checklist

- [ ] Update [SETUP.md](https://github.com/Automattic/vip-cli/blob/trunk/docs/SETUP.md#list-of-environmental-variables) with any new environmental variables.
- [ ] Update [the documentation](https://github.com/Automattic/vip-cli/blob/trunk/docs).
- [x] [Manually test](https://github.com/Automattic/vip-cli/blob/trunk/docs/TESTING.md#manual-testing) the relevant changes.
- [ ] Follow the [pull request checklist](https://github.com/Automattic/vip-cli/blob/trunk/docs/RELEASING.md#new-pull-requests)
- [x] Add/update [automated tests](https://github.com/Automattic/vip-cli/blob/trunk/docs/TESTING.md#automated-testing) as needed.

## New release checklist

- [ ] [Automated tests](https://github.com/Automattic/vip-cli/blob/trunk/docs/TESTING.md#automated-testing) pass.
- [ ] The [Preparing for release checklist](https://github.com/Automattic/vip-cli/blob/trunk/docs/RELEASING.md#preparing-for-release) is completed.

## Steps to Test

- Create an SQL file with these contents:

```
DROP TABLE IF EXISTS `wp_5_postmeta`;

CREATE TABLE IF NOT EXISTS `wp_5_postmeta` (
  `meta_id` bigint unsigned NOT NULL AUTO_INCREMENT,
  `post_id` bigint unsigned NOT NULL DEFAULT '0',
  `meta_key` varchar(255) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci DEFAULT NULL,
  `meta_value` longtext CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci,
  PRIMARY KEY (`meta_id`),
  KEY `post_id` (`post_id`),
  KEY `vip_meta_key_value` (`meta_key`(191),`meta_value`(100))
) ENGINE=InnoDB AUTO_INCREMENT=105388 DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
```

1. Check out PR.
1. Run `npm run build`
1. Run `./dist/bin/vip-import-sql.js path_to_file.sql @<id>.production` (where the id corresponds to a multisite installation)
1. Verify you do not receive the error: `Error:  You have requested a subsite SQL import but have not provided a subsite compatiable SQL dump.`
