### PR TITLE
Use a more reliable way to convert to string

### DIFF
--- a/__tests__/lib/cli/format.js
+++ b/__tests__/lib/cli/format.js
@@ -1,4 +1,4 @@
-import { formatBytes, formatDuration, requoteArgs } from '../../../src/lib/cli/format';
+import { formatBytes, formatDuration, requoteArgs, table } from '../../../src/lib/cli/format';
 
 describe( 'utils/cli/format', () => {
 	describe( 'requoteArgs', () => {
@@ -55,6 +55,12 @@ describe( 'utils/cli/format', () => {
 			expect( formatBytes( 1024 ) ).toStrictEqual( '1 KB' );
 			expect( formatBytes( 1000000 ) ).toStrictEqual( '976.56 KB' );
 			expect( formatBytes( 10004008 ) ).toStrictEqual( '9.54 MB' );
+		} );
+	} );
+
+	describe( 'table', () => {
+		it( 'should properly format null values', () => {
+			expect( table( [ { name: 'Hello', value: null } ] ) ).toMatch( /.*Hello.*null.*/i );
 		} );
 	} );
 

--- a/src/lib/cli/format.ts
+++ b/src/lib/cli/format.ts
@@ -92,7 +92,7 @@ export function table( data: Record< string, Stringable >[] ): string {
 	} );
 
 	data.forEach( datum => {
-		const row = fields.map( field => datum[ field ].toString() );
+		const row = fields.map( field => String( datum[ field ] ) );
 		dataTable.push( row );
 	} );
 


### PR DESCRIPTION
## Description

Due to the recent MFA changes, my role was demoted to `Member` instead of `Admin`. When I tried to run `vip @97.production config envvar get-all`, the variables had the value of `null`, which caused the following error:

```
$ vip @97.production config envvar get-all
✕ Please contact VIP Support with the following information:
TypeError: Cannot read properties of null (reading 'toString')
    at /Users/bor0/.nvm/versions/node/v18.11.0/lib/node_modules/@automattic/vip/dist/lib/cli/format.js:75:50
    at Array.map (<anonymous>)
    at /Users/bor0/.nvm/versions/node/v18.11.0/lib/node_modules/@automattic/vip/dist/lib/cli/format.js:75:24
    at Array.forEach (<anonymous>)
    at table (/Users/bor0/.nvm/versions/node/v18.11.0/lib/node_modules/@automattic/vip/dist/lib/cli/format.js:74:8)
    at formatData (/Users/bor0/.nvm/versions/node/v18.11.0/lib/node_modules/@automattic/vip/dist/lib/cli/format.js:37:14)
    at getAllEnvVarsCommand (/Users/bor0/.nvm/versions/node/v18.11.0/lib/node_modules/@automattic/vip/dist/bin/vip-config-envvar-get-all.js:86:38)
    at process.processTicksAndRejections (node:internal/process/task_queues:95:5)
    at async _args.default.argv (/Users/bor0/.nvm/versions/node/v18.11.0/lib/node_modules/@automattic/vip/dist/lib/cli/command.js:461:11)
Error:  Unexpected error
Debug:  VIP-CLI v3.8.4, Node v18.11.0, darwin 24.0.0 arm64
```

Ideally, it should have returned something like this instead:

```
┌──────────────────────┬───────┐
│ name                 │ value │
├──────────────────────┼───────┤
│ AWS_S3_KEY_ADDONS    │ null  │
├──────────────────────┼───────┤
│ AWS_S3_SECRET_ADDONS │ null  │
...
```

This PR achieves that.

## Pull request checklist

- [x] Update [SETUP.md](https://github.com/Automattic/vip-cli/blob/trunk/docs/SETUP.md#list-of-environmental-variables) with any new environmental variables.
- [x] Update [the documentation](https://github.com/Automattic/vip-cli/blob/trunk/docs).
- [x] [Manually test](https://github.com/Automattic/vip-cli/blob/trunk/docs/TESTING.md#manual-testing) the relevant changes.
- [x] Follow the [pull request checklist](https://github.com/Automattic/vip-cli/blob/trunk/docs/RELEASING.md#new-pull-requests)
- [x] Add/update [automated tests](https://github.com/Automattic/vip-cli/blob/trunk/docs/TESTING.md#automated-testing) as needed.

## New release checklist

- [ ] [Automated tests](https://github.com/Automattic/vip-cli/blob/trunk/docs/TESTING.md#automated-testing) pass.
- [ ] The [Preparing for release checklist](https://github.com/Automattic/vip-cli/blob/trunk/docs/RELEASING.md#preparing-for-release) is completed.

## Steps to Test

1. Check out `trunk`.
2. Apply this [test.patch](https://github.com/user-attachments/files/17396597/test.patch)
3. Run `vip @97.production config envvar get-all`
Expected: error should appear
4. Switch to this branch
5. Run `vip @97.production config envvar get-all`
Expected: should be rendered properly