### PR TITLE
fix(dev-env): accept `demo` as an alias of `image`

### DIFF
--- a/src/lib/dev-environment/dev-environment-configuration-file.ts
+++ b/src/lib/dev-environment/dev-environment-configuration-file.ts
@@ -137,20 +137,14 @@ function adjustRelativePaths(
 ): ConfigurationFileOptions {
 	const configurationDirectory = path.resolve( path.dirname( configurationFilePath ) );
 	const imageOption = [ 'demo', 'image' ];
-	let value: string | undefined;
 
-	value = configuration[ 'app-code' ];
-	if ( value && ! imageOption.includes( value ) ) {
-		configuration[ 'app-code' ] = path.isAbsolute( value )
-			? value
-			: path.join( configurationDirectory, value );
-	}
-
-	value = configuration[ 'mu-plugins' ];
-	if ( value && ! imageOption.includes( value ) ) {
-		configuration[ 'mu-plugins' ] = path.isAbsolute( value )
-			? value
-			: path.join( configurationDirectory, value );
+	for ( const option of [ 'app-code', 'mu-plugins' ] as const ) {
+		const value = configuration[ option ];
+		if ( value && ! imageOption.includes( value ) ) {
+			configuration[ option ] = path.isAbsolute( value )
+				? value
+				: path.join( configurationDirectory, value );
+		}
 	}
 
 	return configuration;

--- a/src/lib/dev-environment/dev-environment-configuration-file.ts
+++ b/src/lib/dev-environment/dev-environment-configuration-file.ts
@@ -136,19 +136,21 @@ function adjustRelativePaths(
 	configurationFilePath: string
 ): ConfigurationFileOptions {
 	const configurationDirectory = path.resolve( path.dirname( configurationFilePath ) );
+	const imageOption = [ 'demo', 'image' ];
+	let value: string | undefined;
 
-	if ( configuration[ 'app-code' ] && configuration[ 'app-code' ] !== 'image' ) {
-		const dir = configuration[ 'app-code' ];
-		configuration[ 'app-code' ] = path.isAbsolute( dir )
-			? dir
-			: path.join( configurationDirectory, dir );
+	value = configuration[ 'app-code' ];
+	if ( value && ! imageOption.includes( value ) ) {
+		configuration[ 'app-code' ] = path.isAbsolute( value )
+			? value
+			: path.join( configurationDirectory, value );
 	}
 
-	if ( configuration[ 'mu-plugins' ] && configuration[ 'mu-plugins' ] !== 'image' ) {
-		const dir = configuration[ 'mu-plugins' ];
-		configuration[ 'mu-plugins' ] = path.isAbsolute( dir )
-			? dir
-			: path.join( configurationDirectory, dir );
+	value = configuration[ 'mu-plugins' ];
+	if ( value && ! imageOption.includes( value ) ) {
+		configuration[ 'mu-plugins' ] = path.isAbsolute( value )
+			? value
+			: path.join( configurationDirectory, value );
 	}
 
 	return configuration;


### PR DESCRIPTION
## Description

See DOC-10154

`app-code` and `mu-plugins` options of dev env configuration file now support `demo` as an alias of `image`.

## Pull request checklist

- [ ] Update [SETUP.md](https://github.com/Automattic/vip-cli/blob/trunk/docs/SETUP.md#list-of-environmental-variables) with any new environmental variables.
- [ ] Update [the documentation](https://github.com/Automattic/vip-cli/blob/trunk/docs).
- [x] [Manually test](https://github.com/Automattic/vip-cli/blob/trunk/docs/TESTING.md#manual-testing) the relevant changes.
- [x] Follow the [pull request checklist](https://github.com/Automattic/vip-cli/blob/trunk/docs/RELEASING.md#new-pull-requests)
- [ ] Add/update [automated tests](https://github.com/Automattic/vip-cli/blob/trunk/docs/TESTING.md#automated-testing) as needed.

## New release checklist

- [ ] [Automated tests](https://github.com/Automattic/vip-cli/blob/trunk/docs/TESTING.md#automated-testing) pass.
- [ ] The [Preparing for release checklist](https://github.com/Automattic/vip-cli/blob/trunk/docs/RELEASING.md#preparing-for-release) is completed.

## Steps to Test

Create a dev env config with `app-code: demo` and `mi-plugins: demo` and ensure the dev env works.
