### PR TITLE
fix(dev-env): remove `lando/compose/env` directory when environment is destroyed

### DIFF
--- a/src/lib/dev-environment/dev-environment-core.ts
+++ b/src/lib/dev-environment/dev-environment-core.ts
@@ -3,6 +3,7 @@ import copydir from 'copy-dir';
 import debugLib from 'debug';
 import ejs from 'ejs';
 import { prompt } from 'enquirer';
+import { dockerComposify } from 'lando/lib/utils';
 import fetch from 'node-fetch';
 import fs from 'node:fs';
 import path from 'node:path';
@@ -268,6 +269,14 @@ export async function destroyEnvironment(
 	} else {
 		debug( "Lando file doesn't exist, skipping lando destroy." );
 	}
+
+	await fs.promises.rm(
+		path.join( xdgDataDirectory(), 'vip', 'lando', 'compose', dockerComposify( slug ) ),
+		{
+			force: true,
+			recursive: true,
+		}
+	);
 
 	if ( removeFiles ) {
 		await fs.promises.rm( instancePath, { recursive: true } );

--- a/types/lando/lib/utils.d.ts
+++ b/types/lando/lib/utils.d.ts
@@ -1,5 +1,5 @@
 export function getAppMounts( app: any ): any;
-export function dockerComposify( data: any ): any;
+export function dockerComposify( data: string ): string;
 export function appMachineName( data: any ): string;
 export function dumpComposeData( data: any, dir: any ): any;
 export function loadComposeFiles( files: any, dir: any ): any;


### PR DESCRIPTION
## Description

When we destroy an environment, `docker compose` files in `~/.local/share/vip/lando/compose/<env>` remain. This may cause interesting bugs when an environment with the same name is created later.

This PR ensures that the directory is removed when the environment gets destroyed.

## Pull request checklist

- [ ] Update [SETUP.md](https://github.com/Automattic/vip-cli/blob/trunk/docs/SETUP.md#list-of-environmental-variables) with any new environmental variables.
- [ ] Update [the documentation](https://github.com/Automattic/vip-cli/blob/trunk/docs).
- [x] [Manually test](https://github.com/Automattic/vip-cli/blob/trunk/docs/TESTING.md#manual-testing) the relevant changes.
- [x] Follow the [pull request checklist](https://github.com/Automattic/vip-cli/blob/trunk/docs/RELEASING.md#new-pull-requests)
- [ ] Add/update [automated tests](https://github.com/Automattic/vip-cli/blob/trunk/docs/TESTING.md#automated-testing) as needed.

## New release checklist

- [ ] [Automated tests](https://github.com/Automattic/vip-cli/blob/trunk/docs/TESTING.md#automated-testing) pass.
- [ ] The [Preparing for release checklist](https://github.com/Automattic/vip-cli/blob/trunk/docs/RELEASING.md#preparing-for-release) is completed.

## Steps to Test

1. `vip dev-env create -s test-env < /dev/null`
2. `vip dev-env start -s test-env`
3. Ensure `~/.local/share/vip/lando/compose/testenv` exists and contains `.yml` files
4. `vip dev-env destroy -s test-env`
5. Ensure `~/.local/share/vip/lando/compose/testenv` is gone
