### PR TITLE
Update socket error handler

### DIFF
--- a/src/bin/vip-wp.js
+++ b/src/bin/vip-wp.js
@@ -66,14 +66,12 @@ const bindStreamEvents = ( { subShellRl, commonTrackingParams, isSubShell, stdou
 	stdoutStream.on( 'error', err => {
 		commandRunning = false;
 
-		setImmediate( () => {
-			if ( criticalErrors.includes( err.code ) ) {
-				console.error( `Error: ${ err.message }` );
-			} else {
-				// TODO handle this better
-				debug( 'Error: ' + err.message );
-			}
-		} );
+		if ( criticalErrors.includes( err.code ) ) {
+			console.error( `Error: ${ err.message }` );
+		} else {
+			// TODO handle this better
+			debug( 'Error: ' + err.message );
+		}
 	} );
 
 	stdoutStream.on( 'end', async () => {


### PR DESCRIPTION
## Description

This update should help users to have a smoother experience running WP-CLI commands.
- Clearer error handling: I've categorized critical errors (like network timeouts or unreachable hosts) to ensure they’re still logged and noticeable, while non-critical errors are managed quietly in the background.
- Better connection recovery: omitting some messages caused by brief network hiccups is less likely to disrupt command streams.
These changes should make command execution feel more stable and responsive, even if this is not the ideal solution.

## Pull request checklist

- [ ] Update [SETUP.md](https://github.com/Automattic/vip-cli/blob/trunk/docs/SETUP.md#list-of-environmental-variables) with any new environmental variables.
- [ ] Update [the documentation](https://github.com/Automattic/vip-cli/blob/trunk/docs).
- [ ] [Manually test](https://github.com/Automattic/vip-cli/blob/trunk/docs/TESTING.md#manual-testing) the relevant changes.
- [ ] Follow the [pull request checklist](https://github.com/Automattic/vip-cli/blob/trunk/docs/RELEASING.md#new-pull-requests)
- [ ] Add/update [automated tests](https://github.com/Automattic/vip-cli/blob/trunk/docs/TESTING.md#automated-testing) as needed.

## New release checklist

- [ ] [Automated tests](https://github.com/Automattic/vip-cli/blob/trunk/docs/TESTING.md#automated-testing) pass.
- [ ] The [Preparing for release checklist](https://github.com/Automattic/vip-cli/blob/trunk/docs/RELEASING.md#preparing-for-release) is completed.

## Steps to Test

Note: to see the actual result, we need to test a wp cli command that will output a large stream and currently will have the "Connection aborted" message in between the streams. 

1. Check out PR.
1. Run `npm run build`
1. Run ` node ./dist/bin/vip-wp @[APP_NAME].[ENVIRONMENT] -y -- option list --format=json `
1. Connection aborted shouldn't be experienced.

Examples of output
Before:
<img width="1642" alt="Screenshot 2024-11-13 at 1 38 45 pm" src="https://github.com/user-attachments/assets/f8dcb3c7-48c2-4c25-9cc7-81e0243129e2">


After:
<img width="1646" alt="Screenshot 2024-11-13 at 1 39 08 pm" src="https://github.com/user-attachments/assets/1244950d-4cc3-41f2-91e2-eeb0487395a3">
