### PR TITLE
Fix dev-env-sync for mydumper backups

### DIFF
--- a/src/commands/dev-env-import-sql.ts
+++ b/src/commands/dev-env-import-sql.ts
@@ -17,6 +17,7 @@ import {
 import {
 	addAdminUser,
 	dataCleanup,
+	executeQuery,
 	flushCache,
 	reIndexSearch,
 } from '../lib/dev-environment/dev-environment-database';
@@ -31,6 +32,7 @@ export interface DevEnvImportSQLOptions {
 	inPlace: boolean;
 	skipValidate: boolean;
 	quiet: boolean;
+	postImportSQL?: string;
 }
 
 export class DevEnvImportSQLCommand {
@@ -119,6 +121,10 @@ export class DevEnvImportSQLCommand {
 
 		if ( searchReplace?.length && ! inPlace ) {
 			fs.unlinkSync( resolvedPath );
+		}
+
+		if ( this.options.postImportSQL ) {
+			await executeQuery( lando, this.slug, this.options.postImportSQL );
 		}
 
 		await flushCache( lando, this.slug, this.options.quiet );

--- a/src/commands/dev-env-sync-sql.ts
+++ b/src/commands/dev-env-sync-sql.ts
@@ -246,15 +246,16 @@ export class DevEnvSyncSQLCommand {
 			inPlace: true,
 			skipValidate: true,
 			quiet: true,
+			postImportSQL: this.fixBlogsTableQuery(),
 		};
 		const importCommand = new DevEnvImportSQLCommand( this.sqlFile, importOptions, this.slug );
 		await importCommand.run();
 	}
 
-	public async fixBlogsTable(): Promise< void > {
+	private fixBlogsTableQuery() {
 		const networkSites = this.env.wpSitesSDS?.nodes;
 		if ( ! networkSites ) {
-			return;
+			return '';
 		}
 
 		const prologue = `
@@ -294,10 +295,11 @@ DROP PROCEDURE vip_sync_update_blog_domains;
 			);
 		}
 
-		if ( queries.length ) {
-			const sql = `${ prologue }\n${ queries.join( '\n' ) }\n${ epilogue }`;
-			await fs.promises.appendFile( this.sqlFile, sql );
+		if ( queries.length === 0 ) {
+			return '';
 		}
+
+		return `${ prologue }\n${ queries.join( '\n' ) }\n${ epilogue }`;
 	}
 
 	/**
@@ -360,7 +362,6 @@ DROP PROCEDURE vip_sync_update_blog_domains;
 			}
 
 			await this.runSearchReplace();
-			await this.fixBlogsTable();
 			console.log( `${ chalk.green( '✓' ) } Search-replace operation is complete` );
 		} catch ( err ) {
 			const error = err as Error;

--- a/src/lib/dev-environment/dev-environment-database.ts
+++ b/src/lib/dev-environment/dev-environment-database.ts
@@ -45,3 +45,7 @@ export const flushCache = async ( lando: Lando, slug: string, quiet?: boolean ) 
 	);
 	await exec( lando, slug, cacheArg );
 };
+
+export const executeQuery = async ( lando: Lando, slug: string, query: string ) => {
+	await exec( lando, slug, [ 'wp', 'db', 'query', query ] );
+};


### PR DESCRIPTION
## Description

Currently, the `fixBlogsTable` stored procedure is incorrectly appended to the `mydumper` stream backup file during the dev-env db sync. This causes an error because stored procedures do not conform to the `mydumper` stream backup file format.

This PR introduces a new step in `DevEnvImportSQLCommand` that ensures stored procedures are handled separately. Specifically, a new post-import SQL execution step (`postImportSQL`) is added, which runs only after the SQL import completes successfully.

With this change, the `fixBlogsTable` stored procedure is executed as part of `postImportSQL`, ensuring it is independent of the backup file and runs correctly without format conflicts.

## Pull request checklist

- [ ] Update [SETUP.md](https://github.com/Automattic/vip-cli/blob/trunk/docs/SETUP.md#list-of-environmental-variables) with any new environmental variables.
- [ ] Update [the documentation](https://github.com/Automattic/vip-cli/blob/trunk/docs).
- [ ] [Manually test](https://github.com/Automattic/vip-cli/blob/trunk/docs/TESTING.md#manual-testing) the relevant changes.
- [ ] Follow the [pull request checklist](https://github.com/Automattic/vip-cli/blob/trunk/docs/RELEASING.md#new-pull-requests)
- [ ] Add/update [automated tests](https://github.com/Automattic/vip-cli/blob/trunk/docs/TESTING.md#automated-testing) as needed.

## New release checklist

- [ ] [Automated tests](https://github.com/Automattic/vip-cli/blob/trunk/docs/TESTING.md#automated-testing) pass.
- [ ] The [Preparing for release checklist](https://github.com/Automattic/vip-cli/blob/trunk/docs/RELEASING.md#preparing-for-release) is completed.

## Steps to Test

Outline the steps to test and verify the PR here.

Example:

1. Check out PR.
1. Run `npm run build`
1. Run `./dist/bin/vip-cookies.js nom`
1. Verify cookies are delicious.
