### PR TITLE
Change the error description for when a token is disabled due to inactivity

### DIFF
--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -54,7 +54,7 @@ export default function API( {
 				networkError.result?.code === 'token-disabled-inactivity'
 			) {
 				message =
-					'Your token has been disabled due to inactivity; please log out with `vip logout`, then try again.';
+					'Your token has expired due to inactivity; please log out with `vip logout`, then try again.';
 			}
 			console.error( chalk.red( 'Unauthorized:' ), message );
 			process.exit( 1 );


### PR DESCRIPTION
## Description

Improved the error message we provide to the user when a token is marked as disabled due to inactivity.
This is a followup to #2084 

## Pull request checklist

- [ ] Update [SETUP.md](https://github.com/Automattic/vip-cli/blob/trunk/docs/SETUP.md#list-of-environmental-variables) with any new environmental variables.
- [ ] Update [the documentation](https://github.com/Automattic/vip-cli/blob/trunk/docs).
- [ ] [Manually test](https://github.com/Automattic/vip-cli/blob/trunk/docs/TESTING.md#manual-testing) the relevant changes.
- [ ] Follow the [pull request checklist](https://github.com/Automattic/vip-cli/blob/trunk/docs/RELEASING.md#new-pull-requests)
- [ ] Add/update [automated tests](https://github.com/Automattic/vip-cli/blob/trunk/docs/TESTING.md#automated-testing) as needed.

## New release checklist

- [ ] [Automated tests](https://github.com/Automattic/vip-cli/blob/trunk/docs/TESTING.md#automated-testing) pass.
- [ ] The [Preparing for release checklist](https://github.com/Automattic/vip-cli/blob/trunk/docs/RELEASING.md#preparing-for-release) is completed.

## Steps to Test

Follow the testing steps in #2084 and ensure the error now states
```
Your token has been disabled due to inactivity; please log out with `vip logout`, then try again.
```
