### PR TITLE
fix: properly quote parameters for `vip wp`

### DIFF
--- a/__tests__/lib/cli/format.js
+++ b/__tests__/lib/cli/format.js
@@ -9,27 +9,27 @@ describe( 'utils/cli/format', () => {
 			},
 			{
 				input: [ 'textnospaces' ],
-				expected: [ 'textnospaces' ],
+				expected: [ '"textnospaces"' ],
 			},
 			{
 				input: [ '{"json":"json with spaces"}' ],
-				expected: [ '{"json":"json with spaces"}' ],
+				expected: [ '"{\\"json\\":\\"json with spaces\\"}"' ],
 			},
 			{
 				input: [ '{ "json"     :    "json with spaces outside strings"     }' ],
-				expected: [ '{ "json"     :    "json with spaces outside strings"     }' ],
+				expected: [ '"{ \\"json\\"     :    \\"json with spaces outside strings\\"     }"' ],
 			},
 			{
 				input: [
 					'   { "json"     :    "json with spaces outside strings and outside the object"     }   ',
 				],
 				expected: [
-					'   { "json"     :    "json with spaces outside strings and outside the object"     }   ',
+					'"   { \\"json\\"     :    \\"json with spaces outside strings and outside the object\\"     }   "',
 				],
 			},
 			{
 				input: [ '{ "json" : "spaces-outside-strings-only"      }' ],
-				expected: [ '{ "json" : "spaces-outside-strings-only"      }' ],
+				expected: [ '"{ \\"json\\" : \\"spaces-outside-strings-only\\"      }"' ],
 			},
 			{
 				input: [ '{"json":broken json with spaces}' ],
@@ -37,11 +37,11 @@ describe( 'utils/cli/format', () => {
 			},
 			{
 				input: [ '--foo=bar1 "bar2" "bar3"' ],
-				expected: [ '--foo="bar1 \\"bar2\\" \\"bar3\\""' ],
+				expected: [ '"--foo=bar1 \\"bar2\\" \\"bar3\\""' ],
 			},
 			{
 				input: [ '--foo', 'bar1 "bar2" "bar3"' ],
-				expected: [ '--foo', '"bar1 \\"bar2\\" \\"bar3\\""' ],
+				expected: [ '"--foo"', '"bar1 \\"bar2\\" \\"bar3\\""' ],
 			},
 		] )( 'should requote args when needed - %o', ( { input, expected } ) => {
 			const result = requoteArgs( input );

--- a/src/lib/cli/format.ts
+++ b/src/lib/cli/format.ts
@@ -140,30 +140,7 @@ export function keyValue( values: Tuple[] ): string {
 }
 
 export function requoteArgs( args: string[] ): string[] {
-	return args.map( arg => {
-		if ( arg.includes( '--' ) && arg.includes( '=' ) && arg.includes( ' ' ) ) {
-			return arg.replace( /"/g, '\\"' ).replace( /^--([^=]*)=(.*)$/, '--$1="$2"' );
-		}
-
-		if ( arg.includes( ' ' ) && ! isJsonObject( arg ) ) {
-			return `"${ arg.replace( /"/g, '\\"' ) }"`;
-		}
-
-		return arg;
-	} );
-}
-
-export function isJsonObject( str: unknown ): boolean {
-	return typeof str === 'string' && str.trim().startsWith( '{' ) && isJson( str );
-}
-
-export function isJson( str: string ): boolean {
-	try {
-		JSON.parse( str );
-		return true;
-	} catch ( error ) {
-		return false;
-	}
+	return args.map( arg => `"${ arg.replace( /"/g, '\\"' ) }"` );
 }
 
 export function capitalize( str: unknown ): string {


### PR DESCRIPTION
## Description

The way the parameters are quoted now is insecure and vulnerable to parameter injection.

This PR tries to fix this.

Because we don't care about shell expansion or redirection (WP CLI commands will be executed directly, not via a shell), we can simplify quoting by enclosing the parameter in double quotes and escaping all inner double quotes with a slash.

Related: Automattic/cron-control-runner#32

## Pull request checklist

- [ ] Update [SETUP.md](https://github.com/Automattic/vip-cli/blob/trunk/docs/SETUP.md#list-of-environmental-variables) with any new environmental variables.
- [ ] Update [the documentation](https://github.com/Automattic/vip-cli/blob/trunk/docs).
- [x] [Manually test](https://github.com/Automattic/vip-cli/blob/trunk/docs/TESTING.md#manual-testing) the relevant changes.
- [x] Follow the [pull request checklist](https://github.com/Automattic/vip-cli/blob/trunk/docs/RELEASING.md#new-pull-requests)
- [ ] Add/update [automated tests](https://github.com/Automattic/vip-cli/blob/trunk/docs/TESTING.md#automated-testing) as needed.

## New release checklist

- [x] [Automated tests](https://github.com/Automattic/vip-cli/blob/trunk/docs/TESTING.md#automated-testing) pass.
- [ ] The [Preparing for release checklist](https://github.com/Automattic/vip-cli/blob/trunk/docs/RELEASING.md#preparing-for-release) is completed.

## Steps to Test

TBD.
