### PR TITLE
feat(dev-env): write integrations config when creating an environment

### DIFF
--- a/assets/dev-env.lando.template.yml.ejs
+++ b/assets/dev-env.lando.template.yml.ejs
@@ -301,6 +301,7 @@ tooling:
         - ./log:/wp/log
         - ./uploads:/wp/wp-content/uploads
         - ./wordpress:/wp
+        - ./integrations-config:/wp/config/integrations-config
 <% if ( muPlugins.mode == 'image' ) { %>
         - type: volume
           source: mu-plugins

--- a/src/bin/vip-dev-env-create.js
+++ b/src/bin/vip-dev-env-create.js
@@ -123,12 +123,15 @@ cmd.argv( process.argv, async ( arg, opt ) => {
 		exit.withError( messageToShow );
 	}
 
-	/** @type {InstanceOptions} */
+	/** @type {import('../lib/dev-environment/types').InstanceOptions} */
 	let defaultOptions = {};
+	/** @type {Record<string,unknown>} */
+	let integrationsConfig = {};
 
 	try {
 		if ( opt.app ) {
 			const appInfo = await getApplicationInformation( opt.app, opt.env );
+			integrationsConfig = appInfo.environment?.integrations ?? {};
 			defaultOptions = getOptionsFromAppInfo( appInfo );
 		}
 	} catch ( error ) {
@@ -156,7 +159,7 @@ cmd.argv( process.argv, async ( arg, opt ) => {
 	instanceData.siteSlug = slug;
 
 	try {
-		await createEnvironment( lando, instanceData );
+		await createEnvironment( lando, instanceData, integrationsConfig );
 
 		await printEnvironmentInfo( lando, slug, { extended: false, suppressWarnings: true } );
 

--- a/src/lib/constants/dev-environment.ts
+++ b/src/lib/constants/dev-environment.ts
@@ -49,4 +49,4 @@ export const DEV_ENVIRONMENT_DEFAULTS = {
 	phpVersion: Object.keys( DEV_ENVIRONMENT_PHP_VERSIONS )[ 0 ],
 } as const;
 
-export const DEV_ENVIRONMENT_VERSION = '2.1.3';
+export const DEV_ENVIRONMENT_VERSION = '2.2.0';

--- a/src/lib/dev-environment/dev-environment-core.ts
+++ b/src/lib/dev-environment/dev-environment-core.ts
@@ -70,9 +70,12 @@ const landoFileName = '.lando.yml';
 const landoBackupFileName = '.lando.backup.yml';
 const nginxFileName = 'extra.conf';
 const instanceDataFileName = 'instance_data.json';
+const integrationsConfigFileName = 'integrations.json';
+const integrationsConfigBackupFileName = 'integrations.json.bak';
 
 const uploadPathString = 'uploads';
 const nginxPathString = 'nginx';
+const integrationsConfigPathString = 'integrations-config';
 
 interface StartEnvironmentOptions {
 	skipRebuild: boolean;
@@ -147,7 +150,8 @@ export async function stopEnvironment( lando: Lando, slug: string ): Promise< vo
 
 export async function createEnvironment(
 	lando: Lando,
-	instanceData: InstanceData
+	instanceData: InstanceData,
+	integrationsConfig?: Record< string, unknown > | undefined
 ): Promise< void > {
 	const slug = instanceData.siteSlug;
 	debug( 'Will process an environment', slug, 'with instanceData for creation: ', instanceData );
@@ -165,7 +169,7 @@ export async function createEnvironment(
 	const preProcessedInstanceData = preProcessInstanceData( instanceData );
 	debug( 'Will create an environment', slug, 'with instanceData: ', preProcessedInstanceData );
 
-	await prepareLandoEnv( lando, preProcessedInstanceData, instancePath );
+	await prepareLandoEnv( lando, preProcessedInstanceData, instancePath, integrationsConfig );
 }
 
 export async function updateEnvironment(
@@ -188,7 +192,7 @@ export async function updateEnvironment(
 	const preProcessedInstanceData = preProcessInstanceData( instanceData );
 	debug( 'Will create an environment', slug, 'with instanceData: ', preProcessedInstanceData );
 
-	await prepareLandoEnv( lando, preProcessedInstanceData, instancePath );
+	await prepareLandoEnv( lando, preProcessedInstanceData, instancePath, undefined );
 }
 
 function preProcessInstanceData( instanceData: InstanceData ): InstanceData {
@@ -494,10 +498,46 @@ export function writeEnvironmentData( slug: string, data: InstanceData ): Promis
 	return fs.promises.writeFile( instanceDataTargetPath, JSON.stringify( data, null, 2 ) );
 }
 
+async function writeIntegrationsConfig(
+	instancePath: string,
+	integrationsConfig: Record< string, unknown > | undefined
+): Promise< void > {
+	const integrationsConfigPath = path.join( instancePath, integrationsConfigPathString );
+	const integrationsConfigTargetPath = path.join(
+		integrationsConfigPath,
+		integrationsConfigFileName
+	);
+
+	await fs.promises.mkdir( integrationsConfigPath, { recursive: true } );
+
+	if ( integrationsConfig !== undefined ) {
+		const integrationsConfigBackupTargetPath = path.join(
+			integrationsConfigPath,
+			integrationsConfigBackupFileName
+		);
+
+		try {
+			await fs.promises.rename( integrationsConfigTargetPath, integrationsConfigBackupTargetPath );
+			console.log(
+				`Backup of ${ integrationsConfigFileName } was created in ${ integrationsConfigBackupTargetPath }`
+			);
+		} catch ( err ) {
+			if ( 'ENOENT' !== ( err as NodeJS.ErrnoException ).code ) {
+				throw err;
+			}
+		}
+
+		const configJson = JSON.stringify( integrationsConfig, null, 4 );
+		await fs.promises.writeFile( integrationsConfigTargetPath, configJson );
+		debug( `Integrations configuration file created in ${ integrationsConfigTargetPath }` );
+	}
+}
+
 async function prepareLandoEnv(
 	lando: Lando,
 	instanceData: InstanceData,
-	instancePath: string
+	instancePath: string,
+	integrationsConfig: Record< string, unknown > | undefined
 ): Promise< void > {
 	const templateData = {
 		...instanceData,
@@ -536,6 +576,8 @@ async function prepareLandoEnv(
 	debug( `Lando file created in ${ landoFileTargetPath }` );
 	debug( `Nginx file created in ${ nginxFileTargetPath }` );
 	debug( `Instance data file created in ${ instanceDataTargetPath }` );
+
+	await writeIntegrationsConfig( instancePath, integrationsConfig );
 }
 
 export function getAllEnvironmentNames(): string[] {


### PR DESCRIPTION
## Description

This PR updates the environment creation workflow to create integration configuration and mount it into WordPress.

Note that WordPress will not load the configuration yet: this requires changes to the `dev-tools` and/or `wordpress` Docker images, as well as mu-plugins.

Related: Automattic/vip-go-mu-plugins#6101

## Pull request checklist

- [ ] Update [SETUP.md](https://github.com/Automattic/vip-cli/blob/trunk/docs/SETUP.md#list-of-environmental-variables) with any new environmental variables.
- [ ] Update [the documentation](https://github.com/Automattic/vip-cli/blob/trunk/docs).
- [x] [Manually test](https://github.com/Automattic/vip-cli/blob/trunk/docs/TESTING.md#manual-testing) the relevant changes.
- [x] Follow the [pull request checklist](https://github.com/Automattic/vip-cli/blob/trunk/docs/RELEASING.md#new-pull-requests)
- [ ] Add/update [automated tests](https://github.com/Automattic/vip-cli/blob/trunk/docs/TESTING.md#automated-testing) as needed.

## New release checklist

- [ ] [Automated tests](https://github.com/Automattic/vip-cli/blob/trunk/docs/TESTING.md#automated-testing) pass.
- [ ] The [Preparing for release checklist](https://github.com/Automattic/vip-cli/blob/trunk/docs/RELEASING.md#preparing-for-release) is completed.

## Steps to Test

1. `vip @app.env dev-env create < /dev/null`
2. Observe that `~/.local/share/vip/dev-environment/<NAME>/integrations-config/integrations.json` exists
3. `vip dev-env start`
4. `vip dev-env shell -- cat /wp/config/integrations-config/integrations.json`
