### PR TITLE
refactor(dev-env): make `wordpress` init-only container

### DIFF
--- a/assets/dev-env.lando.template.yml.ejs
+++ b/assets/dev-env.lando.template.yml.ejs
@@ -198,10 +198,6 @@ services:
           target: /scripts
           volume:
             nocopy: true
-      environment:
-        LANDO_NO_USER_PERMS: 1
-        LANDO_NO_SCRIPTS: 1
-        LANDO_NEEDS_EXEC: 1
     initOnly: true
     entrypoint: /usr/bin/rsync -a --chown=${LANDO_HOST_USER_ID}:${LANDO_HOST_GROUP_ID} /wp/ /shared/
 

--- a/assets/dev-env.lando.template.yml.ejs
+++ b/assets/dev-env.lando.template.yml.ejs
@@ -73,7 +73,7 @@ services:
         devtools:
           condition: service_completed_successfully
         wordpress:
-          condition: service_started
+          condition: service_completed_successfully
 <% if ( muPlugins.mode == 'image' ) { %>
         vip-mu-plugins:
           condition: service_started

--- a/assets/dev-env.lando.template.yml.ejs
+++ b/assets/dev-env.lando.template.yml.ejs
@@ -191,8 +191,6 @@ services:
     type: compose
     services:
       image: ghcr.io/automattic/vip-container-images/wordpress:<%= wordpress.tag %>
-#      command: /usr/local/bin/entrypoint.sh
-      command: sh -c "rsync -a --chown=www-data:www-data /wp/ /shared/; sleep infinity"
       volumes:
         - ./wordpress:/shared
         - type: volume
@@ -200,10 +198,12 @@ services:
           target: /scripts
           volume:
             nocopy: true
-#      environment:
-#        LANDO_NO_SCRIPTS: 1
-#        LANDO_NEEDS_EXEC: 1
-#    initOnly: true
+      environment:
+        LANDO_NO_USER_PERMS: 1
+        LANDO_NO_SCRIPTS: 1
+        LANDO_NEEDS_EXEC: 1
+    initOnly: true
+    entrypoint: /usr/bin/rsync -a --chown=${LANDO_HOST_USER_ID}:${LANDO_HOST_GROUP_ID} /wp/ /shared/
 
 <% if ( muPlugins.mode == 'image' ) { %>
   vip-mu-plugins:

--- a/src/lib/dev-environment/dev-environment-lando.ts
+++ b/src/lib/dev-environment/dev-environment-lando.ts
@@ -7,7 +7,7 @@ import landoUtils, { type AppInfo } from 'lando/plugins/lando-core/lib/utils';
 import landoBuildTask from 'lando/plugins/lando-tooling/lib/build';
 import { lookup } from 'node:dns/promises';
 import { mkdir, rename } from 'node:fs/promises';
-import { tmpdir } from 'node:os';
+import { tmpdir, userInfo } from 'node:os';
 import path, { dirname } from 'node:path';
 import { satisfies } from 'semver';
 import xdgBasedir from 'xdg-basedir';
@@ -89,6 +89,10 @@ async function getLandoConfig(): Promise< LandoConfig > {
 		home: fakeHomeDir,
 		domain: 'vipdev.lndo.site',
 		version: 'unknown',
+		env: {
+			LANDO_HOST_USER_ID: process.platform === 'win32' ? '1000' : `${ userInfo().uid }`,
+			LANDO_HOST_GROUP_ID: process.platform === 'win32' ? '1000' : `${ userInfo().gid }`,
+		},
 	};
 
 	return buildConfig( config );


### PR DESCRIPTION
## Description

This PR updates the Dev Environment Lando template to make the `wordpress` service init-only (see #1341 for the background). Because we use `wordpress` only to provide a volume with WordPress installation, we don't need the container after the initialization stage. Letting the container die peacefully will free up some memory and CPU and reduce the number of mount points.

This PR and #2139 will let us merge the `dev-tools` and `wordpress` services into one. We will also be able to replace the dependency condition for `wordpress` from `service_started` to `service_completed_successfully`; this will simplify the WordPress setup script because Docker will start the `php` service after WordPress files are copied to where they belong.

## Pull request checklist

- [ ] Update [SETUP.md](https://github.com/Automattic/vip-cli/blob/trunk/docs/SETUP.md#list-of-environmental-variables) with any new environmental variables.
- [ ] Update [the documentation](https://github.com/Automattic/vip-cli/blob/trunk/docs).
- [x] [Manually test](https://github.com/Automattic/vip-cli/blob/trunk/docs/TESTING.md#manual-testing) the relevant changes.
- [x] Follow the [pull request checklist](https://github.com/Automattic/vip-cli/blob/trunk/docs/RELEASING.md#new-pull-requests)
- [ ] Add/update [automated tests](https://github.com/Automattic/vip-cli/blob/trunk/docs/TESTING.md#automated-testing) as needed.

## New release checklist

- [ ] [Automated tests](https://github.com/Automattic/vip-cli/blob/trunk/docs/TESTING.md#automated-testing) pass.
- [ ] The [Preparing for release checklist](https://github.com/Automattic/vip-cli/blob/trunk/docs/RELEASING.md#preparing-for-release) is completed.

## Steps to Test

1. Check out the PR, `npm run build && npm link`.
2. `vip dev-env create < /dev/null && vip dev-env start`.
3. `vip dev-env logs -S wordpress` must show nothing because we bypass Lando.
4. `docker ps -a --no-trunc` must show the entry point for the `wordpress` service as `"/usr/bin/rsync -a --chown=1000:1000 /wp/ /shared/"` (with the UID and GID of the current user instead of 1000:1000).
5. The environment must work.
