### PR TITLE
refactor(dev-env): bypass Lando entrypoint for auxiliary images

### DIFF
--- a/assets/dev-env.lando.template.yml.ejs
+++ b/assets/dev-env.lando.template.yml.ejs
@@ -212,7 +212,7 @@ services:
     volumes:
       mu-plugins: {}
     initOnly: true
-    entrypoint: /run.sh
+    entrypoint: /usr/bin/rsync -a --delete-after --chown=${LANDO_HOST_USER_ID}:${LANDO_HOST_GROUP_ID} /mu-plugins/ /shared/
 <% } %>
 
 <% if ( appCode.mode == 'image' ) { %>

--- a/assets/dev-env.lando.template.yml.ejs
+++ b/assets/dev-env.lando.template.yml.ejs
@@ -110,10 +110,8 @@ services:
     services:
 <% if ( mariadb ) { %>
       image: mariadb:<%= mariadb %>
-      command: docker-entrypoint.sh mysqld --sql-mode=ERROR_FOR_DIVISION_BY_ZERO,NO_AUTO_CREATE_USER,NO_ENGINE_SUBSTITUTION --max_allowed_packet=67M
 <% } else { %>
       image: mysql:8.4
-      command: docker-entrypoint.sh mysqld --sql-mode=ERROR_FOR_DIVISION_BY_ZERO,NO_ENGINE_SUBSTITUTION --max_allowed_packet=67M --mysql-native-password=ON
 <% } %>
       ports:
         - ":3306"
@@ -129,6 +127,11 @@ services:
         - database_data:/var/lib/mysql
     volumes:
       database_data:
+<% if ( mariadb ) { %>
+    entrypoint: docker-entrypoint.sh mysqld --sql-mode=ERROR_FOR_DIVISION_BY_ZERO,NO_AUTO_CREATE_USER,NO_ENGINE_SUBSTITUTION --max_allowed_packet=67M
+<% } else { %>
+    entrypoint: docker-entrypoint.sh mysqld --sql-mode=ERROR_FOR_DIVISION_BY_ZERO,NO_ENGINE_SUBSTITUTION --max_allowed_packet=67M --mysql-native-password=ON
+<% } %>
 
   memcached:
     type: compose

--- a/assets/dev-env.lando.template.yml.ejs
+++ b/assets/dev-env.lando.template.yml.ejs
@@ -120,9 +120,6 @@ services:
         MYSQL_USER: wordpress
         MYSQL_PASSWORD: wordpress
         MYSQL_DATABASE: wordpress
-        LANDO_NO_USER_PERMS: 1
-        LANDO_NO_SCRIPTS: 1
-        LANDO_NEEDS_EXEC: 1
       volumes:
         - database_data:/var/lib/mysql
     volumes:
@@ -151,8 +148,6 @@ services:
         PMA_USER: root
         PMA_PASSWORD: ''
         UPLOAD_LIMIT: 4G
-        LANDO_NO_USER_PERMS: 1
-        LANDO_NEEDS_EXEC: 1
       ports:
         - 127.0.0.1::80
       volumes:
@@ -189,11 +184,6 @@ services:
       image: ghcr.io/automattic/vip-container-images/wordpress:<%= wordpress.tag %>
       volumes:
         - ./wordpress:/shared
-        - type: volume
-          source: scripts
-          target: /scripts
-          volume:
-            nocopy: true
     initOnly: true
     entrypoint: /usr/bin/rsync -a --chown=${LANDO_HOST_USER_ID}:${LANDO_HOST_GROUP_ID} /wp/ /shared/
 
@@ -204,11 +194,6 @@ services:
       image: ghcr.io/automattic/vip-container-images/mu-plugins:0.1
       volumes:
         - mu-plugins:/shared
-        - type: volume
-          source: scripts
-          target: /scripts
-          volume:
-            nocopy: true
     volumes:
       mu-plugins: {}
     initOnly: true

--- a/assets/dev-env.lando.template.yml.ejs
+++ b/assets/dev-env.lando.template.yml.ejs
@@ -134,18 +134,13 @@ services:
     type: compose
     services:
       image: memcached:1.6-alpine
-      command: memcached -m 64
-      environment:
-        LANDO_NO_USER_PERMS: 1
-        LANDO_NO_SCRIPTS: 1
-        LANDO_NEEDS_EXEC: 1
+    entrypoint: /usr/local/bin/memcached -m 64
 
 <% if ( phpmyadmin ) { %>
   phpmyadmin:
     type: compose
     services:
       image: phpmyadmin:5
-      command: /docker-entrypoint.sh apache2-foreground
       environment:
         MYSQL_ROOT_PASSWORD: ''
         PMA_HOSTS: database
@@ -161,6 +156,7 @@ services:
         - pma_www:/var/www/html
     volumes:
       pma_www:
+    entrypoint: /docker-entrypoint.sh apache2-foreground
 <% } %>
 
 <% if ( elasticsearch ) { %>
@@ -168,7 +164,6 @@ services:
     type: compose
     services:
       image: elasticsearch:7.17.8
-      command: /usr/local/bin/docker-entrypoint.sh
       environment:
         ELASTICSEARCH_IS_DEDICATED_NODE: 'no'
         ELASTICSEARCH_CLUSTER_NAME: 'bespin'
@@ -176,15 +171,13 @@ services:
         ELASTICSEARCH_PORT_NUMBER: 9200
         discovery.type: 'single-node'
         xpack.security.enabled: 'false'
-        LANDO_NO_USER_PERMS: 1
-        LANDO_NO_SCRIPTS: 1
-        LANDO_NEEDS_EXEC: 1
       ports:
         - ":9200"
       volumes:
         - search_data:/usr/share/elasticsearch/data
     volumes:
       search_data:
+    entrypoint: /usr/local/bin/docker-entrypoint.sh
 <% } %>
 
   wordpress:
@@ -227,7 +220,6 @@ services:
     type: compose
     services:
       image: ghcr.io/automattic/vip-container-images/skeleton:latest
-      command: exit 0
       volumes:
         - clientcode_clientmuPlugins:/clientcode/client-mu-plugins
         - clientcode_images:/clientcode/images
@@ -245,6 +237,7 @@ services:
       clientcode_themes: {}
       clientcode_vipconfig: {}
     initOnly: true
+    entrypoint: /bin/true
 <% } %>
 
 <% if ( mailpit ) { %>
@@ -252,13 +245,10 @@ services:
     type: compose
     services:
       image: axllent/mailpit:latest
-      command: /mailpit
       ports:
         - ":1025"
         - ":8025"
-      environment:
-        LANDO_NO_USER_PERMS: 1
-        LANDO_NEEDS_EXEC: 1
+    entrypoint: /mailpit
 <% } %>
 
 <% if ( photon ) { %>
@@ -266,13 +256,9 @@ services:
     type: compose
     services:
       image: ghcr.io/automattic/vip-container-images/photon:latest
-      command: /usr/sbin/php-fpm
-      environment:
-        LANDO_NO_USER_PERMS: 1
-        LANDO_NO_SCRIPTS: 1
-        LANDO_NEEDS_EXEC: 1
       volumes:
         - ./uploads:/usr/share/webapps/photon/uploads:ro
+    entrypoint: /usr/sbin/php-fpm
 <% } %>
 
 tooling:

