### PR TITLE
security(dev-env): update memcached image

### DIFF
--- a/assets/dev-env.lando.template.yml.ejs
+++ b/assets/dev-env.lando.template.yml.ejs
@@ -117,7 +117,7 @@ services:
   memcached:
     type: compose
     services:
-      image: memcached:1.6-alpine3.16
+      image: memcached:1.6-alpine
       command: memcached -m 64
       environment:
         LANDO_NO_USER_PERMS: 1


### PR DESCRIPTION
## Description

This PR‌ updates the image of `memcached` because of multiple security vulnerabilities:

```
┌──────────────┬────────────────┬──────────┬────────┬───────────────────┬───────────────┬─────────────────────────────────────────────────────────────┐
│   Library    │ Vulnerability  │ Severity │ Status │ Installed Version │ Fixed Version │                            Title                            │
├──────────────┼────────────────┼──────────┼────────┼───────────────────┼───────────────┼─────────────────────────────────────────────────────────────┤
│ busybox      │ CVE-2023-42366 │ MEDIUM   │ fixed  │ 1.35.0-r17        │ 1.35.0-r18    │ busybox: A heap-buffer-overflow                             │
│              │                │          │        │                   │               │ https://avd.aquasec.com/nvd/cve-2023-42366                  │
├──────────────┼────────────────┼──────────┤        ├───────────────────┼───────────────┼─────────────────────────────────────────────────────────────┤
│ libcrypto1.1 │ CVE-2022-4450  │ HIGH     │        │ 1.1.1s-r0         │ 1.1.1t-r0     │ openssl: double free after calling PEM_read_bio_ex          │
│              │                │          │        │                   │               │ https://avd.aquasec.com/nvd/cve-2022-4450                   │
│              ├────────────────┤          │        │                   │               ├─────────────────────────────────────────────────────────────┤
│              │ CVE-2023-0215  │          │        │                   │               │ openssl: use-after-free following BIO_new_NDEF              │
│              │                │          │        │                   │               │ https://avd.aquasec.com/nvd/cve-2023-0215                   │
│              ├────────────────┤          │        │                   │               ├─────────────────────────────────────────────────────────────┤
│              │ CVE-2023-0286  │          │        │                   │               │ openssl: X.400 address type confusion in X.509 GeneralName  │
│              │                │          │        │                   │               │ https://avd.aquasec.com/nvd/cve-2023-0286                   │
│              ├────────────────┤          │        │                   ├───────────────┼─────────────────────────────────────────────────────────────┤
│              │ CVE-2023-0464  │          │        │                   │ 1.1.1t-r1     │ openssl: Denial of service by excessive resource usage in   │
│              │                │          │        │                   │               │ verifying X509 policy...                                    │
│              │                │          │        │                   │               │ https://avd.aquasec.com/nvd/cve-2023-0464                   │
│              ├────────────────┼──────────┤        │                   ├───────────────┼─────────────────────────────────────────────────────────────┤
│              │ CVE-2022-4304  │ MEDIUM   │        │                   │ 1.1.1t-r0     │ openssl: timing attack in RSA Decryption implementation     │
│              │                │          │        │                   │               │ https://avd.aquasec.com/nvd/cve-2022-4304                   │
│              ├────────────────┤          │        │                   ├───────────────┼─────────────────────────────────────────────────────────────┤
│              │ CVE-2023-0465  │          │        │                   │ 1.1.1t-r2     │ openssl: Invalid certificate policies in leaf certificates  │
│              │                │          │        │                   │               │ are silently ignored                                        │
│              │                │          │        │                   │               │ https://avd.aquasec.com/nvd/cve-2023-0465                   │
│              ├────────────────┤          │        │                   ├───────────────┼─────────────────────────────────────────────────────────────┤
│              │ CVE-2023-2650  │          │        │                   │ 1.1.1u-r0     │ openssl: Possible DoS translating ASN.1 object identifiers  │
│              │                │          │        │                   │               │ https://avd.aquasec.com/nvd/cve-2023-2650                   │
│              ├────────────────┤          │        │                   ├───────────────┼─────────────────────────────────────────────────────────────┤
│              │ CVE-2023-3446  │          │        │                   │ 1.1.1u-r2     │ openssl: Excessive time spent checking DH keys and          │
│              │                │          │        │                   │               │ parameters                                                  │
│              │                │          │        │                   │               │ https://avd.aquasec.com/nvd/cve-2023-3446                   │
│              ├────────────────┤          │        │                   ├───────────────┼─────────────────────────────────────────────────────────────┤
│              │ CVE-2023-3817  │          │        │                   │ 1.1.1v-r0     │ OpenSSL: Excessive time spent checking DH q parameter value │
│              │                │          │        │                   │               │ https://avd.aquasec.com/nvd/cve-2023-3817                   │
│              ├────────────────┤          │        │                   ├───────────────┼─────────────────────────────────────────────────────────────┤
│              │ CVE-2023-5678  │          │        │                   │ 1.1.1w-r1     │ openssl: Generating excessively long X9.42 DH keys or       │
│              │                │          │        │                   │               │ checking excessively long X9.42...                          │
│              │                │          │        │                   │               │ https://avd.aquasec.com/nvd/cve-2023-5678                   │
├──────────────┼────────────────┼──────────┤        │                   ├───────────────┼─────────────────────────────────────────────────────────────┤
│ libssl1.1    │ CVE-2022-4450  │ HIGH     │        │                   │ 1.1.1t-r0     │ openssl: double free after calling PEM_read_bio_ex          │
│              │                │          │        │                   │               │ https://avd.aquasec.com/nvd/cve-2022-4450                   │
│              ├────────────────┤          │        │                   │               ├─────────────────────────────────────────────────────────────┤
│              │ CVE-2023-0215  │          │        │                   │               │ openssl: use-after-free following BIO_new_NDEF              │
│              │                │          │        │                   │               │ https://avd.aquasec.com/nvd/cve-2023-0215                   │
│              ├────────────────┤          │        │                   │               ├─────────────────────────────────────────────────────────────┤
│              │ CVE-2023-0286  │          │        │                   │               │ openssl: X.400 address type confusion in X.509 GeneralName  │
│              │                │          │        │                   │               │ https://avd.aquasec.com/nvd/cve-2023-0286                   │
│              ├────────────────┤          │        │                   ├───────────────┼─────────────────────────────────────────────────────────────┤
│              │ CVE-2023-0464  │          │        │                   │ 1.1.1t-r1     │ openssl: Denial of service by excessive resource usage in   │
│              │                │          │        │                   │               │ verifying X509 policy...                                    │
│              │                │          │        │                   │               │ https://avd.aquasec.com/nvd/cve-2023-0464                   │
│              ├────────────────┼──────────┤        │                   ├───────────────┼─────────────────────────────────────────────────────────────┤
│              │ CVE-2022-4304  │ MEDIUM   │        │                   │ 1.1.1t-r0     │ openssl: timing attack in RSA Decryption implementation     │
│              │                │          │        │                   │               │ https://avd.aquasec.com/nvd/cve-2022-4304                   │
│              ├────────────────┤          │        │                   ├───────────────┼─────────────────────────────────────────────────────────────┤
│              │ CVE-2023-0465  │          │        │                   │ 1.1.1t-r2     │ openssl: Invalid certificate policies in leaf certificates  │
│              │                │          │        │                   │               │ are silently ignored                                        │
│              │                │          │        │                   │               │ https://avd.aquasec.com/nvd/cve-2023-0465                   │
│              ├────────────────┤          │        │                   ├───────────────┼─────────────────────────────────────────────────────────────┤
│              │ CVE-2023-2650  │          │        │                   │ 1.1.1u-r0     │ openssl: Possible DoS translating ASN.1 object identifiers  │
│              │                │          │        │                   │               │ https://avd.aquasec.com/nvd/cve-2023-2650                   │
│              ├────────────────┤          │        │                   ├───────────────┼─────────────────────────────────────────────────────────────┤
│              │ CVE-2023-3446  │          │        │                   │ 1.1.1u-r2     │ openssl: Excessive time spent checking DH keys and          │
│              │                │          │        │                   │               │ parameters                                                  │
│              │                │          │        │                   │               │ https://avd.aquasec.com/nvd/cve-2023-3446                   │
│              ├────────────────┤          │        │                   ├───────────────┼─────────────────────────────────────────────────────────────┤
│              │ CVE-2023-3817  │          │        │                   │ 1.1.1v-r0     │ OpenSSL: Excessive time spent checking DH q parameter value │
│              │                │          │        │                   │               │ https://avd.aquasec.com/nvd/cve-2023-3817                   │
│              ├────────────────┤          │        │                   ├───────────────┼─────────────────────────────────────────────────────────────┤
│              │ CVE-2023-5678  │          │        │                   │ 1.1.1w-r1     │ openssl: Generating excessively long X9.42 DH keys or       │
│              │                │          │        │                   │               │ checking excessively long X9.42...                          │
│              │                │          │        │                   │               │ https://avd.aquasec.com/nvd/cve-2023-5678                   │
├──────────────┼────────────────┤          │        ├───────────────────┼───────────────┼─────────────────────────────────────────────────────────────┤
│ ssl_client   │ CVE-2023-42366 │          │        │ 1.35.0-r17        │ 1.35.0-r18    │ busybox: A heap-buffer-overflow                             │
│              │                │          │        │                   │               │ https://avd.aquasec.com/nvd/cve-2023-42366                  │
└──────────────┴────────────────┴──────────┴────────┴───────────────────┴───────────────┴─────────────────────────────────────────────────────────────┘

```

## Pull request checklist

- [ ] Update [SETUP.md](https://github.com/Automattic/vip-cli/blob/trunk/docs/SETUP.md#list-of-environmental-variables) with any new environmental variables.
- [ ] Update [the documentation](https://github.com/Automattic/vip-cli/blob/trunk/docs).
- [x] [Manually test](https://github.com/Automattic/vip-cli/blob/trunk/docs/TESTING.md#manual-testing) the relevant changes.
- [x] Follow the [pull request checklist](https://github.com/Automattic/vip-cli/blob/trunk/docs/RELEASING.md#new-pull-requests)
- [ ] Add/update [automated tests](https://github.com/Automattic/vip-cli/blob/trunk/docs/TESTING.md#automated-testing) as needed.

## New release checklist

- [ ] [Automated tests](https://github.com/Automattic/vip-cli/blob/trunk/docs/TESTING.md#automated-testing) pass.
- [ ] The [Preparing for release checklist](https://github.com/Automattic/vip-cli/blob/trunk/docs/RELEASING.md#preparing-for-release) is completed.

## Steps to Test

E2E tests must pass.
