### PR TITLE
feat(dev-env): Improvements to configuration wizard

### DIFF
--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -42,11 +42,18 @@ function isServerError(
 
 export default function API( {
 	exitOnError = true,
+	silenceAuthErrors = false,
 }: {
 	exitOnError?: boolean;
+	silenceAuthErrors?: boolean;
 } = {} ): ApolloClient< NormalizedCacheObject > {
 	const errorLink = onError( ( { networkError, graphQLErrors } ) => {
-		if ( networkError && 'statusCode' in networkError && networkError.statusCode === 401 ) {
+		if (
+			! silenceAuthErrors &&
+			networkError &&
+			'statusCode' in networkError &&
+			networkError.statusCode === 401
+		) {
 			let message =
 				'You are not authorized to perform this request; please logout with `vip logout`, then try again.';
 			if (

--- a/src/lib/api/user.ts
+++ b/src/lib/api/user.ts
@@ -21,8 +21,8 @@ const QUERY_CURRENT_USER = gql`
 	}
 `;
 
-export async function getCurrentUserInfo(): Promise< Me > {
-	const api = API();
+export async function getCurrentUserInfo( silenceAuthErrors = false ): Promise< Me > {
+	const api = API( { silenceAuthErrors } );
 
 	const response = await api.query< IsVipQuery, IsVipQueryVariables >( {
 		query: QUERY_CURRENT_USER,

--- a/src/lib/constants/dev-environment.ts
+++ b/src/lib/constants/dev-environment.ts
@@ -7,7 +7,7 @@ export const DEV_ENVIRONMENT_PROMPT_INTRO =
 	'You may also choose to create multiple environments with different settings using the --slug option.\n\n';
 export const DEV_ENVIRONMENT_NOT_FOUND = 'Environment not found.';
 
-export const DEV_ENVIRONMENT_COMPONENTS = [ 'muPlugins', 'appCode' ] as const;
+export const DEV_ENVIRONMENT_COMPONENTS = [ 'appCode', 'muPlugins' ] as const;
 export const DEV_ENVIRONMENT_COMPONENTS_WITH_WP = [
 	'wordpress',
 	...DEV_ENVIRONMENT_COMPONENTS,

--- a/src/lib/dev-environment/dev-environment-cli.ts
+++ b/src/lib/dev-environment/dev-environment-cli.ts
@@ -414,20 +414,19 @@ async function processComponent(
 	let allowLocal: boolean = true;
 
 	if ( component === 'muPlugins' ) {
-		let currentUser = null;
 		try {
-			currentUser = await getCurrentUserInfo();
-			allowLocal = currentUser?.isVIP || false;
+			const currentUser = await getCurrentUserInfo( true );
+			allowLocal = currentUser?.isVIP ?? false;
 		} catch ( err ) {
 			allowLocal = false;
 		}
 	}
 
 	const defaultObject = defaultValue
-		? processComponentOptionInput( defaultValue, allowLocal )
+		? processComponentOptionInput( defaultValue, allowLocal as unknown as true )
 		: null;
 	if ( preselectedValue ) {
-		result = processComponentOptionInput( preselectedValue, allowLocal );
+		result = processComponentOptionInput( preselectedValue, allowLocal as unknown as true );
 
 		if ( ! suppressPrompts ) {
 			console.log(

--- a/src/lib/dev-environment/dev-environment-cli.ts
+++ b/src/lib/dev-environment/dev-environment-cli.ts
@@ -18,6 +18,7 @@ import {
 	readEnvironmentData,
 } from './dev-environment-core';
 import { validateDockerInstalled } from './dev-environment-lando';
+import { getCurrentUserInfo } from '../api/user';
 import { Args } from '../cli/command';
 import {
 	DEV_ENVIRONMENT_FULL_COMMAND,
@@ -62,7 +63,7 @@ const componentDisplayNames: Record<
 	string
 > = {
 	wordpress: 'WordPress',
-	muPlugins: 'vip-go-mu-plugins',
+	muPlugins: 'VIP MU Plugins',
 	appCode: 'application code',
 } as const;
 
@@ -410,7 +411,18 @@ async function processComponent(
 	);
 	let result: ComponentConfig;
 
-	const allowLocal = true;
+	let allowLocal: boolean = true;
+
+	if ( component === 'muPlugins' ) {
+		let currentUser = null;
+		try {
+			currentUser = await getCurrentUserInfo();
+			allowLocal = currentUser?.isVIP || false;
+		} catch ( err ) {
+			allowLocal = false;
+		}
+	}
+
 	const defaultObject = defaultValue
 		? processComponentOptionInput( defaultValue, allowLocal )
 		: null;
@@ -746,7 +758,7 @@ export async function promptForComponent(
 	const messagePrefix = selectMode ? '\t' : `${ componentDisplayName } - `;
 	if ( 'local' === modeResult ) {
 		const directoryPath = await promptForText(
-			`${ messagePrefix }What is a path to your local ${ componentDisplayName }`,
+			`${ messagePrefix }What is a path to your local ${ componentDisplayName }?`,
 			defaultObject?.dir ?? ''
 		);
 		return {


### PR DESCRIPTION
## Description

The biggest thing here is hiding the local option for mu-plugins from the wizard for non-VIP users. This option has caused confusion over the years and is only useful for a small subset of users - for those the named argument still exists.


## Pull request checklist

- [ ] Update [SETUP.md](https://github.com/Automattic/vip-cli/blob/trunk/docs/SETUP.md#list-of-environmental-variables) with any new environmental variables.
- [ ] Update [the documentation](https://github.com/Automattic/vip-cli/blob/trunk/docs).
- [x] [Manually test](https://github.com/Automattic/vip-cli/blob/trunk/docs/TESTING.md#manual-testing) the relevant changes.
- [ ] Follow the [pull request checklist](https://github.com/Automattic/vip-cli/blob/trunk/docs/RELEASING.md#new-pull-requests)
- [ ] Add/update [automated tests](https://github.com/Automattic/vip-cli/blob/trunk/docs/TESTING.md#automated-testing) as needed.

## New release checklist

- [ ] [Automated tests](https://github.com/Automattic/vip-cli/blob/trunk/docs/TESTING.md#automated-testing) pass.
- [ ] The [Preparing for release checklist](https://github.com/Automattic/vip-cli/blob/trunk/docs/RELEASING.md#preparing-for-release) is completed.

## Steps to Test

Outline the steps to test and verify the PR here.

Example:

1. Check out PR.
1. Run `npm run build`
1. Run `vip dev-env create` while proxied, note that the mu-plugins option is present
2. Disconnect from proxy, repeat the process note the option is not present anymore.

