### PR TITLE
fix: rsync to skip files based on checksum

### DIFF
--- a/assets/dev-env.lando.template.yml.ejs
+++ b/assets/dev-env.lando.template.yml.ejs
@@ -184,7 +184,7 @@ services:
         - devtools:/dev-tools
         - scripts:/scripts
     initOnly: true
-    entrypoint: sh -c '/usr/bin/rsync -a --delete --chown=${LANDO_HOST_USER_ID}:${LANDO_HOST_GROUP_ID} /wp/ /shared/; /usr/bin/rsync -a --chown=${LANDO_HOST_USER_ID}:${LANDO_HOST_GROUP_ID} --delete /dev-tools-orig/ /dev-tools/'
+    entrypoint: /bin/sh -c '/usr/bin/rsync -ac --delete --chown=${LANDO_HOST_USER_ID}:${LANDO_HOST_GROUP_ID} /wp/ /shared/; /usr/bin/rsync -ac --chown=${LANDO_HOST_USER_ID}:${LANDO_HOST_GROUP_ID} --delete /dev-tools-orig/ /dev-tools/'
     volumes:
       devtools:
       scripts:
@@ -194,7 +194,7 @@ services:
     type: compose
     services:
       image: ghcr.io/automattic/vip-container-images/mu-plugins:0.1
-      command: sh /run.sh
+      command: /bin/sh /run.sh
       volumes:
         - mu-plugins:/shared
         - type: volume

--- a/src/lib/constants/dev-environment.ts
+++ b/src/lib/constants/dev-environment.ts
@@ -49,4 +49,4 @@ export const DEV_ENVIRONMENT_DEFAULTS = {
 	phpVersion: Object.keys( DEV_ENVIRONMENT_PHP_VERSIONS )[ 0 ],
 } as const;
 
-export const DEV_ENVIRONMENT_VERSION = '2.2.2';
+export const DEV_ENVIRONMENT_VERSION = '2.2.3';


### PR DESCRIPTION
## Description

Because `rsync`, by default, checks whether files differ using the modification time and size, this leads to interesting bugs when both files have the size date/time and size but different content. For example, this is the case for `wp-includes/version.php` in WP 6.6.2 and 6.7.2.

This PR instructs `rsync` to use checksums to decide whether files differ.

## Pull request checklist

- [ ] Update [SETUP.md](https://github.com/Automattic/vip-cli/blob/trunk/docs/SETUP.md#list-of-environmental-variables) with any new environmental variables.
- [ ] Update [the documentation](https://github.com/Automattic/vip-cli/blob/trunk/docs).
- [x] [Manually test](https://github.com/Automattic/vip-cli/blob/trunk/docs/TESTING.md#manual-testing) the relevant changes.
- [x] Follow the [pull request checklist](https://github.com/Automattic/vip-cli/blob/trunk/docs/RELEASING.md#new-pull-requests)
- [ ] Add/update [automated tests](https://github.com/Automattic/vip-cli/blob/trunk/docs/TESTING.md#automated-testing) as needed.

## New release checklist

- [ ] [Automated tests](https://github.com/Automattic/vip-cli/blob/trunk/docs/TESTING.md#automated-testing) pass.
- [ ] The [Preparing for release checklist](https://github.com/Automattic/vip-cli/blob/trunk/docs/RELEASING.md#preparing-for-release) is completed.

## Steps to Test

```sh
vip dev-env create -w 6.6 < /dev/null
vip dev-env start
vip dev-env -w
vip dev-env update -w 6.7 < /dev/null
vip dev-env start
vip dev-env exec -- wp core version
```

Without this patch, the last command will report 6.6.2; with this patch, it will report 6.7.2.
