### PR TITLE
Add a warning on `vip export` when exporting a MyDumper SQL dump

### DIFF
--- a/src/commands/export-sql.generated.d.ts
+++ b/src/commands/export-sql.generated.d.ts
@@ -13,12 +13,14 @@ export type AppBackupAndJobStatusQuery = {
 		environments?: Array< {
 			__typename?: 'AppEnvironment';
 			id?: number | null;
+			backupsSqlDumpTool?: string | null;
 			latestBackup?: {
 				__typename?: 'Backup';
 				id?: number | null;
 				type?: string | null;
 				size?: number | null;
 				filename?: string | null;
+				sqlDumpTool?: string | null;
 				createdAt?: string | null;
 			} | null;
 			jobs?: Array<

--- a/src/commands/export-sql.ts
+++ b/src/commands/export-sql.ts
@@ -33,11 +33,13 @@ const BACKUP_AND_JOB_STATUS_QUERY = gql`
 			id
 			environments(id: $envId) {
 				id
+				backupsSqlDumpTool
 				latestBackup {
 					id
 					type
 					size
 					filename
+					sqlDumpTool
 					createdAt
 				}
 				jobs(jobTypes: [db_backup_copy]) {
@@ -98,6 +100,7 @@ async function fetchLatestBackupAndJobStatusBase(
 ): Promise< {
 	latestBackup: Backup | undefined;
 	jobs: Job[];
+	envSqlDumpTool: string | null | undefined;
 } > {
 	const api = API();
 
@@ -108,11 +111,12 @@ async function fetchLatestBackupAndJobStatusBase(
 	} );
 
 	const environments = response.data.app?.environments;
+	const envSqlDumpTool = environments?.[ 0 ]?.backupsSqlDumpTool;
 
 	const latestBackup: Backup | undefined = environments?.[ 0 ]?.latestBackup as Backup;
 	const jobs: Job[] = ( environments?.[ 0 ]?.jobs || [] ) as Job[];
 
-	return { latestBackup, jobs };
+	return { latestBackup, jobs, envSqlDumpTool };
 }
 
 async function fetchLatestBackupAndJobStatus(
@@ -412,7 +416,10 @@ export class ExportSQLCommand {
 			await this.runBackupJob();
 		}
 
-		const { latestBackup } = await fetchLatestBackupAndJobStatus( this.app.id, this.env.id );
+		const { latestBackup, envSqlDumpTool } = await fetchLatestBackupAndJobStatus(
+			this.app.id,
+			this.env.id
+		);
 
 		if ( ! latestBackup ) {
 			await this.track( 'error', {
@@ -433,6 +440,18 @@ export class ExportSQLCommand {
 				`${ getGlyphForStatus( 'success' ) } Backup created with timestamp ${
 					latestBackup.createdAt
 				}`
+			);
+		}
+
+		const showMyDumperWarning = ( latestBackup.sqlDumpTool ?? envSqlDumpTool ) === 'mydumper';
+		if ( showMyDumperWarning ) {
+			console.warn(
+				chalk.yellow.bold( 'WARNING:' ),
+				chalk.yellow(
+					'This is a large or complex database. The backup file for this database is generated with MyDumper. ' +
+						'The file can only be loaded with MyLoader. ' +
+						'For more information: https://github.com/mydumper/mydumper'
+				)
 			);
 		}
 

--- a/src/graphqlTypes.d.ts
+++ b/src/graphqlTypes.d.ts
@@ -1186,6 +1186,7 @@ export type Backup = {
 	filename?: Maybe< Scalars[ 'String' ][ 'output' ] >;
 	id?: Maybe< Scalars[ 'Float' ][ 'output' ] >;
 	size?: Maybe< Scalars[ 'Float' ][ 'output' ] >;
+	sqlDumpTool?: Maybe< Scalars[ 'String' ][ 'output' ] >;
 	type?: Maybe< Scalars[ 'String' ][ 'output' ] >;
 };
 


### PR DESCRIPTION
## Description

Add a warning on `vip export` when exporting a MyDumper SQL dump.

Before:
![Screenshot_2024-11-27_11-26-11](https://github.com/user-attachments/assets/a9885770-4530-4432-875f-0889b8a66c10)

After: 
![Screenshot_2024-11-27_11-26-57](https://github.com/user-attachments/assets/09fe74ef-6f28-4bf2-b4e3-a5fdf06abbff)

## Pull request checklist

- [ ] Update [SETUP.md](https://github.com/Automattic/vip-cli/blob/trunk/docs/SETUP.md#list-of-environmental-variables) with any new environmental variables.
- [ ] Update [the documentation](https://github.com/Automattic/vip-cli/blob/trunk/docs).
- [ ] [Manually test](https://github.com/Automattic/vip-cli/blob/trunk/docs/TESTING.md#manual-testing) the relevant changes.
- [ ] Follow the [pull request checklist](https://github.com/Automattic/vip-cli/blob/trunk/docs/RELEASING.md#new-pull-requests)
- [ ] Add/update [automated tests](https://github.com/Automattic/vip-cli/blob/trunk/docs/TESTING.md#automated-testing) as needed.

## New release checklist

- [ ] [Automated tests](https://github.com/Automattic/vip-cli/blob/trunk/docs/TESTING.md#automated-testing) pass.
- [ ] The [Preparing for release checklist](https://github.com/Automattic/vip-cli/blob/trunk/docs/RELEASING.md#preparing-for-release) is completed.

## Steps to Test

1. Check out PR.
1. Run `npm run build`
1. Run `./dist/bin/vip-export-sql.js @yourapp.develop`
1. Verify the warning only shows for sites using MyDumper as the SQL dump tool.
