### PR TITLE
fix(dev-env): make `wp plugin scaffold` work

### DIFF
--- a/assets/dev-env.lando.template.yml.ejs
+++ b/assets/dev-env.lando.template.yml.ejs
@@ -81,6 +81,9 @@ services:
 <% wpVolumes() %>
     run_as_root:
       - chown www-data:www-data /wp/wp-content/mu-plugins /wp/config /wp/log /wp/wp-content/uploads /wp
+<% if ( appCode.mode == 'image' ) { %>
+      - chown www-data:www-data /wp/wp-content/plugins
+<% } %>
     run:
       - >
         sh /dev-tools/setup.sh

--- a/src/lib/constants/dev-environment.ts
+++ b/src/lib/constants/dev-environment.ts
@@ -49,4 +49,4 @@ export const DEV_ENVIRONMENT_DEFAULTS = {
 	phpVersion: Object.keys( DEV_ENVIRONMENT_PHP_VERSIONS )[ 0 ],
 } as const;
 
-export const DEV_ENVIRONMENT_VERSION = '2.2.1';
+export const DEV_ENVIRONMENT_VERSION = '2.2.2';

--- a/src/lib/dev-environment/dev-environment-lando.ts
+++ b/src/lib/dev-environment/dev-environment-lando.ts
@@ -659,7 +659,6 @@ export async function landoExec(
 
 		tool.app = app;
 		tool.name = toolName;
-		tool.dir = '/';
 
 		if ( options.stdio ) {
 			tool.stdio = options.stdio;


### PR DESCRIPTION
## Description

This PR makes `wp plugin scaffold` work with `vip dev-env exec`.

See CANTINA-997

## Pull request checklist

- [ ] Update [SETUP.md](https://github.com/Automattic/vip-cli/blob/trunk/docs/SETUP.md#list-of-environmental-variables) with any new environmental variables.
- [ ] Update [the documentation](https://github.com/Automattic/vip-cli/blob/trunk/docs).
- [x] [Manually test](https://github.com/Automattic/vip-cli/blob/trunk/docs/TESTING.md#manual-testing) the relevant changes.
- [x] Follow the [pull request checklist](https://github.com/Automattic/vip-cli/blob/trunk/docs/RELEASING.md#new-pull-requests)
- [ ] Add/update [automated tests](https://github.com/Automattic/vip-cli/blob/trunk/docs/TESTING.md#automated-testing) as needed.

## New release checklist

- [ ] [Automated tests](https://github.com/Automattic/vip-cli/blob/trunk/docs/TESTING.md#automated-testing) pass.
- [ ] The [Preparing for release checklist](https://github.com/Automattic/vip-cli/blob/trunk/docs/RELEASING.md#preparing-for-release) is completed.

## Steps to Test

1. `vip dev-env create < /dev/null && vip dev-env start`
2. `vip dev-env exec -- wp plugin scaffold foo`
3. `vip dev-env shell -- wp plugin scaffold foo1`

Compare the results with and without the patch.
