### PR TITLE
fix(dev-env): handling of absolute paths in configuration files

### DIFF
--- a/src/lib/dev-environment/dev-environment-configuration-file.ts
+++ b/src/lib/dev-environment/dev-environment-configuration-file.ts
@@ -135,14 +135,17 @@ function adjustRelativePaths(
 	const configurationDirectory = path.resolve( path.dirname( configurationFilePath ) );
 
 	if ( configuration[ 'app-code' ] && configuration[ 'app-code' ] !== 'image' ) {
-		configuration[ 'app-code' ] = path.join( configurationDirectory, configuration[ 'app-code' ] );
+		const dir = configuration[ 'app-code' ];
+		configuration[ 'app-code' ] = path.isAbsolute( dir )
+			? dir
+			: path.join( configurationDirectory, dir );
 	}
 
 	if ( configuration[ 'mu-plugins' ] && configuration[ 'mu-plugins' ] !== 'image' ) {
-		configuration[ 'mu-plugins' ] = path.join(
-			configurationDirectory,
-			configuration[ 'mu-plugins' ]
-		);
+		const dir = configuration[ 'mu-plugins' ];
+		configuration[ 'mu-plugins' ] = path.isAbsolute( dir )
+			? dir
+			: path.join( configurationDirectory, dir );
 	}
 
 	return configuration;


### PR DESCRIPTION
## Description

Absolute paths in dev env configuration files did not work because the system treated every path as relative to the configuration file directory.

## Pull request checklist

- [ ] Update [SETUP.md](https://github.com/Automattic/vip-cli/blob/trunk/docs/SETUP.md#list-of-environmental-variables) with any new environmental variables.
- [ ] Update [the documentation](https://github.com/Automattic/vip-cli/blob/trunk/docs).
- [ ] [Manually test](https://github.com/Automattic/vip-cli/blob/trunk/docs/TESTING.md#manual-testing) the relevant changes.
- [x] Follow the [pull request checklist](https://github.com/Automattic/vip-cli/blob/trunk/docs/RELEASING.md#new-pull-requests)
- [ ] Add/update [automated tests](https://github.com/Automattic/vip-cli/blob/trunk/docs/TESTING.md#automated-testing) as needed.

## New release checklist

- [ ] [Automated tests](https://github.com/Automattic/vip-cli/blob/trunk/docs/TESTING.md#automated-testing) pass.
- [ ] The [Preparing for release checklist](https://github.com/Automattic/vip-cli/blob/trunk/docs/RELEASING.md#preparing-for-release) is completed.

## Steps to Test

Create a dev env configuration with an absolute path in `app-code` or `mu-plugins`. It will work with the patch and won't without.
