### PR TITLE
Add new parameter `allow-all-file-types` for Media import to bypass file type validations

### DIFF
--- a/src/bin/vip-import-media.js
+++ b/src/bin/vip-import-media.js
@@ -106,17 +106,30 @@ Are you sure you want to import the contents of the URL?
 		'Check the status of a currently running media import or retrieve an error log of the most recent media import.'
 	)
 	.command( 'abort', 'Abort the media import currently in progress.' )
-	.option( 'exportFileErrorsToJson', 'Format the error log in JSON. Default is TXT.' )
+	.option( 'exportFileErrorsToJson', 'Alias for --export-file-errors-to-json. (deprecated)' )
+	.option( 'export-file-errors-to-json', 'Format the error log in JSON. Default is TXT.' )
+	.option( 'saveErrorLog', 'Alias for --save-error-log. (deprecated)' )
 	.option(
-		'saveErrorLog',
+		'save-error-log',
 		'Skip the confirmation prompt and download an error log for the import automatically.'
 	)
+	.option( 'overwriteExistingFiles', 'Alias for --overwrite-existing-files. (deprecated)', false )
 	.option(
-		'overwriteExistingFiles',
+		'overwrite-existing-files',
 		'Overwrite existing files with the imported files if they have the same path and file name.',
 		false
 	)
-	.option( 'importIntermediateImages', 'Include intermediate image files in the import.', false )
+	.option(
+		[ 't', 'allow-all-file-types' ],
+		'Allow all files to be imported, bypass the file type validation rules.',
+		false
+	)
+	.option(
+		'importIntermediateImages',
+		'Alias for --import-intermediate-images. (deprecated)',
+		false
+	)
+	.option( 'import-intermediate-images', 'Include intermediate image files in the import.', false )
 	.examples( examples )
 	.argv( process.argv, async ( args, opts ) => {
 		const {
@@ -125,6 +138,7 @@ Are you sure you want to import the contents of the URL?
 			exportFileErrorsToJson,
 			saveErrorLog,
 			overwriteExistingFiles,
+			allowAllFileTypes,
 			importIntermediateImages,
 		} = opts;
 		const [ url ] = args;
@@ -167,6 +181,7 @@ Importing Media into your App...
 						archiveUrl: url,
 						overwriteExistingFiles,
 						importIntermediateImages,
+						skipFileTypeValidation: allowAllFileTypes,
 						apiVersion: API_VERSION,
 					},
 				},

--- a/src/bin/vip-import-media.js
+++ b/src/bin/vip-import-media.js
@@ -163,6 +163,8 @@ Error:
 			overwrite_existing_files: overwriteExistingFiles,
 			allow_all_file_types: allowAllFileTypes,
 			import_intermediate_images: importIntermediateImages,
+			export_file_errors_to_json: exportFileErrorsToJson,
+			save_error_log: saveErrorLog,
 		} );
 
 		const progressTracker = new MediaImportProgressTracker( [] );

--- a/src/bin/vip-import-media.js
+++ b/src/bin/vip-import-media.js
@@ -159,7 +159,11 @@ Error:
 		debug( 'Options: ', opts );
 		debug( 'Args:', args );
 
-		await track( 'import_media_start_execute' );
+		await track( 'import_media_start_execute', {
+			overwrite_existing_files: overwriteExistingFiles,
+			allow_all_file_types: allowAllFileTypes,
+			import_intermediate_images: importIntermediateImages,
+		} );
 
 		const progressTracker = new MediaImportProgressTracker( [] );
 		progressTracker.prefix = `

--- a/src/lib/cli/command.js
+++ b/src/lib/cli/command.js
@@ -497,6 +497,11 @@ args.argv = async function ( argv, cb ) {
 					value: options.importIntermediateImages ? '✅ Yes' : `${ chalk.red( 'x' ) } No`,
 				} );
 
+				info.push( {
+					key: 'Allow all file types',
+					value: options.allowAllFileTypes ? '✅ Yes' : `${ chalk.red( 'x' ) } No`,
+				} );
+
 				options.exportFileErrorsToJson =
 					Object.hasOwn( options, 'exportFileErrorsToJson' ) &&
 					Boolean( options.exportFileErrorsToJson ) &&


### PR DESCRIPTION
## Description

This PR tries to add a new optional parameter `allow-all-file-types` which will bypass file type validations when performing a Media import.

It also updates the older parameters from `camelCase` to `kebab-case`. For backward compatibility, we are still allowing older `camelCase` parameters while introducing the newer ones.

## Steps to Test
1. Check out PR.
1. Run `npm run build`
2. Run `npm link` so that your locally built lib is used
3. Create a zip file that contains a file with unsupported file format
1. Run `./dist/bin/vip import media @SITE_ID ZIP_FILE_LINK --allow-all-file-types`
1. Verify that the import was successful

## Post-Release
- Update the CLI documentation with the new supported parameters
