### PR TITLE
Updating Node.js versions and standardize the format

### DIFF
--- a/src/bin/vip-validate-preflight.js
+++ b/src/bin/vip-validate-preflight.js
@@ -25,7 +25,7 @@ import { parseEnvAliasFromArgv } from '../lib/cli/envAlias';
 import * as exit from '../lib/cli/exit';
 import { trackEvent } from '../lib/tracker';
 
-const ALLOWED_NODEJS_VERSIONS = [ '14', '16', '18' ];
+const ALLOWED_NODEJS_VERSIONS = [ '18', '20', '22' ];
 
 export const appQuery = `
 	id
@@ -50,7 +50,7 @@ export const appQuery = `
 `;
 
 let suppressOutput = false;
-let outputJson = false;
+let outputFormat = 'table';
 
 let harmoniaArgs = [];
 
@@ -382,7 +382,7 @@ async function handleResults( harmonia, results ) {
 	} );
 
 	// If the output is JSON, reenable the logToConsole output and print-out the json format.
-	if ( outputJson ) {
+	if ( outputFormat === 'json' ) {
 		suppressOutput = false;
 		logToConsole( harmonia.resultsJSON() );
 		process.exit( 0 );
@@ -490,9 +490,9 @@ async function validateArgs( opt ) {
 	}
 
 	// If the JSON option is enabled, all the stdout should be suppressed to prevent polluting the output.
-	if ( opt.json ) {
+	if ( opt.format === 'json' ) {
 		suppressOutput = true;
-		outputJson = true;
+		outputFormat = 'json';
 	}
 
 	if ( opt.app ) {
@@ -588,7 +588,9 @@ command( commandOpts )
 	)
 	.option(
 		'node-version',
-		'Select a specific target Node.JS version in semver format (MAJOR.MINOR.PATCH) or a MAJOR'
+		`Select a specific target Node.JS version in semver format (MAJOR.MINOR.PATCH) or a MAJOR (${ ALLOWED_NODEJS_VERSIONS.join(
+			', '
+		) })`
 	)
 	.option(
 		'wait',
@@ -599,7 +601,7 @@ command( commandOpts )
 		[ 'p', 'port' ],
 		'Configure the port to use for the app (defaults to a random port between 3001 and 3999)'
 	)
-	.option( 'json', 'Output the results as JSON', false )
+	.option( 'format', 'Output the log lines in CSV or JSON format', 'table' )
 	.option( [ 'P', 'path' ], 'Path to the app to be tested', process.cwd() )
 	.examples( [
 		{
@@ -608,7 +610,7 @@ command( commandOpts )
 				'Runs the preflight tests to validate if your application is ready to be deployed to VIP Go',
 		},
 		{
-			usage: 'vip @mysite.production validate preflight --json > results.json',
+			usage: 'vip @mysite.production validate preflight --format json > results.json',
 			description:
 				'Runs the preflight tests, but output the results in JSON format, and redirect the output to a file',
 		},

--- a/src/lib/config/software.ts
+++ b/src/lib/config/software.ts
@@ -153,6 +153,7 @@ interface VersionChoice {
 	message: string;
 	value: string;
 	disabled?: boolean;
+	deprecated?: boolean;
 }
 
 interface VersionChoices {
@@ -175,16 +176,19 @@ const _optionsForVersion = ( softwareSettings: SoftwareSetting ): VersionChoice[
 			versionChoices.deprecated.push( {
 				message: `${ option.version } (deprecated)`,
 				value: option.version,
+				deprecated: option.deprecated,
 			} );
 		} else if ( option.unstable ) {
 			versionChoices.test.push( {
 				message: `${ option.version } (test)`,
 				value: option.version,
+				deprecated: option.deprecated,
 			} );
 		} else {
 			versionChoices.supported.push( {
 				message: option.version,
 				value: option.version,
+				deprecated: option.deprecated,
 			} );
 		}
 	}
@@ -431,9 +435,12 @@ export const formatSoftwareSettings = (
 	};
 
 	if ( includes.includes( 'available_versions' ) ) {
-		result.available_versions = _optionsForVersion( softwareSetting ).map( option => option.value );
+		result.available_versions = _optionsForVersion( softwareSetting )
+			.filter( option => ! option.deprecated )
+			.map( option => option.value );
+
 		if ( format !== 'json' ) {
-			result.available_versions = result.available_versions.join( ',' );
+			result.available_versions = result.available_versions.sort().join( ',' );
 		}
 	}
 


### PR DESCRIPTION
## Description

The `ALLOWED_NODEJS_VERSIONS` versions in `vip validate-preflight` contain outdated versions. This PR updates the list of available versions to the latest `node` versions - `18, 20, 22`

Standardize the `format` options for the `vip validate preflight` command

## Pull request checklist

- [ ] Update [SETUP.md](https://github.com/Automattic/vip-cli/blob/trunk/docs/SETUP.md#list-of-environmental-variables) with any new environmental variables.
- [ ] Update [the documentation](https://github.com/Automattic/vip-cli/blob/trunk/docs).
- [ ] [Manually test](https://github.com/Automattic/vip-cli/blob/trunk/docs/TESTING.md#manual-testing) the relevant changes.
- [ ] Follow the [pull request checklist](https://github.com/Automattic/vip-cli/blob/trunk/docs/RELEASING.md#new-pull-requests)
- [ ] Add/update [automated tests](https://github.com/Automattic/vip-cli/blob/trunk/docs/TESTING.md#automated-testing) as needed.

## New release checklist

- [ ] [Automated tests](https://github.com/Automattic/vip-cli/blob/trunk/docs/TESTING.md#automated-testing) pass.
- [ ] The [Preparing for release checklist](https://github.com/Automattic/vip-cli/blob/trunk/docs/RELEASING.md#preparing-for-release) is completed.

## Steps to Test

1. Pull down the PR
2. Run `npm run build`
3. run `npm run test`
