### PR TITLE
refactor(dev-env): let `dev-tools` handle their volumes

### DIFF
--- a/assets/dev-env.lando.template.yml.ejs
+++ b/assets/dev-env.lando.template.yml.ejs
@@ -19,7 +19,6 @@ services:
     type: compose
     services:
       image: ghcr.io/automattic/vip-container-images/dev-tools:0.9
-      command: /bin/true
       volumes:
         - devtools:/dev-tools
         - scripts:/scripts
@@ -31,6 +30,7 @@ services:
       devtools: {}
       scripts:
     initOnly: true
+    entrypoint: sh -c 'test -d /dev-tools-orig && /usr/bin/rsync -a --delete /dev-tools-orig/ /dev-tools/ || true'
 
   nginx:
     type: compose
@@ -66,6 +66,17 @@ services:
 <% } %>
         LANDO_NO_USER_PERMS: 'enable'
         LANDO_NEEDS_EXEC: 1
+      depends_on:
+        database:
+          condition: service_started
+        memcached:
+          condition: service_started
+<% if ( elasticsearch ) { %>
+        elasticsearch:
+          condition: service_started
+<% } %>
+        devtools:
+          condition: service_completed_successfully
       volumes:
         - type: volume
           source: devtools

--- a/assets/dev-env.lando.template.yml.ejs
+++ b/assets/dev-env.lando.template.yml.ejs
@@ -22,10 +22,6 @@ services:
       volumes:
         - devtools:/dev-tools
         - scripts:/scripts
-      environment:
-        LANDO_NO_USER_PERMS: 1
-        LANDO_NO_SCRIPTS: 1
-        LANDO_NEEDS_EXEC: 1
     volumes:
       devtools: {}
       scripts:
@@ -38,14 +34,13 @@ services:
     sslExpose: false
     services:
       image: ghcr.io/automattic/vip-container-images/nginx:latest
-      command: nginx -g "daemon off;"
-      environment:
-        LANDO_NEEDS_EXEC: 1
-        LANDO_WEBROOT_USER: nginx
-        LANDO_WEBROOT_GROUP: nginx
       volumes:
         - ./nginx/extra.conf:/etc/nginx/conf.extra/extra.conf
 <% wpVolumes() %>
+      depends_on:
+        php:
+          condition: service_started
+    entrypoint: /usr/sbin/nginx -g "daemon off;"
 
   php:
     type: compose
@@ -77,6 +72,16 @@ services:
 <% } %>
         devtools:
           condition: service_completed_successfully
+        wordpress:
+          condition: service_started
+<% if ( muPlugins.mode == 'image' ) { %>
+        vip-mu-plugins:
+          condition: service_started
+<% } %>
+<% if ( appCode.mode == 'image' ) { %>
+        demo-app-code:
+          condition: service_completed_successfully
+<% } %>
       volumes:
         - type: volume
           source: devtools

--- a/src/lib/constants/dev-environment.ts
+++ b/src/lib/constants/dev-environment.ts
@@ -49,4 +49,4 @@ export const DEV_ENVIRONMENT_DEFAULTS = {
 	phpVersion: Object.keys( DEV_ENVIRONMENT_PHP_VERSIONS )[ 0 ],
 } as const;
 
-export const DEV_ENVIRONMENT_VERSION = '2.1.2';
+export const DEV_ENVIRONMENT_VERSION = '2.1.3';

--- a/src/lib/dev-environment/dev-environment-lando.ts
+++ b/src/lib/dev-environment/dev-environment-lando.ts
@@ -285,8 +285,6 @@ export async function landoRebuild( lando: Lando, instancePath: string ): Promis
 
 		const app = await getLandoApplication( lando, instancePath );
 
-		app.events.on( 'post-uninstall', async () => removeDevToolsVolumes( lando, app ) );
-
 		await ensureNoOrphantProxyContainer( lando );
 		await app.rebuild();
 	} finally {
@@ -702,44 +700,6 @@ export async function landoShell(
 		user,
 		_app: app,
 	} );
