### PR TITLE
feat(dev-env): overrides for the default configuration

### DIFF
--- a/__tests__/devenv-e2e/013-configuration-file.spec.js
+++ b/__tests__/devenv-e2e/013-configuration-file.spec.js
@@ -1,5 +1,5 @@
 import { describe, expect, it, jest } from '@jest/globals';
-import { mkdtemp, rm, mkdir, realpath } from 'node:fs/promises';
+import { mkdtemp, rm, mkdir, realpath, readFile, stat } from 'node:fs/promises';
 import os from 'node:os';
 import path from 'node:path';
 import xdgBaseDir from 'xdg-basedir';
@@ -333,5 +333,81 @@ describe( 'vip dev-env configuration file', () => {
 			photon: ! expectedPhoton,
 			cron: ! expectedCron,
 		} );
+	} );
+
+	it( 'should create .lando.local.yml if overrides have been provided', async () => {
+		const slug = getProjectSlug();
+		const expectedOverrides = `services:\n  wordpress:\n    services:\n      pull_policy: never\n`;
+
+		expect( await checkEnvExists( slug ) ).toBe( false );
+
+		await writeConfigurationFile( tmpWorkingDirectoryPath, {
+			'configuration-version': '1',
+			slug,
+			overrides: expectedOverrides,
+		} );
+
+		const spawnOptions = {
+			env,
+			cwd: tmpWorkingDirectoryPath,
+		};
+
+		const result = await cliTest.spawn(
+			[ process.argv[ 0 ], vipDevEnvCreate ],
+			spawnOptions,
+			true
+		);
+		expect( result.rc ).toBe( 0 );
+		expect( result.stdout ).toContain( `Using environment ${ slug }` );
+		expect( result.stderr ).toBe( '' );
+
+		const data = readEnvironmentData( slug );
+		expect( data ).toMatchObject( {
+			siteSlug: slug,
+			overrides: expectedOverrides,
+		} );
+
+		const overrideFile = path.join( tmpPath, 'vip', 'dev-environment', slug, '.lando.local.yml' );
+		const overrideContent = await readFile( overrideFile, 'utf8' );
+		expect( overrideContent ).toBe( expectedOverrides );
+	} );
+
+	it( 'should remove .lando.local.yml if no overrides have been provided', async () => {
+		const slug = getProjectSlug();
+		const overrides = `services:\n  wordpress:\n    services:\n      pull_policy: never\n`;
+
+		expect( await checkEnvExists( slug ) ).toBe( false );
+
+		await writeConfigurationFile( tmpWorkingDirectoryPath, {
+			'configuration-version': '1',
+			slug,
+			overrides,
+		} );
+
+		const spawnOptions = {
+			env,
+			cwd: tmpWorkingDirectoryPath,
+		};
+
+		let result = await cliTest.spawn( [ process.argv[ 0 ], vipDevEnvCreate ], spawnOptions, true );
+		expect( result.rc ).toBe( 0 );
+		expect( result.stdout ).toContain( `Using environment ${ slug }` );
+		expect( result.stderr ).toBe( '' );
+
+		await writeConfigurationFile( tmpWorkingDirectoryPath, {
+			'configuration-version': '1',
+			slug,
+			overrides: '',
+		} );
+
+		result = await cliTest.spawn( [ process.argv[ 0 ], vipDevEnvUpdate ], spawnOptions, true );
+		expect( result.rc ).toBe( 0 );
+		expect( result.stderr ).toBe( '' );
+
+		const data = readEnvironmentData( slug );
+		expect( data.overrides ).toBeFalsy();
+
+		const overrideFile = path.join( tmpPath, 'vip', 'dev-environment', slug, '.lando.local.yml' );
+		return expect( stat( overrideFile ) ).rejects.toThrow();
 	} );
 } );

