### PR TITLE
fix(dev-env): verify the container is running before URL scan

### DIFF
--- a/src/lib/dev-environment/dev-environment-lando.ts
+++ b/src/lib/dev-environment/dev-environment-lando.ts
@@ -599,7 +599,7 @@ export async function checkEnvHealth(
 				status: false,
 			} );
 
-			debug( 'Service %s is not running, removing %s from the sacn queue', service, url );
+			debug( 'Service %s is not running, removing %s from the scan queue', service, url );
 			urlsToScan.splice( urlsToScan.indexOf( url ), 1 );
 		}
 	} );


### PR DESCRIPTION
## Description

In #1896, we removed the 404 code from the list of "unhealthy" codes. However, that introduced a bug: if Traefik cannot find a container matching the host, it returns a 404 response. Because of that, all environments are shown as "UP."

In this PR, we ensure service containers are running before starting a URL scan.

## Pull request checklist

- [ ] Update [SETUP.md](https://github.com/Automattic/vip-cli/blob/trunk/docs/SETUP.md#list-of-environmental-variables) with any new environmental variables.
- [ ] Update [the documentation](https://github.com/Automattic/vip-cli/blob/trunk/docs).
- [x] [Manually test](https://github.com/Automattic/vip-cli/blob/trunk/docs/TESTING.md#manual-testing) the relevant changes.
- [x] Follow the [pull request checklist](https://github.com/Automattic/vip-cli/blob/trunk/docs/RELEASING.md#new-pull-requests)
- [ ] Add/update [automated tests](https://github.com/Automattic/vip-cli/blob/trunk/docs/TESTING.md#automated-testing) as needed.

## New release checklist

- [ ] [Automated tests](https://github.com/Automattic/vip-cli/blob/trunk/docs/TESTING.md#automated-testing) pass.
- [ ] The [Preparing for release checklist](https://github.com/Automattic/vip-cli/blob/trunk/docs/RELEASING.md#preparing-for-release) is completed.

## Steps to Test

1. Create two environments.
2. Start one of them
3. Run `vip dev-env list` or `vip dev-env info -s slug_of_not_running_env`: even if the environment is not running, it will be shown as "UP."
4. Apply the patch and ensure the problem hs gone away.
