### PR TITLE
fix(dev-env): do not show the update prompt when stdin is not a TTY

### DIFF
--- a/src/lib/dev-environment/dev-environment-core.ts
+++ b/src/lib/dev-environment/dev-environment-core.ts
@@ -124,7 +124,7 @@ export async function startEnvironment(
 	}
 
 	let updated = false;
-	if ( ! options.skipWpVersionsCheck ) {
+	if ( ! options.skipWpVersionsCheck && process.stdin.isTTY ) {
 		updated = await maybeUpdateWordPressImage( lando, slug );
 	}
 	updated = updated || ( await maybeUpdateVersion( lando, slug ) );


### PR DESCRIPTION
## Description

When running `vip dev-env start < /dev/null`, if you happen not to have the latest version of WordPress, VIP CLI will crash on the "Would you like to upgrade WordPress?" prompt because the input is not a TTY.

This PR fixes that.

## Pull request checklist

- [ ] Update [SETUP.md](https://github.com/Automattic/vip-cli/blob/trunk/docs/SETUP.md#list-of-environmental-variables) with any new environmental variables.
- [ ] Update [the documentation](https://github.com/Automattic/vip-cli/blob/trunk/docs).
- [x] [Manually test](https://github.com/Automattic/vip-cli/blob/trunk/docs/TESTING.md#manual-testing) the relevant changes.
- [x] Follow the [pull request checklist](https://github.com/Automattic/vip-cli/blob/trunk/docs/RELEASING.md#new-pull-requests)
- [ ] Add/update [automated tests](https://github.com/Automattic/vip-cli/blob/trunk/docs/TESTING.md#automated-testing) as needed.

## New release checklist

- [ ] [Automated tests](https://github.com/Automattic/vip-cli/blob/trunk/docs/TESTING.md#automated-testing) pass.
- [ ] The [Preparing for release checklist](https://github.com/Automattic/vip-cli/blob/trunk/docs/RELEASING.md#preparing-for-release) is completed.

## Steps to Test

```sh
vip dev-env create -w 6.6 < /dev/null
vip dev-env start < /dev/null
```

VIP CLI will crash without this patch and start the environment with it.