--- a/assets/dev-env.lando.template.yml.ejs
+++ b/assets/dev-env.lando.template.yml.ejs
@@ -76,7 +76,7 @@ services:
           condition: service_completed_successfully
 <% if ( muPlugins.mode == 'image' ) { %>
         vip-mu-plugins:
-          condition: service_started
+          condition: service_completed_successfully
 <% } %>
 <% if ( appCode.mode == 'image' ) { %>
         demo-app-code:
@@ -202,7 +202,6 @@ services:
     type: compose
     services:
       image: ghcr.io/automattic/vip-container-images/mu-plugins:0.1
-      command: sh /run.sh
       volumes:
         - mu-plugins:/shared
         - type: volume
@@ -210,12 +209,10 @@ services:
           target: /scripts
           volume:
             nocopy: true
-      environment:
-        LANDO_NO_SCRIPTS: 1
-        LANDO_NEEDS_EXEC: 1
     volumes:
       mu-plugins: {}
     initOnly: true
+    entrypoint: /run.sh
 <% } %>
 
 <% if ( appCode.mode == 'image' ) { %>

--- a/src/lib/constants/dev-environment.ts
+++ b/src/lib/constants/dev-environment.ts
@@ -49,4 +49,4 @@ export const DEV_ENVIRONMENT_DEFAULTS = {
 	phpVersion: Object.keys( DEV_ENVIRONMENT_PHP_VERSIONS )[ 0 ],
 } as const;
 
-export const DEV_ENVIRONMENT_VERSION = '2.1.3';
+export const DEV_ENVIRONMENT_VERSION = '2.1.4';


### PR DESCRIPTION
## Description

This PR updates the Landofile template to completely bypass the Lando entry point for auxiliary images that do not need custom scripts or permissions sweeps.

This:
* reduces the number of mounts;
* improves startup time (entry point scripts are executed directly, bypassing bash + Lando entry point script);
* slightly reduces memory usage;
* allows us to use distroless images (Automattic/vip-container-images#983, Automattic/vip-container-images#984).

## Pull request checklist

- [ ] Update [SETUP.md](https://github.com/Automattic/vip-cli/blob/trunk/docs/SETUP.md#list-of-environmental-variables) with any new environmental variables.
- [ ] Update [the documentation](https://github.com/Automattic/vip-cli/blob/trunk/docs).
- [x] [Manually test](https://github.com/Automattic/vip-cli/blob/trunk/docs/TESTING.md#manual-testing) the relevant changes.
- [x] Follow the [pull request checklist](https://github.com/Automattic/vip-cli/blob/trunk/docs/RELEASING.md#new-pull-requests)
- [ ] Add/update [automated tests](https://github.com/Automattic/vip-cli/blob/trunk/docs/TESTING.md#automated-testing) as needed.

## New release checklist

- [ ] [Automated tests](https://github.com/Automattic/vip-cli/blob/trunk/docs/TESTING.md#automated-testing) pass.
- [ ] The [Preparing for release checklist](https://github.com/Automattic/vip-cli/blob/trunk/docs/RELEASING.md#preparing-for-release) is completed.

## Steps to Test

```sh
vip dev-env create -e -A -H -p < /dev/null
vip dev-env start
docker ps
```

* `ghcr.io/automattic/vip-container-images/nginx:latest`, `elasticsearch:7.17.8`, `phpmyadmin:5`, `axllent/mailpit:latest`, `memcached:1.6-alpine`, and `mysql:8.4` containers must be running, and their `COMMAND` must not mention `lando-entrypoint`;
* `vip dev-env logs -S demo-app-code` must return nothing;
* `vip dev-env logs -S devtools` must return nothing;
* `vip dev-env logs -S wordpress` must return nothing;
* the environment must work.