-}
-
-/**
- * Dev-tools volumes can get stale and is not updated when the new version of dev-tools
- * image is installed. Removing it during rebuild ensures the content is freshly populated
- * on startup.
- *
- * @param {Lando} lando
- * @param {App}   app
- */
-async function removeDevToolsVolumes( lando: Lando, app: App ) {
-	debug( 'Attempting to removing dev-tools volumes' );
-
-	const scanResult = await lando.engine.docker.listVolumes();
-	const devToolsVolumeNames = scanResult.Volumes.map( volume => volume.Name )
-		// eslint-disable-next-line security/detect-non-literal-regexp
-		.filter( volumeName => new RegExp( `${ app.project }.*devtools` ).test( volumeName ) );
-
-	debug( 'Will remove', devToolsVolumeNames );
-
-	const removalPromises = devToolsVolumeNames.map( volumeName =>
-		removeVolume( lando, volumeName )
-	);
-	await Promise.all( removalPromises );
-}
-
-/**
- * Remove volume
- */
-async function removeVolume( lando: Lando, volumeName: string ): Promise< void > {
-	debug( `Removing devtools volume ${ volumeName }` );
-	const devToolsVolume = lando.engine.docker.getVolume( volumeName );
-	try {
-		await devToolsVolume.remove();
-		debug( `${ volumeName } volume removed` );
-	} catch ( err ) {
-		debug( `Failed to remove volume ${ volumeName }`, err );
-	}
 }
 
 /**


### PR DESCRIPTION
## Description

This PR updates the dev-env code to avoid messing with the `dev-tools` volume.

1. We no longer remove `dev-tools` volumes;
2. We ensure that the `php` service starts after `devtools` completes to avoid race conditions;
3. We sync `/dev-tools-orig` with `/dev-tools`. This step is necessary because Lando sets its own entrypoint script if we don't provide ours.

Related PR: Automattic/vip-container-images#985 (must be merged before this one)
Volume removal logic was introduced in #1317.

## Pull request checklist

- [ ] Update [SETUP.md](https://github.com/Automattic/vip-cli/blob/trunk/docs/SETUP.md#list-of-environmental-variables) with any new environmental variables.
- [ ] Update [the documentation](https://github.com/Automattic/vip-cli/blob/trunk/docs).
- [x] [Manually test](https://github.com/Automattic/vip-cli/blob/trunk/docs/TESTING.md#manual-testing) the relevant changes.
- [x] Follow the [pull request checklist](https://github.com/Automattic/vip-cli/blob/trunk/docs/RELEASING.md#new-pull-requests)
- [ ] Add/update [automated tests](https://github.com/Automattic/vip-cli/blob/trunk/docs/TESTING.md#automated-testing) as needed.

## New release checklist

- [ ] [Automated tests](https://github.com/Automattic/vip-cli/blob/trunk/docs/TESTING.md#automated-testing) pass.
- [ ] The [Preparing for release checklist](https://github.com/Automattic/vip-cli/blob/trunk/docs/RELEASING.md#preparing-for-release) is completed.

## Steps to Test

1. Check out Automattic/vip-container-images#985, `cd dev-tools && docker build -t dev-tools:local`
2. Check out this PR, `npm run build && npm link`
3. vip dev-env create < /dev/null
4. Create `~/.local/share/vip/dev-environment/vip-local/.lando.local.yml`:
```yml
services:
  devtools:
    services:
      image: dev-tools:local
      pull_policy: never
```
5. Run `vip dev-env start` and ensure everything works
6. Run `vip dev-env shell -- sh -c 'md5sum /dev-tools/*'` and save the output.
7. Update one of the dev-tools scripts and rebuild the image (`docker build -t dev-tools:local`)
8. Restart the environment (`vip dev-env start`).
9. Run `vip dev-env shell -- sh -c 'md5sum /dev-tools/*'` and compare the output with the one from step 6. The hash for the updated script must differ.
