### PR TITLE
fix: forcefully strip `.js` from the command

### DIFF
--- a/src/lib/cli/command.js
+++ b/src/lib/cli/command.js
@@ -36,8 +36,15 @@ let _opts = {};
 
 let alreadyConfirmedDebugAttachment = false;
 
+/**
+ * @param {string[]} argv
+ */
 // eslint-disable-next-line complexity
 args.argv = async function ( argv, cb ) {
+	if ( process.platform !== 'win32' && argv[ 1 ]?.endsWith( '.js' ) ) {
+		argv[ 1 ] = argv[ 1 ].slice( 0, -3 );
+	}
+
 	if ( process.execArgv.includes( '--inspect' ) && ! alreadyConfirmedDebugAttachment ) {
 		await prompt( {
 			type: 'confirm',


### PR DESCRIPTION
## Description

Strip the `.js` suffix from the command so that `args` properly construct the name of the subcommand script.

See 202944-z.

## Pull request checklist

- [ ] Update [SETUP.md](https://github.com/Automattic/vip-cli/blob/trunk/docs/SETUP.md#list-of-environmental-variables) with any new environmental variables.
- [ ] Update [the documentation](https://github.com/Automattic/vip-cli/blob/trunk/docs).
- [x] [Manually test](https://github.com/Automattic/vip-cli/blob/trunk/docs/TESTING.md#manual-testing) the relevant changes.
- [x] Follow the [pull request checklist](https://github.com/Automattic/vip-cli/blob/trunk/docs/RELEASING.md#new-pull-requests)
- [ ] Add/update [automated tests](https://github.com/Automattic/vip-cli/blob/trunk/docs/TESTING.md#automated-testing) as needed.

## New release checklist

- [ ] [Automated tests](https://github.com/Automattic/vip-cli/blob/trunk/docs/TESTING.md#automated-testing) pass.
- [ ] The [Preparing for release checklist](https://github.com/Automattic/vip-cli/blob/trunk/docs/RELEASING.md#preparing-for-release) is completed.

## Steps to Test

```
$ dist/bin/vip.js dev-env list
✕ Please contact VIP Support with the following information:
Error: spawn vip.js-dev-env ENOENT
...
$ npm run build
$ dist/bin/vip.js dev-env list
// Works
```