### PR TITLE
feat(dev-env): automatically enable Elasticsearch when Enterprise Search integration is enabled

### DIFF
--- a/src/bin/vip-dev-env-create.js
+++ b/src/bin/vip-dev-env-create.js
@@ -125,7 +125,7 @@ cmd.argv( process.argv, async ( arg, opt ) => {
 
 	/** @type {import('../lib/dev-environment/types').InstanceOptions} */
 	let defaultOptions = {};
-	/** @type {Record<string,unknown>} */
+	/** @type {Record<string,import('../lib/dev-environment/types').IntegrationConfig>} */
 	let integrationsConfig = {};
 
 	try {

--- a/src/lib/dev-environment/dev-environment-cli.ts
+++ b/src/lib/dev-environment/dev-environment-cli.ts
@@ -226,6 +226,9 @@ export function processComponentOptionInput(
 }
 
 export function getOptionsFromAppInfo( appInfo: AppInfo ): InstanceOptions {
+	const integrationsConfig = appInfo.environment?.integrations ?? {};
+	const hasES = integrationsConfig[ 'enterprise-search' ]?.env?.status === 'enabled';
+
 	return {
 		// eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
 		title: appInfo.environment?.name || appInfo.name || '', // NOSONAR
@@ -233,6 +236,7 @@ export function getOptionsFromAppInfo( appInfo: AppInfo ): InstanceOptions {
 		mediaRedirectDomain: appInfo.environment?.primaryDomain,
 		php: appInfo.environment?.php ?? '',
 		wordpress: appInfo.environment?.wordpress ?? '',
+		elasticsearch: hasES,
 	};
 }
 

--- a/src/lib/dev-environment/dev-environment-core.ts
+++ b/src/lib/dev-environment/dev-environment-core.ts
@@ -45,7 +45,13 @@ import { createProxyAgent } from '../http/proxy-agent';
 import { searchAndReplace } from '../search-and-replace';
 import UserError from '../user-error';
 
-import type { AppInfo, ComponentConfig, InstanceData, WordPressConfig } from './types';
+import type {
+	AppInfo,
+	ComponentConfig,
+	InstanceData,
+	IntegrationConfig,
+	WordPressConfig,
+} from './types';
 import type Lando from 'lando';
 
 const debug = debugLib( '@automattic/vip:bin:dev-environment' );
@@ -151,9 +157,10 @@ export async function stopEnvironment( lando: Lando, slug: string ): Promise< vo
 export async function createEnvironment(
 	lando: Lando,
 	instanceData: InstanceData,
-	integrationsConfig?: Record< string, unknown > | undefined
+	integrationsConfig?: Record< string, IntegrationConfig > | undefined
 ): Promise< void > {
 	const slug = instanceData.siteSlug;
+	integrationsConfig ??= {};
 	debug( 'Will process an environment', slug, 'with instanceData for creation: ', instanceData );
 
 	const instancePath = getEnvironmentPath( slug );
@@ -167,6 +174,7 @@ export async function createEnvironment(
 	}
 
 	const preProcessedInstanceData = preProcessInstanceData( instanceData );
+
 	debug( 'Will create an environment', slug, 'with instanceData: ', preProcessedInstanceData );
 
 	await prepareLandoEnv( lando, preProcessedInstanceData, instancePath, integrationsConfig );
@@ -682,7 +690,8 @@ export async function getApplicationInformation(
 				php: envData.softwareSettings?.php?.current.version ?? '',
 				wordpress: envData.softwareSettings?.wordpress?.current.version ?? '',
 				integrations:
-					( envData.getIntegrationsDevEnvConfig?.data as Record< string, unknown > ) ?? {},
+					( envData.getIntegrationsDevEnvConfig?.data as Record< string, IntegrationConfig > ) ??
+					{},
 			};
 		}
 	}

--- a/src/lib/dev-environment/types.ts
+++ b/src/lib/dev-environment/types.ts
@@ -20,6 +20,18 @@ export interface InstanceOptions {
 	[ index: string ]: unknown;
 }
 
+export interface IntergrationSettings {
+	status: string;
+	config?: Record< string, unknown >;
+}
+
+export interface IntegrationConfig {
+	type?: string;
+	org?: IntergrationSettings;
+	env?: IntergrationSettings;
+	network_sites?: IntergrationSettings;
+}
+
 export interface AppInfo {
 	id?: number | null;
 	name?: string | null;
@@ -32,7 +44,7 @@ export interface AppInfo {
 		primaryDomain: string;
 		php: string;
 		wordpress: string;
-		integrations: Record< string, unknown >;
+		integrations: Record< string, IntegrationConfig >;
 	};
 }
 


### PR DESCRIPTION
## Description

This PR updates the code to enable Elasticsearch when a user creates an environment with Enterprise Search integration enabled.

## Pull request checklist

- [ ] Update [SETUP.md](https://github.com/Automattic/vip-cli/blob/trunk/docs/SETUP.md#list-of-environmental-variables) with any new environmental variables.
- [ ] Update [the documentation](https://github.com/Automattic/vip-cli/blob/trunk/docs).
- [x] [Manually test](https://github.com/Automattic/vip-cli/blob/trunk/docs/TESTING.md#manual-testing) the relevant changes.
- [x] Follow the [pull request checklist](https://github.com/Automattic/vip-cli/blob/trunk/docs/RELEASING.md#new-pull-requests)
- [ ] Add/update [automated tests](https://github.com/Automattic/vip-cli/blob/trunk/docs/TESTING.md#automated-testing) as needed.

## New release checklist

- [ ] [Automated tests](https://github.com/Automattic/vip-cli/blob/trunk/docs/TESTING.md#automated-testing) pass.
- [ ] The [Preparing for release checklist](https://github.com/Automattic/vip-cli/blob/trunk/docs/RELEASING.md#preparing-for-release) is completed.

## Steps to Test

1. `vip @app.env dev-env create --elasticsearch`; `@app.env` must have ES integration enabled.
2. Observe that `Enable Elasticsearch` is `Y` by default (or `elasticsearch` is among the services when using unattended creation).

Fixes PLTFRM-280
