### PR TITLE
fix: `table` format output

### DIFF
--- a/__tests__/bin/vip-logs.js
+++ b/__tests__/bin/vip-logs.js
@@ -63,14 +63,26 @@ describe( 'getLogs', () => {
 			],
 		} ) );
 
-		await getLogs( [], opts );
+		const isTTY = process.stdout.isTTY;
+		try {
+			process.stdout.isTTY = false;
+			await getLogs( [], opts );
+		} finally {
+			process.stdout.isTTY = isTTY;
+		}
 
 		expect( logsLib.getRecentLogs ).toHaveBeenCalledTimes( 1 );
 		expect( logsLib.getRecentLogs ).toHaveBeenCalledWith( 1, 3, 'app', 500 );
 
 		expect( console.log ).toHaveBeenCalledTimes( 1 );
 		expect( console.log ).toHaveBeenCalledWith(
-			'2021-11-05T20:18:36.234041811Z My container message 1\n2021-11-09T20:47:07.301221112Z My container message 2'
+			'┌────────────────────────────────┬────────────────────────┐\n' +
+				'│ Timestamp                      │ Message                │\n' +
+				'├────────────────────────────────┼────────────────────────┤\n' +
+				'│ 2021-11-05T20:18:36.234041811Z │ My container message 1 │\n' +
+				'├────────────────────────────────┼────────────────────────┤\n' +
+				'│ 2021-11-09T20:47:07.301221112Z │ My container message 2 │\n' +
+				'└────────────────────────────────┴────────────────────────┘'
 		);
 
 		const trackingParams = {


### PR DESCRIPTION
## Description

This PR enables the `table` format option for the `vip logs` command to work as expected and for `table` to be the default output format.

See: BB8-11593

## Pull request checklist

- [ ] Update [SETUP.md](https://github.com/Automattic/vip-cli/blob/trunk/docs/SETUP.md#list-of-environmental-variables) with any new environmental variables.
- [ ] Update [the documentation](https://github.com/Automattic/vip-cli/blob/trunk/docs).
- [x] [Manually test](https://github.com/Automattic/vip-cli/blob/trunk/docs/TESTING.md#manual-testing) the relevant changes.
- [x] Follow the [pull request checklist](https://github.com/Automattic/vip-cli/blob/trunk/docs/RELEASING.md#new-pull-requests)
- [ ] Add/update [automated tests](https://github.com/Automattic/vip-cli/blob/trunk/docs/TESTING.md#automated-testing) as needed.

## New release checklist

- [ ] [Automated tests](https://github.com/Automattic/vip-cli/blob/trunk/docs/TESTING.md#automated-testing) pass.
- [ ] The [Preparing for release checklist](https://github.com/Automattic/vip-cli/blob/trunk/docs/RELEASING.md#preparing-for-release) is completed.

## Steps to Test

Compare the output of `vip logs @env` with and without this patch.
