### PR TITLE
fix(dev-env): add support for colima socket

### DIFF
--- a/src/lib/dev-environment/docker-utils.ts
+++ b/src/lib/dev-environment/docker-utils.ts
@@ -60,7 +60,9 @@ export async function getDockerSocket(): Promise< string | null > {
 		// Try the default location
 		paths.push( '/var/run/docker.sock' );
 		// Try alternative locations
+		paths.push( '/run/docker.sock' );
 		paths.push( join( homedir(), '.docker', 'run', 'docker.sock' ) );
+		paths.push( join( homedir(), '.colima', 'default', 'docker.sock' ) );
 		paths.push( join( homedir(), '.orbstack', 'run', 'docker.sock' ) );
 
 		for ( const socketPath of paths ) {


### PR DESCRIPTION
## Description

This PR adds `~/.colima/default/docker.sock` to the list of the possible Docker socket paths.

## Pull request checklist

- [ ] Update [SETUP.md](https://github.com/Automattic/vip-cli/blob/trunk/docs/SETUP.md#list-of-environmental-variables) with any new environmental variables.
- [ ] Update [the documentation](https://github.com/Automattic/vip-cli/blob/trunk/docs).
- [ ] [Manually test](https://github.com/Automattic/vip-cli/blob/trunk/docs/TESTING.md#manual-testing) the relevant changes.
- [ ] Follow the [pull request checklist](https://github.com/Automattic/vip-cli/blob/trunk/docs/RELEASING.md#new-pull-requests)
- [ ] Add/update [automated tests](https://github.com/Automattic/vip-cli/blob/trunk/docs/TESTING.md#automated-testing) as needed.

## New release checklist

- [ ] [Automated tests](https://github.com/Automattic/vip-cli/blob/trunk/docs/TESTING.md#automated-testing) pass.
- [ ] The [Preparing for release checklist](https://github.com/Automattic/vip-cli/blob/trunk/docs/RELEASING.md#preparing-for-release) is completed.

## Steps to Test

TBD.