--- a/src/lib/dev-environment/dev-environment-cli.ts
+++ b/src/lib/dev-environment/dev-environment-cli.ts
@@ -309,6 +309,7 @@ export async function promptForArguments(
 		mailpit: false,
 		photon: false,
 		cron: false,
+		overrides: preselectedOptions.overrides,
 	};
 
 	const promptLabels = {

--- a/src/lib/dev-environment/dev-environment-configuration-file.ts
+++ b/src/lib/dev-environment/dev-environment-configuration-file.ts
@@ -116,6 +116,7 @@ function sanitizeConfiguration(
 		'media-redirect-domain': configuration[ 'media-redirect-domain' ]?.toString(),
 		photon: stringToBooleanIfDefined( configuration.photon ),
 		cron: stringToBooleanIfDefined( configuration.cron ),
+		overrides: configuration.overrides?.toString(),
 		meta: configurationMeta,
 	};
 
@@ -174,6 +175,7 @@ export function mergeConfigurationFileOptions(
 		mediaRedirectDomain: configurationFileOptions[ 'media-redirect-domain' ],
 		photon: configurationFileOptions.photon,
 		cron: configurationFileOptions.cron,
+		overrides: configurationFileOptions.overrides,
 	};
 
 	const mergedOptions: InstanceOptions = {};

--- a/src/lib/dev-environment/dev-environment-core.ts
+++ b/src/lib/dev-environment/dev-environment-core.ts
@@ -73,6 +73,7 @@ const nginxFileTemplatePath = path.join(
 	'dev-env.nginx.template.conf.ejs'
 );
 const landoFileName = '.lando.yml';
+const landoOverridesFileName = '.lando.local.yml';
 const landoBackupFileName = '.lando.backup.yml';
 const nginxFileName = 'extra.conf';
 const instanceDataFileName = 'instance_data.json';
@@ -256,6 +257,8 @@ function preProcessInstanceData( instanceData: InstanceData ): InstanceData {
 	// newInstanceData
 	newInstanceData.autologinKey = uuid();
 	newInstanceData.version = DEV_ENVIRONMENT_VERSION;
+
+	newInstanceData.overrides = instanceData.overrides ?? '';
 
 	return newInstanceData;
 }
@@ -557,6 +560,7 @@ async function prepareLandoEnv(
 	const instanceDataFile = JSON.stringify( instanceData );
 
 	const landoFileTargetPath = path.join( instancePath, landoFileName );
+	const landoOverridesFileTargetPath = path.join( instancePath, landoOverridesFileName );
 	const landoBackupFileTargetPath = path.join( instancePath, landoBackupFileName );
 	const nginxFolderPath = path.join( instancePath, nginxPathString );
 	const nginxFileTargetPath = path.join( nginxFolderPath, nginxFileName );
@@ -586,6 +590,12 @@ async function prepareLandoEnv(
 	debug( `Instance data file created in ${ instanceDataTargetPath }` );
 
 	await writeIntegrationsConfig( instancePath, integrationsConfig );
+
+	if ( instanceData.overrides ) {
+		await fs.promises.writeFile( landoOverridesFileTargetPath, instanceData.overrides );
+	} else {
+		await fs.promises.rm( landoOverridesFileTargetPath, { force: true } );
+	}
 }
 
 export function getAllEnvironmentNames(): string[] {

--- a/src/lib/dev-environment/types.ts
+++ b/src/lib/dev-environment/types.ts
@@ -16,6 +16,7 @@ export interface InstanceOptions {
 	mailpit?: boolean;
 	photon?: boolean;
 	cron?: boolean;
+	overrides?: string;
 
 	[ index: string ]: unknown;
 }
@@ -86,6 +87,7 @@ export interface ConfigurationFileOptions {
 	'media-redirect-domain'?: string;
 	photon?: boolean;
 	cron?: boolean;
+	overrides?: string;
 
 	meta?: ConfigurationFileMeta;
 	[ index: string ]: unknown;
@@ -116,4 +118,5 @@ export interface InstanceData {
 	pullAfter?: number;
 	autologinKey?: string;
 	version?: string;
+	overrides?: string;
 }


### PR DESCRIPTION
## Description

This PR adds support for overrides to the dev env configuration file.

Sometimes, we need non-standard things like custom images, custom MySQL options to improve performance, etc. We use the `.lando.local.yml` file for all customizations, but it is not very convenient when we have to automate things.

This PR adds a new key to the configuration file (`.wpvip/vip-dev-env.yml`): `overrides`.

Example:
```yaml
configuration-version: 1
slug: overrides
title: Dev Site
php: 8.2
wordpress: 6.7
app-code: image
mu-plugins: image
multisite: false
phpmyadmin: false
elasticsearch: false
xdebug: false
mailpit: false
photon: false
cron: false
overrides: |
  services:
    wordpress:
      services:
        image: wp:6.7.2
        pull_policy: never
```

When we create or update the environment, the data from `overrides` are placed into `.lando.local.yml`. If the value of `overrides` is empty, the file is deleted.

## Pull request checklist

- [ ] Update [SETUP.md](https://github.com/Automattic/vip-cli/blob/trunk/docs/SETUP.md#list-of-environmental-variables) with any new environmental variables.
- [ ] Update [the documentation](https://github.com/Automattic/vip-cli/blob/trunk/docs).
- [x] [Manually test](https://github.com/Automattic/vip-cli/blob/trunk/docs/TESTING.md#manual-testing) the relevant changes.
- [x] Follow the [pull request checklist](https://github.com/Automattic/vip-cli/blob/trunk/docs/RELEASING.md#new-pull-requests)
- [x] Add/update [automated tests](https://github.com/Automattic/vip-cli/blob/trunk/docs/TESTING.md#automated-testing) as needed.

## New release checklist

- [ ] [Automated tests](https://github.com/Automattic/vip-cli/blob/trunk/docs/TESTING.md#automated-testing) pass.
- [ ] The [Preparing for release checklist](https://github.com/Automattic/vip-cli/blob/trunk/docs/RELEASING.md#preparing-for-release) is completed.

## Steps to Test

1. Build a custom WordPress 6.7 image (for example, from here: Automattic/vip-container-images#1076): `docker build --build-arg WP_GIT_REF=6.7.2 -t wp:6.7.2 .`
2. Create the `.wpvip/vip-dev-env.yml` file with the abovementioned content.
3. Run `vip dev-env create`.
4. Ensure that `~/.local/share/vip/dev-environment/overrides/.lando.local.yml` exists
5. Start the environment and ensure it works.
6. Remove `overrides` from `.wpvip/vip-dev-env.yml` and run `vip dev-env update`.
7. Ensure that `~/.local/share/vip/dev-environment/overrides/.lando.local.yml` is gone.
8. Run `vip dev-env destroy`.