### PR TITLE
Add option to skip maintenance mode during SQL import

### DIFF
--- a/src/bin/vip-import-sql.js
+++ b/src/bin/vip-import-sql.js
@@ -407,10 +407,14 @@ void command( {
 		'output',
 		'The local file path to save a copy of the results from the search and replace operation when the --search-replace option is passed. Ignored when used with the --in-place option.'
 	)
+	.option(
+		'skip-maintenance-mode',
+		'Imports data without putting the environment in maintenance mode. Available only for unlaunched environments. Caution: This may cause site instability during import.'
+	)
 	.examples( examples )
 	.argv( process.argv, async ( arg, opts ) => {
 		const { app, env } = opts;
-		let { skipValidate, searchReplace } = opts;
+		let { skipValidate, searchReplace, skipMaintenanceMode } = opts;
 		const { id: envId, appId } = env;
 		const [ fileName ] = arg;
 		const isMultiSite = await isMultiSiteInSiteMeta( appId, envId );
@@ -583,6 +587,7 @@ Processing the SQL import for your environment...
 				basename,
 				md5,
 				searchReplace: [],
+				skipMaintenanceMode,
 			};
 
 			if ( searchReplace ) {


### PR DESCRIPTION
## Description

Currently, during an SQL import, if the site is unlaunched, it is automatically placed in maintenance mode. This behavior may not always be desirable.

This PR introduces an option (`--skip-maintenance-mode`) to skip maintenance mode during an SQL import for unlaunched sites. This allows for more flexibility in managing database imports without unnecessary downtime.

## Pull request checklist

- [ ] Update [SETUP.md](https://github.com/Automattic/vip-cli/blob/trunk/docs/SETUP.md#list-of-environmental-variables) with any new environmental variables.
- [ ] Update [the documentation](https://github.com/Automattic/vip-cli/blob/trunk/docs).
- [ ] [Manually test](https://github.com/Automattic/vip-cli/blob/trunk/docs/TESTING.md#manual-testing) the relevant changes.
- [ ] Follow the [pull request checklist](https://github.com/Automattic/vip-cli/blob/trunk/docs/RELEASING.md#new-pull-requests)
- [ ] Add/update [automated tests](https://github.com/Automattic/vip-cli/blob/trunk/docs/TESTING.md#automated-testing) as needed.

## New release checklist

- [ ] [Automated tests](https://github.com/Automattic/vip-cli/blob/trunk/docs/TESTING.md#automated-testing) pass.
- [ ] The [Preparing for release checklist](https://github.com/Automattic/vip-cli/blob/trunk/docs/RELEASING.md#preparing-for-release) is completed.

## Steps to Test

Outline the steps to test and verify the PR here.

Example:

1. Check out PR.
1. Run `npm run build`
1. Run `./dist/bin/vip-cookies.js nom`
1. Verify cookies are delicious.
