### PR TITLE
fix(wp): handling of CR characters

### DIFF
--- a/src/bin/vip-wp.js
+++ b/src/bin/vip-wp.js
@@ -6,7 +6,7 @@ import gql from 'graphql-tag';
 import readline from 'readline';
 import SocketIO from 'socket.io-client';
 import IOStream from 'socket.io-stream';
-import { Writable } from 'stream';
+import { Transform, Writable } from 'stream';
 
 import { WPCliCommandOverSSH } from '../commands/wp-ssh';
 import API, { API_HOST, disableGlobalGraphQLErrorHandling } from '../lib/api';
@@ -43,14 +43,32 @@ const cancelCommandChar = '\x03';
 let currentJob = null;
 let currentOffset = 0;
 let commandRunning = false;
+const isStdinTty = process.stdin.isTTY;
+
+const normalizeNewlineStream = new Transform( {
+	transform( chunk, encoding, callback ) {
+		callback( null, chunk.toString().replace( /\r/g, '\n' ) );
+	},
+} );
 
 const pipeStreamsToProcess = ( { stdin, stdout: outStream } ) => {
-	process.stdin.pipe( stdin );
+	if ( isStdinTty ) {
+		process.stdin.pipe( normalizeNewlineStream ).pipe( stdin );
+	} else {
+		process.stdin.pipe( stdin );
+	}
+
 	outStream.pipe( process.stdout );
 };
 
 const unpipeStreamsFromProcess = ( { stdin, stdout: outStream } ) => {
-	process.stdin.unpipe( stdin );
+	if ( isStdinTty ) {
+		process.stdin.unpipe( normalizeNewlineStream );
+		normalizeNewlineStream.unpipe( stdin );
+	} else {
+		process.stdin.unpipe( stdin );
+	}
+
 	outStream.unpipe( process.stdout );
 };
 
@@ -394,6 +412,7 @@ commandWrapper( {
 			terminal: true,
 			prompt: '',
 			historySize: 0,
+			crlfDelay: Infinity,
 		};
 
 		if ( isSubShell ) {
@@ -504,16 +523,6 @@ commandWrapper( {
 				commonTrackingParams,
 				isSubShell,
 			} );
-		} );
-
-		// Fix to re-add the \n character that readline strips when terminal == true
-		process.stdin.on( 'data', data => {
-			// only run this in interactive mode for prompts from WP commands
-			if ( commandRunning && 0 === Buffer.compare( data, Buffer.from( '\r' ) ) ) {
-				if ( currentJob?.stdinStream ) {
-					currentJob.stdinStream.write( '\n' );
-				}
-			}
 		} );
 
 		subShellRl.on( 'SIGINT', async () => {


### PR DESCRIPTION
## Description

This PR strips CR characters from the input stream, making `--prompt` option work.

Ref: pbq1wL-1LP#comment-1898

## Pull request checklist

- [ ] Update [SETUP.md](https://github.com/Automattic/vip-cli/blob/trunk/docs/SETUP.md#list-of-environmental-variables) with any new environmental variables.
- [ ] Update [the documentation](https://github.com/Automattic/vip-cli/blob/trunk/docs).
- [x] [Manually test](https://github.com/Automattic/vip-cli/blob/trunk/docs/TESTING.md#manual-testing) the relevant changes.
- [x] Follow the [pull request checklist](https://github.com/Automattic/vip-cli/blob/trunk/docs/RELEASING.md#new-pull-requests)
- [ ] Add/update [automated tests](https://github.com/Automattic/vip-cli/blob/trunk/docs/TESTING.md#automated-testing) as needed.

## New release checklist

- [ ] [Automated tests](https://github.com/Automattic/vip-cli/blob/trunk/docs/TESTING.md#automated-testing) pass.
- [ ] The [Preparing for release checklist](https://github.com/Automattic/vip-cli/blob/trunk/docs/RELEASING.md#preparing-for-release) is completed.

## Steps to Test

Try `vip @env -y -- wp option update --prompt` command to ensure they work.
