### PR TITLE
fix(phpmyadmin): populate application name in App Query

### DIFF
--- a/src/bin/vip-db-phpmyadmin.ts
+++ b/src/bin/vip-db-phpmyadmin.ts
@@ -22,6 +22,7 @@ const examples = [
 
 const appQuery = `
 	id,
+	name,
 	environments{
 		id
 		appId


### PR DESCRIPTION
## Description

This PR fixes the error:

```
$ vip db phpmyadmin
Error:  Cannot read properties of undefined (reading 'choices')
Debug:  VIP-CLI v3.9.4-dev.0, Node v22.11.0, linux 6.8.0-49-generic x64
```

This happens because AppQuery does not query for the application name; as a result, we pass an array of `undefined` to `prompt`, and it bails out.

## Pull request checklist

- [ ] Update [SETUP.md](https://github.com/Automattic/vip-cli/blob/trunk/docs/SETUP.md#list-of-environmental-variables) with any new environmental variables.
- [ ] Update [the documentation](https://github.com/Automattic/vip-cli/blob/trunk/docs).
- [x] [Manually test](https://github.com/Automattic/vip-cli/blob/trunk/docs/TESTING.md#manual-testing) the relevant changes.
- [x] Follow the [pull request checklist](https://github.com/Automattic/vip-cli/blob/trunk/docs/RELEASING.md#new-pull-requests)
- [ ] Add/update [automated tests](https://github.com/Automattic/vip-cli/blob/trunk/docs/TESTING.md#automated-testing) as needed.

## New release checklist

- [x] [Automated tests](https://github.com/Automattic/vip-cli/blob/trunk/docs/TESTING.md#automated-testing) pass.
- [ ] The [Preparing for release checklist](https://github.com/Automattic/vip-cli/blob/trunk/docs/RELEASING.md#preparing-for-release) is completed.

## Steps to Test

Compare the output of `vip db phpmyadmin` with and without this patch.
