### PR TITLE
Provide dedicated error message for when a token is marked as disabled due to inactivity

### DIFF
--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -41,7 +41,7 @@ export default function API( {
 				'You are not authorized to perform this request; please logout with `vip logout`, then try again.';
 			if ( 'result' in networkError && networkError.result?.code === 'token-disabled-inactivity' ) {
 				message =
-					'The configured VIP-CLI token has been disabled due to inactivity, please logout with `vip logout` then try again.';
+					'Your token has been disabled due to inactivity; please log out with `vip logout`, then try again.';
 			}
 			console.error( chalk.red( 'Unauthorized:' ), message );
 			process.exit( 1 );

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -8,7 +8,6 @@ import { setContext } from '@apollo/client/link/context';
 import { ApolloLink } from '@apollo/client/link/core';
 import { ErrorResponse, onError } from '@apollo/client/link/error';
 import { ServerError } from '@apollo/client/link/utils';
-
 import chalk from 'chalk';
 
 import http from './api/http';

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -37,10 +37,13 @@ export default function API( {
 } = {} ): ApolloClient< NormalizedCacheObject > {
 	const errorLink = onError( ( { networkError, graphQLErrors } ) => {
 		if ( networkError && 'statusCode' in networkError && networkError.statusCode === 401 ) {
-			console.error(
-				chalk.red( 'Unauthorized:' ),
-				'You are unauthorized to perform this request, please logout with `vip logout` then try again.'
-			);
+			let message =
+				'You are unauthorized to perform this request, please logout with `vip logout` then try again.';
+			if ( 'result' in networkError && networkError.result?.code === 'token-disabled-inactivity' ) {
+				message =
+					'The configured VIP-CLI token has been disabled due to inactivity, please logout with `vip logout` then try again.';
+			}
+			console.error( chalk.red( 'Unauthorized:' ), message );
 			process.exit( 1 );
 		}
 

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -38,7 +38,7 @@ export default function API( {
 	const errorLink = onError( ( { networkError, graphQLErrors } ) => {
 		if ( networkError && 'statusCode' in networkError && networkError.statusCode === 401 ) {
 			let message =
-				'You are unauthorized to perform this request, please logout with `vip logout` then try again.';
+				'You are not authorized to perform this request; please logout with `vip logout`, then try again.';
 			if ( 'result' in networkError && networkError.result?.code === 'token-disabled-inactivity' ) {
 				message =
 					'The configured VIP-CLI token has been disabled due to inactivity, please logout with `vip logout` then try again.';


### PR DESCRIPTION
## Description

This PR adds support for the new unauthorized error for inactive tokens. 

## Changelog Description

Adds support for the disabled token due to inactivity error so that it shows a dedicated error message.

## Pull request checklist

- [ ] Update [SETUP.md](https://github.com/Automattic/vip-cli/blob/trunk/docs/SETUP.md#list-of-environmental-variables) with any new environmental variables.
- [ ] Update [the documentation](https://github.com/Automattic/vip-cli/blob/trunk/docs).
- [X] [Manually test](https://github.com/Automattic/vip-cli/blob/trunk/docs/TESTING.md#manual-testing) the relevant changes.
- [ ] Follow the [pull request checklist](https://github.com/Automattic/vip-cli/blob/trunk/docs/RELEASING.md#new-pull-requests)
- [ ] Add/update [automated tests](https://github.com/Automattic/vip-cli/blob/trunk/docs/TESTING.md#automated-testing) as needed.

## New release checklist

- [ ] [Automated tests](https://github.com/Automattic/vip-cli/blob/trunk/docs/TESTING.md#automated-testing) pass.
- [ ] The [Preparing for release checklist](https://github.com/Automattic/vip-cli/blob/trunk/docs/RELEASING.md#preparing-for-release) is completed.

## Steps to Test

1. Check out PR.
1. Run `npm run build`
1. Run `VIP_PROXY="" API_HOST=http://localhost:4000 node ./dist/bin/vip app list` with a token that is disabled due to inactivity
1. Check the error message is 'Unauthorized: Your token has been disabled due to inactivity, please logout with `vip logout` then try again.'
1. Repeat the same test with a valid token and an expired token, to ensure previous behavior hasn't changed. 
