### PR TITLE
Set the mount path for vip-config to ABSPATH/vip-config to match production

### DIFF
--- a/assets/dev-env.lando.template.yml.ejs
+++ b/assets/dev-env.lando.template.yml.ejs
@@ -332,7 +332,7 @@ tooling:
             nocopy: true
         - type: volume
           source: clientcode_vipconfig
-          target: /wp/wp-content/vip-config
+          target: /wp/vip-config
           volume:
             nocopy: true
 <% } else { %>
@@ -342,6 +342,6 @@ tooling:
         - <%= appCode.dir %>/plugins:/wp/wp-content/plugins
         - <%= appCode.dir %>/private:/wp/wp-content/private
         - <%= appCode.dir %>/themes:/wp/wp-content/themes
-        - <%= appCode.dir %>/vip-config:/wp/wp-content/vip-config
+        - <%= appCode.dir %>/vip-config:/wp/vip-config
 <% } %>
 <% } %>

--- a/src/lib/constants/dev-environment.ts
+++ b/src/lib/constants/dev-environment.ts
@@ -49,4 +49,4 @@ export const DEV_ENVIRONMENT_DEFAULTS = {
 	phpVersion: Object.keys( DEV_ENVIRONMENT_PHP_VERSIONS )[ 0 ],
 } as const;
 
-export const DEV_ENVIRONMENT_VERSION = '2.1.1';
+export const DEV_ENVIRONMENT_VERSION = '2.1.2';


### PR DESCRIPTION
## Description

For legacy reasons we were loading `vip-config.php` from `/wp/wp-content/vip-config.php`. This broke sunrise loader because it was expected to be loaded from  `ABSPATH . /vip-config/` rather than from `WP_CONTENT_DIR . /vip-config/`.

We've implemented a fallback loader in the dev env awhile back, so this change shouldn't negatively affect existing environments. 

This also bumps `DEV_ENVIRONMENT_VERSION` to ensure that `.lando.yml` will be regenerated on startup.

## Pull request checklist

- [ ] Update [SETUP.md](https://github.com/Automattic/vip-cli/blob/trunk/docs/SETUP.md#list-of-environmental-variables) with any new environmental variables.
- [ ] Update [the documentation](https://github.com/Automattic/vip-cli/blob/trunk/docs).
- [ ] [Manually test](https://github.com/Automattic/vip-cli/blob/trunk/docs/TESTING.md#manual-testing) the relevant changes.
- [ ] Follow the [pull request checklist](https://github.com/Automattic/vip-cli/blob/trunk/docs/RELEASING.md#new-pull-requests)
- [ ] Add/update [automated tests](https://github.com/Automattic/vip-cli/blob/trunk/docs/TESTING.md#automated-testing) as needed.

## New release checklist

- [ ] [Automated tests](https://github.com/Automattic/vip-cli/blob/trunk/docs/TESTING.md#automated-testing) pass.
- [ ] The [Preparing for release checklist](https://github.com/Automattic/vip-cli/blob/trunk/docs/RELEASING.md#preparing-for-release) is completed.

## Steps to Test

1. Check out PR.
1. Run `npm run build && npm link`
1. Spin up an environment, add `define( 'SUNRISE', true );` to wp-config-defaults.php
2. Make some changes to `/vip-config/client-sunrise.php` (like `exit`)` or run a file_exists check from `wp shell` 