### PR TITLE
fix: make the help text for the `format` option consistent for all commands

### DIFF
--- a/src/bin/vip-app-list.js
+++ b/src/bin/vip-app-list.js
@@ -8,7 +8,7 @@ import { trackEvent } from '../lib/tracker';
 
 const baseUsage = 'vip app list';
 
-command( { format: true, usage: baseUsage } )
+command( { usage: baseUsage } )
 	.examples( [
 		{
 			usage:

--- a/src/bin/vip-app-list.js
+++ b/src/bin/vip-app-list.js
@@ -8,7 +8,7 @@ import { trackEvent } from '../lib/tracker';
 
 const baseUsage = 'vip app list';
 
-command( { usage: baseUsage } )
+command( { format: true, usage: baseUsage } )
 	.examples( [
 		{
 			usage:

--- a/src/bin/vip-app.js
+++ b/src/bin/vip-app.js
@@ -6,7 +6,7 @@ import app from '../lib/api/app';
 import command, { getEnvIdentifier } from '../lib/cli/command';
 import { trackEvent } from '../lib/tracker';
 
-command( { requiredArgs: 1, format: true } )
+command( { requiredArgs: 1 } )
 	.example(
 		'vip app list',
 		'Retrieve a list of applications that can be accessed by the current authenticated VIP-CLI user.'

--- a/src/bin/vip-logs.js
+++ b/src/bin/vip-logs.js
@@ -251,8 +251,7 @@ command( {
 	.option( 'follow', 'Output new entries as they are generated.' )
 	.option(
 		'format',
-		'Render output in a particular format. Accepts “csv”, “json”, and “text”.',
-		'table'
+		'Render output in a particular format. Accepts “table“ (default), “csv“, “json“, and “text”.'
 	)
 	.examples( [
 		{

--- a/src/bin/vip-slowlogs.ts
+++ b/src/bin/vip-slowlogs.ts
@@ -190,7 +190,7 @@ void command( {
 	appContext: true,
 	appQuery,
 	envContext: true,
-	format: false,
+	format: true,
 	module: 'slowlogs',
 	usage: baseUsage,
 } )
@@ -199,7 +199,6 @@ void command( {
 		'Set the maximum number of log entries. Accepts an integer value between 1 and 500.',
 		500
 	)
-	.option( 'format', 'Render output in a particular format. Accepts “csv”, and “json”.', 'table' )
 	.examples( [
 		{
 			description:

--- a/src/bin/vip-validate-preflight.js
+++ b/src/bin/vip-validate-preflight.js
@@ -560,6 +560,7 @@ function sanitizeArgsForTracking( args ) {
 
 let commandOpts = {
 	module: 'harmonia',
+	format: true,
 };
 
 // The @app.env selector is optional, so we need to check if it was passed
@@ -601,7 +602,6 @@ command( commandOpts )
 		[ 'p', 'port' ],
 		'Configure the port to use for the app (defaults to a random port between 3001 and 3999)'
 	)
-	.option( 'format', 'Output the log lines in CSV or JSON format', 'table' )
 	.option( [ 'P', 'path' ], 'Path to the app to be tested', process.cwd() )
 	.examples( [
 		{

--- a/src/lib/cli/command.js
+++ b/src/lib/cli/command.js
@@ -67,6 +67,10 @@ args.argv = async function ( argv, cb ) {
 		debug: false,
 	} );
 
+	if ( _opts.format && ! options.format ) {
+		options.format = 'table';
+	}
+
 	if ( options.h || options.help ) {
 		this.showHelp();
 	}
@@ -603,8 +607,7 @@ export default function ( opts ) {
 	if ( _opts.format ) {
 		args.option(
 			'format',
-			'Render output in a particular format. Accepts “csv”, and “json”.',
-			'table'
+			'Render output in a particular format. Accepts “table“ (default), “csv“, and “json“.'
 		);
 	}
 


### PR DESCRIPTION
## Description

As discussed, this PR changes the help text for the `--format` option to

```
Render output in a particular format. Accepts “table“ (default), “csv“, and “json“.
```

Affected commands:
* `vip app list`
* `vip config envvar get-all`
* `vip config software get`
* `vip config envvar list`
* `vip logs` (a `text` option is added to the list)
* `vip slowlogs`
* `vip validate preflight`

## Pull request checklist

- [ ] Update [SETUP.md](https://github.com/Automattic/vip-cli/blob/trunk/docs/SETUP.md#list-of-environmental-variables) with any new environmental variables.
- [ ] Update [the documentation](https://github.com/Automattic/vip-cli/blob/trunk/docs).
- [x] [Manually test](https://github.com/Automattic/vip-cli/blob/trunk/docs/TESTING.md#manual-testing) the relevant changes.
- [x] Follow the [pull request checklist](https://github.com/Automattic/vip-cli/blob/trunk/docs/RELEASING.md#new-pull-requests)
- [ ] Add/update [automated tests](https://github.com/Automattic/vip-cli/blob/trunk/docs/TESTING.md#automated-testing) as needed.

## New release checklist

- [ ] [Automated tests](https://github.com/Automattic/vip-cli/blob/trunk/docs/TESTING.md#automated-testing) pass.
- [ ] The [Preparing for release checklist](https://github.com/Automattic/vip-cli/blob/trunk/docs/RELEASING.md#preparing-for-release) is completed.

## Steps to Test

Run the mentioned commands and make sure they still work.
