### PR TITLE
refactor(dev-env): merge `dev-tools` into `wordpress`

### DIFF
--- a/assets/dev-env.lando.template.yml.ejs
+++ b/assets/dev-env.lando.template.yml.ejs
@@ -15,19 +15,6 @@ proxy:
 keys: false
 
 services:
-  devtools:
-    type: compose
-    services:
-      image: ghcr.io/automattic/vip-container-images/dev-tools:0.9
-      volumes:
-        - devtools:/dev-tools
-        - scripts:/scripts
-    volumes:
-      devtools: {}
-      scripts:
-    initOnly: true
-    entrypoint: sh -c 'test -d /dev-tools-orig && /usr/bin/rsync -a --delete /dev-tools-orig/ /dev-tools/ || true'
-
   nginx:
     type: compose
     ssl: true
@@ -70,8 +57,6 @@ services:
         elasticsearch:
           condition: service_started
 <% } %>
-        devtools:
-          condition: service_completed_successfully
         wordpress:
           condition: service_completed_successfully
 <% if ( muPlugins.mode == 'image' ) { %>
@@ -193,13 +178,13 @@ services:
       image: ghcr.io/automattic/vip-container-images/wordpress:<%= wordpress.tag %>
       volumes:
         - ./wordpress:/shared
-        - type: volume
-          source: scripts
-          target: /scripts
-          volume:
-            nocopy: true
+        - devtools:/dev-tools
+        - scripts:/scripts
     initOnly: true
-    entrypoint: /usr/bin/rsync -a --chown=${LANDO_HOST_USER_ID}:${LANDO_HOST_GROUP_ID} /wp/ /shared/
+    entrypoint: sh -c '/usr/bin/rsync -a --delete --chown=${LANDO_HOST_USER_ID}:${LANDO_HOST_GROUP_ID} /wp/ /shared/; /usr/bin/rsync -a --chown=${LANDO_HOST_USER_ID}:${LANDO_HOST_GROUP_ID} --delete /dev-tools-orig/ /dev-tools/'
+    volumes:
+      devtools:
+      scripts:
 
 <% if ( muPlugins.mode == 'image' ) { %>
   vip-mu-plugins:

--- a/src/lib/constants/dev-environment.ts
+++ b/src/lib/constants/dev-environment.ts
@@ -49,4 +49,4 @@ export const DEV_ENVIRONMENT_DEFAULTS = {
 	phpVersion: Object.keys( DEV_ENVIRONMENT_PHP_VERSIONS )[ 0 ],
 } as const;
 
-export const DEV_ENVIRONMENT_VERSION = '2.2.0';
+export const DEV_ENVIRONMENT_VERSION = '2.2.1';


### PR DESCRIPTION
## Description

This PR merges the `dev-tools` service into `wordpress`.

Related: Automattic/vip-container-images#1030 ✅ 

## Pull request checklist

- [ ] Update [SETUP.md](https://github.com/Automattic/vip-cli/blob/trunk/docs/SETUP.md#list-of-environmental-variables) with any new environmental variables.
- [ ] Update [the documentation](https://github.com/Automattic/vip-cli/blob/trunk/docs).
- [x] [Manually test](https://github.com/Automattic/vip-cli/blob/trunk/docs/TESTING.md#manual-testing) the relevant changes.
- [x] Follow the [pull request checklist](https://github.com/Automattic/vip-cli/blob/trunk/docs/RELEASING.md#new-pull-requests)
- [ ] Add/update [automated tests](https://github.com/Automattic/vip-cli/blob/trunk/docs/TESTING.md#automated-testing) as needed.

## New release checklist

- [ ] [Automated tests](https://github.com/Automattic/vip-cli/blob/trunk/docs/TESTING.md#automated-testing) pass.
- [ ] The [Preparing for release checklist](https://github.com/Automattic/vip-cli/blob/trunk/docs/RELEASING.md#preparing-for-release) is completed.

## Steps to Test

Create a dev environment from scratch and ensure that it works.
