### PR TITLE
Add --format="text" option to vip logs

### DIFF
--- a/src/bin/vip-logs.js
+++ b/src/bin/vip-logs.js
@@ -249,7 +249,7 @@ command( {
 		`The maximum number of entries to return. Accepts an integer value between 1 and 5000 (defaults to ${ LIMIT_DEFAULT }).`
 	)
 	.option( 'follow', 'Output new entries as they are generated.' )
-	.option( 'format', 'Render output in a particular format. Accepts “csv”, and “json”.', 'table' )
+	.option( 'format', 'Render output in a particular format. Accepts “csv”, “json” and “text”.', 'table' )
 	.examples( [
 		{
 			usage: 'vip @example-app.production logs',

--- a/src/bin/vip-logs.js
+++ b/src/bin/vip-logs.js
@@ -148,7 +148,7 @@ function printLogs( logs, format ) {
 	} );
 
 	let output = '';
-	if ( format && 'table' === format ) {
+	if ( 'table' === format ) {
 		const options = {
 			wordWrap: true,
 			wrapOnWordBoundary: true,
@@ -179,7 +179,7 @@ function printLogs( logs, format ) {
 		}
 
 		output = table.toString();
-	} else if ( format && 'text' === format ) {
+	} else if ( 'text' === format ) {
 		const rows = [];
 		for ( const { timestamp, message } of logs ) {
 			rows.push( `${ timestamp } ${ message }` );

--- a/src/bin/vip-logs.js
+++ b/src/bin/vip-logs.js
@@ -249,7 +249,7 @@ command( {
 		`The maximum number of entries to return. Accepts an integer value between 1 and 5000 (defaults to ${ LIMIT_DEFAULT }).`
 	)
 	.option( 'follow', 'Output new entries as they are generated.' )
-	.option( 'format', 'Render output in a particular format. Accepts “csv”, “json” and “text”.', 'table' )
+	.option( 'format', 'Render output in a particular format. Accepts “csv”, “json”, and “text”.', 'table' )
 	.examples( [
 		{
 			usage: 'vip @example-app.production logs',

--- a/src/bin/vip-logs.js
+++ b/src/bin/vip-logs.js
@@ -14,7 +14,7 @@ const LIMIT_MIN = 1;
 const LIMIT_MAX = 5000;
 const LIMIT_DEFAULT = 500;
 const ALLOWED_TYPES = [ 'app', 'batch' ];
-const ALLOWED_FORMATS = [ 'csv', 'json', 'table' ];
+const ALLOWED_FORMATS = [ 'csv', 'json', 'table', 'text' ];
 const DEFAULT_POLLING_DELAY_IN_SECONDS = 30;
 const MIN_POLLING_DELAY_IN_SECONDS = 5;
 const MAX_POLLING_DELAY_IN_SECONDS = 300;
@@ -179,6 +179,12 @@ function printLogs( logs, format ) {
 		}
 
 		output = table.toString();
+	} else if ( format && 'text' === format ) {
+		const rows = [];
+		for ( const { timestamp, message } of logs ) {
+			rows.push( `${ timestamp } ${ message }` );
+			output = rows.join( '\n' );
+		}
 	} else {
 		output = formatData( logs, format );
 	}


### PR DESCRIPTION
## Description

In https://github.com/Automattic/vip-cli/pull/2089 the `table` option was formatted to meet a style guide's requirements. I see the default option was actually previously `table` but not formatted as a table so this change makes sense. 

The previous basic text format was nice to have especially when using the `--follow` flag and matches what is described here https://docs.wpvip.com/logs/runtime-logs/cli/

The docs mention an option for formatting called `text` and this PR enables that option and restores the previous formatting of the logs under that option:
https://github.com/Automattic/vip-cli/blame/19c65e4758b30be5d9708ae807f754f2a6883ef1/src/bin/vip-logs.js#L146-L151

## Pull request checklist

- [ n/a ] Update [SETUP.md](https://github.com/Automattic/vip-cli/blob/trunk/docs/SETUP.md#list-of-environmental-variables) with any new environmental variables.
- [ n/a ] Update [the documentation](https://github.com/Automattic/vip-cli/blob/trunk/docs).
- [x] [Manually test](https://github.com/Automattic/vip-cli/blob/trunk/docs/TESTING.md#manual-testing) the relevant changes.
- [x] Follow the [pull request checklist](https://github.com/Automattic/vip-cli/blob/trunk/docs/RELEASING.md#new-pull-requests)
- [ n/a ] Add/update [automated tests](https://github.com/Automattic/vip-cli/blob/trunk/docs/TESTING.md#automated-testing) as needed.

## New release checklist

- [x] [Automated tests](https://github.com/Automattic/vip-cli/blob/trunk/docs/TESTING.md#automated-testing) pass.
- [ ] The [Preparing for release checklist](https://github.com/Automattic/vip-cli/blob/trunk/docs/RELEASING.md#preparing-for-release) is completed.

## Steps to Test

Outline the steps to test and verify the PR here.

Example:

1. Check out PR.
1. Run `npm run build`
1. Run `./dist/bin/vip-cookies.js nom`
1. Verify cookies are delicious.
