### PR TITLE
fix(import-sql): progress tracker is incompatible with interactivity

### DIFF
--- a/src/bin/vip-import-sql.js
+++ b/src/bin/vip-import-sql.js
@@ -11,6 +11,7 @@ import command from '../lib/cli/command';
 import * as exit from '../lib/cli/exit';
 import { formatEnvironment, formatSearchReplaceValues, getGlyphForStatus } from '../lib/cli/format';
 import { ProgressTracker } from '../lib/cli/progress';
+import { confirm } from '../lib/cli/prompt';
 import {
 	checkFileAccess,
 	getFileSize,
@@ -474,6 +475,22 @@ void command( {
 			isMultiSite,
 			tableNames,
 		} );
+
+		if ( opts.inPlace ) {
+			const approved = await confirm(
+				[],
+				'Are you sure you want to run search and replace on your input file? This operation is not reversible.'
+			);
+
+			if ( ! approved ) {
+				await trackEventWithEnv( 'search_replace_in_place_cancelled', {
+					is_import: true,
+					in_place: opts.inPlace,
+				} );
+
+				process.exit();
+			}
+		}
 
 		/**
 		 * =========== WARNING =============

--- a/src/bin/vip-import-sql.js
+++ b/src/bin/vip-import-sql.js
@@ -517,6 +517,7 @@ Processing the SQL import for your environment...
 				isImport: true,
 				inPlace: opts.inPlace,
 				output: opts.output ?? true, // "true" creates a temp output file instead of printing to stdout, as we need to upload the output to S3.
+				batchMode: true,
 			} );
 
 			if ( typeof outputFileName !== 'string' ) {

--- a/src/lib/client-file-uploader.ts
+++ b/src/lib/client-file-uploader.ts
@@ -313,7 +313,14 @@ async function uploadUsingPutObject( {
 		} );
 	}
 
-	const { Code, Message } = parsedResponse.Error;
+	let Code: string;
+	let Message: string;
+	if ( parsedResponse?.Error ) {
+		( { Code, Message } = parsedResponse.Error );
+	} else {
+		Code = `HTTP Error ${ response.status }`;
+		Message = response.statusText;
+	}
 
 	throw new Error( `Unable to upload to cloud storage. ${ JSON.stringify( { Code, Message } ) }` );
 }

--- a/src/lib/search-and-replace.ts
+++ b/src/lib/search-and-replace.ts
@@ -148,13 +148,11 @@ export const searchAndReplace = async (
 	const replacements = pairs.flatMap( pair => pair.split( ',' ).map( str => str.trim() ) );
 	debug( 'Pairs: ', pairs, 'Replacements: ', replacements );
 
-	if ( inPlace ) {
-		const approved =
-			batchMode ||
-			( await confirm(
-				[],
-				'Are you sure you want to run search and replace on your input file? This operation is not reversible.'
-			) );
+	if ( inPlace && ! batchMode ) {
+		const approved = await confirm(
+			[],
+			'Are you sure you want to run search and replace on your input file? This operation is not reversible.'
+		);
 
 		// Bail if user does not wish to proceed
 		if ( ! approved ) {

--- a/src/lib/search-and-replace.ts
+++ b/src/lib/search-and-replace.ts
@@ -102,6 +102,7 @@ export interface SearchReplaceOptions {
 	isImport: boolean;
 	inPlace: boolean;
 	output: boolean | string | Writable;
+	batchMode?: boolean;
 }
 
 export interface SearchReplaceOutput {
@@ -113,7 +114,12 @@ export interface SearchReplaceOutput {
 export const searchAndReplace = async (
 	fileName: string,
 	pairs: string[] | string,
-	{ isImport = true, inPlace = false, output = process.stdout }: SearchReplaceOptions,
+	{
+		isImport = true,
+		inPlace = false,
+		output = process.stdout,
+		batchMode = false,
+	}: SearchReplaceOptions,
 	binary: string | null = null
 ): Promise< SearchReplaceOutput > => {
 	const dumpDetails = await getSqlDumpDetails( fileName );
@@ -143,10 +149,12 @@ export const searchAndReplace = async (
 	debug( 'Pairs: ', pairs, 'Replacements: ', replacements );
 
 	if ( inPlace ) {
-		const approved = await confirm(
-			[],
-			'Are you sure you want to run search and replace on your input file? This operation is not reversible.'
-		);
+		const approved =
+			batchMode ||
+			( await confirm(
+				[],
+				'Are you sure you want to run search and replace on your input file? This operation is not reversible.'
+			) );
 
 		// Bail if user does not wish to proceed
 		if ( ! approved ) {


### PR DESCRIPTION
## Description

In the in-place search/replace mode, the progress tracker breaks the confirmation prompt, asking whether the user wants to overwrite the source file. Because of that, the import process appears to be stuck at the "Loading remaining steps" point.

As a bonus, this PR fixes the `Cannot read properties of null` error in `uploadUsingPutObject` of `client-file-uploader.ts`. The error happens when the upstream returns a non-200 error code and an empty body.

## Pull request checklist

- [ ] Update [SETUP.md](https://github.com/Automattic/vip-cli/blob/trunk/docs/SETUP.md#list-of-environmental-variables) with any new environmental variables.
- [ ] Update [the documentation](https://github.com/Automattic/vip-cli/blob/trunk/docs).
- [x] [Manually test](https://github.com/Automattic/vip-cli/blob/trunk/docs/TESTING.md#manual-testing) the relevant changes.
- [x] Follow the [pull request checklist](https://github.com/Automattic/vip-cli/blob/trunk/docs/RELEASING.md#new-pull-requests)
- [ ] Add/update [automated tests](https://github.com/Automattic/vip-cli/blob/trunk/docs/TESTING.md#automated-testing) as needed.

## New release checklist

- [ ] [Automated tests](https://github.com/Automattic/vip-cli/blob/trunk/docs/TESTING.md#automated-testing) pass.
- [ ] The [Preparing for release checklist](https://github.com/Automattic/vip-cli/blob/trunk/docs/RELEASING.md#preparing-for-release) is completed.

## Steps to Test

See BB8-12271
