### PR TITLE
Fix `--output` option of `vip import sql` command

### DIFF
--- a/src/bin/vip-import-sql.js
+++ b/src/bin/vip-import-sql.js
@@ -397,11 +397,7 @@ void command( {
 		'Search for a given URL in the SQL file and replace it with another. The format for the value is `<from-url>,<to-url>` (e.g. --search-replace="https://from.com,https://to.com"'
 	)
 	.option( 'in-place', 'Search and Replace explicitly on the given input file' )
-	.option(
-		'output',
-		'Specify the replacement output file for Search and Replace',
-		'process.stdout'
-	)
+	.option( 'output', 'Specify the replacement output file for Search and Replace' )
 	.examples( examples )
 	.argv( process.argv, async ( arg, opts ) => {
 		const { app, env } = opts;
@@ -512,7 +508,7 @@ Processing the SQL import for your environment...
 			const { outputFileName } = await searchAndReplace( fileName, searchReplace, {
 				isImport: true,
 				inPlace: opts.inPlace,
-				output: true,
+				output: opts.output ?? true, // "true" creates a temp output file instead of printing to stdout, as we need to upload the output to S3.
 			} );
 
 			if ( typeof outputFileName !== 'string' ) {

--- a/src/bin/vip-search-replace.js
+++ b/src/bin/vip-search-replace.js
@@ -36,7 +36,10 @@ command( {
 } )
 	.option( 'search-replace', 'Specify the <from> and <to> pairs to be replaced' )
 	.option( 'in-place', 'Perform the search and replace explicitly on the input file' )
-	.option( 'output', 'Specify the replacement output file for Search and Replace' )
+	.option(
+		'output',
+		'Specify the replacement output file for Search and Replace (defaults to "process.stdout")'
+	)
 	.examples( examples )
 	.argv( process.argv, async ( arg, opt ) => {
 		// TODO: tracks event for usage of this command stand alone

--- a/src/bin/vip-search-replace.js
+++ b/src/bin/vip-search-replace.js
@@ -38,7 +38,7 @@ command( {
 	.option( 'in-place', 'Perform the search and replace explicitly on the input file' )
 	.option(
 		'output',
-		'Specify the replacement output file for Search and Replace. Defaults to STDOUT.'
+		'Create a local copy of the file with the completed search and replace operations. Ignored if the command includes --in-place. Accepts a local file path. Defaults to STDOUT.'
 	)
 	.examples( examples )
 	.argv( process.argv, async ( arg, opt ) => {

--- a/src/bin/vip-search-replace.js
+++ b/src/bin/vip-search-replace.js
@@ -38,7 +38,7 @@ command( {
 	.option( 'in-place', 'Perform the search and replace explicitly on the input file' )
 	.option(
 		'output',
-		'Specify the replacement output file for Search and Replace (defaults to "process.stdout")'
+		'Specify the replacement output file for Search and Replace. Defaults to STDOUT.'
 	)
 	.examples( examples )
 	.argv( process.argv, async ( arg, opt ) => {


### PR DESCRIPTION
## Description

Fixed an issue with the `output` option of the `vip import sql` command, which wasn't creating an output file as expected. Alongside this fix, this PR also improves the help text for the `vip search-replace` command.

## Pull request checklist

- [N/A] Update [SETUP.md](https://github.com/Automattic/vip-cli/blob/trunk/docs/SETUP.md#list-of-environmental-variables) with any new environmental variables.
- [N/A] Update [the documentation](https://github.com/Automattic/vip-cli/blob/trunk/docs).
- [x] [Manually test](https://github.com/Automattic/vip-cli/blob/trunk/docs/TESTING.md#manual-testing) the relevant changes.
- [x] Follow the [pull request checklist](https://github.com/Automattic/vip-cli/blob/trunk/docs/RELEASING.md#new-pull-requests)
- [ ] Add/update [automated tests](https://github.com/Automattic/vip-cli/blob/trunk/docs/TESTING.md#automated-testing) as needed.

## New release checklist

- [ ] [Automated tests](https://github.com/Automattic/vip-cli/blob/trunk/docs/TESTING.md#automated-testing) pass.
- [ ] The [Preparing for release checklist](https://github.com/Automattic/vip-cli/blob/trunk/docs/RELEASING.md#preparing-for-release) is completed.

## Steps to Test

1. Check out PR.
1. Run `vip @example-app.develop export sql --output=output.sql.gz`
1. Extracts the sql file from gzip.
1. Run `node ./dist/bin/vip-import-sql.js @example-app.develop output.sql --search-replace="from,to" --output="test-output.sql"`
1. Verify `test-output.sql` file is created with the updated content.
