### PR TITLE
Fix --limit arg handling in vip logs command

### DIFF
--- a/src/bin/vip-logs.js
+++ b/src/bin/vip-logs.js
@@ -11,6 +11,7 @@ import { trackEvent } from '../lib/tracker';
 
 const LIMIT_MIN = 1;
 const LIMIT_MAX = 5000;
+const LIMIT_DEFAULT = 500;
 const ALLOWED_TYPES = [ 'app', 'batch' ];
 const ALLOWED_FORMATS = [ 'csv', 'json', 'table' ];
 const DEFAULT_POLLING_DELAY_IN_SECONDS = 30;
@@ -161,6 +162,10 @@ function printLogs( logs, format ) {
  * @param {string} format
  */
 export function validateInputs( type, limit, format ) {
+	if ( limit === undefined ) {
+		limit = LIMIT_DEFAULT;
+	}
+
 	if ( ! ALLOWED_TYPES.includes( type ) ) {
 		exit.withError(
 			`Invalid type: ${ type }. The supported types are: ${ ALLOWED_TYPES.join( ', ' ) }.`
@@ -202,7 +207,7 @@ command( {
 	module: 'logs',
 } )
 	.option( 'type', 'The type of logs to be returned: "app" or "batch"', 'app' )
-	.option( 'limit', 'The maximum number of log lines', 500 )
+	.option( 'limit', `The maximum number of log lines (defaults to ${ LIMIT_DEFAULT })` )
 	.option( 'follow', 'Keep fetching new logs as they are generated' )
 	.option( 'format', 'Output the log lines in CSV or JSON format', 'table' )
 	.examples( [

--- a/src/bin/vip-logs.js
+++ b/src/bin/vip-logs.js
@@ -207,6 +207,7 @@ command( {
 	module: 'logs',
 } )
 	.option( 'type', 'The type of logs to be returned: "app" or "batch"', 'app' )
+	// The default limit is set manually in the validateInputs function to address validation issues, avoiding incorrect replacement of the default value.
 	.option( 'limit', `The maximum number of log lines (defaults to ${ LIMIT_DEFAULT })` )
 	.option( 'follow', 'Keep fetching new logs as they are generated' )
 	.option( 'format', 'Output the log lines in CSV or JSON format', 'table' )


### PR DESCRIPTION
## Description

This PR fixes an issue where invalid inputs like --limit=abc were being replaced with the default before validation.

1. Ensure the default value for --limit (500) is applied only when the flag isn’t provided.
2. Preserve and validate raw user input for --limit, preventing unintended overrides.
3. Added a LIMIT_DEFAULT constant for clarity and consistency.


## Pull request checklist

- [ ] Update [SETUP.md](https://github.com/Automattic/vip-cli/blob/trunk/docs/SETUP.md#list-of-environmental-variables) with any new environmental variables.
- [ ] Update [the documentation](https://github.com/Automattic/vip-cli/blob/trunk/docs).
- [ ] [Manually test](https://github.com/Automattic/vip-cli/blob/trunk/docs/TESTING.md#manual-testing) the relevant changes.
- [ ] Follow the [pull request checklist](https://github.com/Automattic/vip-cli/blob/trunk/docs/RELEASING.md#new-pull-requests)
- [ ] Add/update [automated tests](https://github.com/Automattic/vip-cli/blob/trunk/docs/TESTING.md#automated-testing) as needed.

## New release checklist

- [ ] [Automated tests](https://github.com/Automattic/vip-cli/blob/trunk/docs/TESTING.md#automated-testing) pass.
- [ ] The [Preparing for release checklist](https://github.com/Automattic/vip-cli/blob/trunk/docs/RELEASING.md#preparing-for-release) is completed.

## Steps to Test

Outline the steps to test and verify the PR here.

1. Check out PR.
2. Run `npm run build`
3. Test no `--limit` provided:
 3.1. Run`node ./dist/bin/vip-logs @[APP].[ENV]`
 3.2. Verify: it should use the default limit - 500
4. Test explicit string limit:
4.1. Run `node ./dist/bin/vip-logs @[APP].[ENV] --limit=cookies`
4.2 Verify: it should throw an error: `Invalid limit: cookies. It should be a number between 1 and 5000.`
5. Test explicit number limit:
5.1. Run`node ./dist/bin/vip-logs @[APP].[ENV] --limit=5001`
5.2. Verify: it should throw an error: `Invalid limit: 5001. It should be a number between 1 and 5000.`
