### PR TITLE
refactor(dev-env): use named volumes for WordPress instead of bind mounts

### DIFF
--- a/assets/dev-env.lando.template.yml.ejs
+++ b/assets/dev-env.lando.template.yml.ejs
@@ -192,7 +192,7 @@ services:
     services:
       image: ghcr.io/automattic/vip-container-images/wordpress:<%= wordpress.tag %>
       volumes:
-        - ./wordpress:/shared
+        - wordpress:/shared
         - type: volume
           source: scripts
           target: /scripts
@@ -200,6 +200,8 @@ services:
             nocopy: true
     initOnly: true
     entrypoint: /usr/bin/rsync -a --chown=${LANDO_HOST_USER_ID}:${LANDO_HOST_GROUP_ID} /wp/ /shared/
+    volumes:
+      wordpress: {}
 
 <% if ( muPlugins.mode == 'image' ) { %>
   vip-mu-plugins:
@@ -300,7 +302,11 @@ tooling:
         - ./config:/wp/config
         - ./log:/wp/log
         - ./uploads:/wp/wp-content/uploads
-        - ./wordpress:/wp
+        - type: volume
+          source: wordpress
+          target: /wp
+          volume:
+            nocopy: true
 <% if ( muPlugins.mode == 'image' ) { %>
         - type: volume
           source: mu-plugins

--- a/src/lib/constants/dev-environment.ts
+++ b/src/lib/constants/dev-environment.ts
@@ -49,4 +49,4 @@ export const DEV_ENVIRONMENT_DEFAULTS = {
 	phpVersion: Object.keys( DEV_ENVIRONMENT_PHP_VERSIONS )[ 0 ],
 } as const;
 
-export const DEV_ENVIRONMENT_VERSION = '2.1.3';
+export const DEV_ENVIRONMENT_VERSION = '2.2.0';


### PR DESCRIPTION
## Description

This PR tries to improve the performance of dev environments in Windows by using named volumes instead of bind mounts.

Bind mounts are inherently slow in Windows because of the inefficient 9P protocol, high I/O latency, and virtualization overhead. By putting WordPress into a named volume, we can significantly improve performance.

## Pull request checklist

- [ ] Update [SETUP.md](https://github.com/Automattic/vip-cli/blob/trunk/docs/SETUP.md#list-of-environmental-variables) with any new environmental variables.
- [ ] Update [the documentation](https://github.com/Automattic/vip-cli/blob/trunk/docs).
- [ ] [Manually test](https://github.com/Automattic/vip-cli/blob/trunk/docs/TESTING.md#manual-testing) the relevant changes.
- [ ] Follow the [pull request checklist](https://github.com/Automattic/vip-cli/blob/trunk/docs/RELEASING.md#new-pull-requests)
- [ ] Add/update [automated tests](https://github.com/Automattic/vip-cli/blob/trunk/docs/TESTING.md#automated-testing) as needed.

## New release checklist

- [ ] [Automated tests](https://github.com/Automattic/vip-cli/blob/trunk/docs/TESTING.md#automated-testing) pass.
- [ ] The [Preparing for release checklist](https://github.com/Automattic/vip-cli/blob/trunk/docs/RELEASING.md#preparing-for-release) is completed.

## Steps to Test

TBD.
