### PR TITLE
fix(dev-env): disallow running dev-env as `root`

### DIFF
--- a/src/bin/vip-dev-env.js
+++ b/src/bin/vip-dev-env.js
@@ -2,6 +2,11 @@
 
 import command from '../lib/cli/command';
 
+if ( process.getuid?.() === 0 ) {
+	console.error( 'This script should not be run as root. Exiting.' );
+	process.exit( 1 );
+}
+
 command( {
 	requiredArgs: 0,
 } )


### PR DESCRIPTION
## Description

This PR adds a check that dev env commands are not running under the `root` user. Using the `root` user creates numerous issues (e.g., permissions, user mapping, etc), often resulting in broken environments.

NB: we may want to improve the wording.

Ref: 198752-z

## Pull request checklist

- [ ] Update [SETUP.md](https://github.com/Automattic/vip-cli/blob/trunk/docs/SETUP.md#list-of-environmental-variables) with any new environmental variables.
- [ ] Update [the documentation](https://github.com/Automattic/vip-cli/blob/trunk/docs).
- [x] [Manually test](https://github.com/Automattic/vip-cli/blob/trunk/docs/TESTING.md#manual-testing) the relevant changes.
- [x] Follow the [pull request checklist](https://github.com/Automattic/vip-cli/blob/trunk/docs/RELEASING.md#new-pull-requests)
- [ ] Add/update [automated tests](https://github.com/Automattic/vip-cli/blob/trunk/docs/TESTING.md#automated-testing) as needed.

## New release checklist

- [ ] [Automated tests](https://github.com/Automattic/vip-cli/blob/trunk/docs/TESTING.md#automated-testing) pass.
- [ ] The [Preparing for release checklist](https://github.com/Automattic/vip-cli/blob/trunk/docs/RELEASING.md#preparing-for-release) is completed.

## Steps to Test

Check out the PR, build `vip-cli`, and run (this is a Linux version; I am not sure how to do that on a Mac):

```sh
sudo -E --preserve-env=PATH $(which vip) dev-env ls
```

The expected result is
```
This script should not be run as root. Exiting.
```