### PR TITLE
Remove the unused `--format` option from validate media files command

### DIFF
--- a/src/bin/vip-import-validate-files.js
+++ b/src/bin/vip-import-validate-files.js
@@ -161,7 +161,7 @@ export async function vipImportValidateFilesCmd( arg = [] ) {
 }
 const usage = 'vip import validate-files';
 
-command( { requiredArgs: 1, usage, format: true } )
+command( { requiredArgs: 1, usage } )
 	.examples( [
 		{
 			usage: 'vip import validate-files /Users/user-name/Desktop/uploads',


### PR DESCRIPTION
## Description

The `--format` option on the `vip import validate-files` is not a valid one, and does nothing right now.

We're removing it from the help menu, and ensuring that it is not an option that the user can select.

## Pull request checklist

- [x] Update [SETUP.md](https://github.com/Automattic/vip-cli/blob/trunk/docs/SETUP.md#list-of-environmental-variables) with any new environmental variables.
- [x] Update [the documentation](https://github.com/Automattic/vip-cli/blob/trunk/docs).
- [x] [Manually test](https://github.com/Automattic/vip-cli/blob/trunk/docs/TESTING.md#manual-testing) the relevant changes.
- [x] Follow the [pull request checklist](https://github.com/Automattic/vip-cli/blob/trunk/docs/RELEASING.md#new-pull-requests)
- [x] Add/update [automated tests](https://github.com/Automattic/vip-cli/blob/trunk/docs/TESTING.md#automated-testing) as needed.

## New release checklist

- [ ] [Automated tests](https://github.com/Automattic/vip-cli/blob/trunk/docs/TESTING.md#automated-testing) pass.
- [ ] The [Preparing for release checklist](https://github.com/Automattic/vip-cli/blob/trunk/docs/RELEASING.md#preparing-for-release) is completed.

## Steps to Test

1. Check out PR.
1. Run `npm run build`
1. Run `./dist/bin/vip-import-validate-files.js -h`
1. Verify that the `--format` option does not show up 
