### PR TITLE
fix(dev-env) sync: don't slugify domain if it matches the primary domain

### DIFF
--- a/__tests__/commands/dev-env-sync-sql.ts
+++ b/__tests__/commands/dev-env-sync-sql.ts
@@ -31,6 +31,10 @@ describe( 'commands/DevEnvSyncSQLCommand', () => {
 		wpSitesSDS: {
 			nodes: [
 				{
+					blogId: 1,
+					homeUrl: 'https://test.go-vip.com',
+				},
+				{
 					blogId: 2,
 					homeUrl: 'https://subsite.com',
 				},

--- a/__tests__/commands/dev-env-sync-sql.ts
+++ b/__tests__/commands/dev-env-sync-sql.ts
@@ -42,6 +42,10 @@ describe( 'commands/DevEnvSyncSQLCommand', () => {
 					blogId: 3,
 					homeUrl: 'https://another.com/path',
 				},
+				{
+					blogId: 4,
+					homeUrl: 'https://test.go-vip.com/path',
+				},
 			],
 		},
 	};
@@ -73,13 +77,14 @@ describe( 'commands/DevEnvSyncSQLCommand', () => {
 		it( 'should return a map of search-replace values for multisite', () => {
 			const cmd = new DevEnvSyncSQLCommand( app, msEnv, 'test-slug', lando );
 			cmd.slug = 'test-slug';
-			cmd.siteUrls = [ 'https://test.go-vip.com', 'http://subsite.com', 'http://another.com/path' ];
+			cmd.siteUrls = msEnv.wpSitesSDS.nodes.map( node => node.homeUrl );
 			cmd.generateSearchReplaceMap();
 
 			expect( cmd.searchReplaceMap ).toEqual( {
 				'test.go-vip.com': 'test-slug.vipdev.lndo.site',
 				'subsite.com': 'subsite-com.test-slug.vipdev.lndo.site',
 				'another.com/path': 'another-com.test-slug.vipdev.lndo.site/path',
+				'test.go-vip.com/path': 'test-slug.vipdev.lndo.site/path',
 			} );
 		} );
 	} );

--- a/src/commands/dev-env-sync-sql.ts
+++ b/src/commands/dev-env-sync-sql.ts
@@ -272,6 +272,9 @@ CALL vip_sync_update_blog_domains();
 DROP PROCEDURE vip_sync_update_blog_domains;
 `;
 
+		const primaryUrl = networkSites.find( site => site?.blogId === 1 )?.homeUrl;
+		const primaryDomain = primaryUrl ? new URL( primaryUrl ).hostname : '';
+
 		const queries: string[] = [];
 		for ( const site of networkSites ) {
 			if ( ! site?.blogId || ! site?.homeUrl ) {
@@ -280,7 +283,7 @@ DROP PROCEDURE vip_sync_update_blog_domains;
 
 			const oldDomain = new URL( site.homeUrl ).hostname;
 			const newDomain =
-				site.blogId !== 1
+				primaryDomain !== oldDomain
 					? `${ this.slugifyDomain( oldDomain ) }.${ this.landoDomain }`
 					: this.landoDomain;
 

--- a/src/commands/dev-env-sync-sql.ts
+++ b/src/commands/dev-env-sync-sql.ts
@@ -200,6 +200,9 @@ export class DevEnvSyncSQLCommand {
 		const networkSites = this.env.wpSitesSDS?.nodes;
 		if ( ! networkSites ) return;
 
+		const primaryUrl = networkSites.find( site => site?.blogId === 1 )?.homeUrl;
+		const primaryDomain = primaryUrl ? new URL( primaryUrl ).hostname : '';
+
 		for ( const site of networkSites ) {
 			if ( ! site?.blogId || site.blogId === 1 ) continue;
 
@@ -210,7 +213,10 @@ export class DevEnvSyncSQLCommand {
 			if ( ! this.searchReplaceMap[ strippedUrl ] ) continue;
 
 			const domain = new URL( url ).hostname;
-			const newDomain = `${ this.slugifyDomain( domain ) }.${ this.landoDomain }`;
+			const newDomain =
+				primaryDomain === domain
+					? this.landoDomain
+					: `${ this.slugifyDomain( domain ) }.${ this.landoDomain }`;
 
 			this.searchReplaceMap[ stripProtocol( url ) ] = stripProtocol(
 				replaceDomain( url, newDomain )


### PR DESCRIPTION
## Description

In #2081 we've improved handling of network sites that both utilize subdomains and paths (e.g. `path.site.test` and `site.test/path`) when syncing from a VIP environment.

Unfortunately, this introduced an unintended consequence where a site's primary domain would be slugified and prepended to the local env root domain. E.g. `path.site.test` would become `path-site-test.vip-local.vipdev.lndo.site`

This PR addresses the issue and now the search-replace would follow this logic:

`primary_domain` => `env_slug.vipdev.lndo.site`
`convenience_domain` => `env_slug.vipdev.lndo.site`
`any_other_domain_or_subdomain => `slugified_any_other_domain_or_subdomain.env_slug.vipdev.lndo.site`

Paths are handled respectively. E.g. `primary_domain/my/site/` => `env_slug.vipdev.lndo.site/my/site`


## Pull request checklist

- [ ] Update [SETUP.md](https://github.com/Automattic/vip-cli/blob/trunk/docs/SETUP.md#list-of-environmental-variables) with any new environmental variables.
- [ ] Update [the documentation](https://github.com/Automattic/vip-cli/blob/trunk/docs).
- [x] [Manually test](https://github.com/Automattic/vip-cli/blob/trunk/docs/TESTING.md#manual-testing) the relevant changes.
- [x] Follow the [pull request checklist](https://github.com/Automattic/vip-cli/blob/trunk/docs/RELEASING.md#new-pull-requests)
- [x] Add/update [automated tests](https://github.com/Automattic/vip-cli/blob/trunk/docs/TESTING.md#automated-testing) as needed.

## New release checklist

- [ ] [Automated tests](https://github.com/Automattic/vip-cli/blob/trunk/docs/TESTING.md#automated-testing) pass.
- [ ] The [Preparing for release checklist](https://github.com/Automattic/vip-cli/blob/trunk/docs/RELEASING.md#preparing-for-release) is completed.

## Steps to Test

Outline the steps to test and verify the PR here.

Example:

1. Check out PR.
1. Run `npm run build`
1. Run `./dist/bin/vip-cookies.js nom`
1. Verify cookies are delicious.
