### PR TITLE
Only use myloader source-db when provided

### DIFF
--- a/src/commands/dev-env-import-sql.ts
+++ b/src/commands/dev-env-import-sql.ts
@@ -150,10 +150,18 @@ export class DevEnvImportSQLCommand {
 		);
 		const threadCount = Math.max( os.cpus().length - 2, 1 );
 		if ( dumpDetails.type === SqlDumpType.MYDUMPER ) {
+			if ( ! dumpDetails.sourceDb ) {
+				console.log(
+					`${ chalk.yellow(
+						'!'
+					) } Unable to identify source DB. Skipping myloader source-db option`
+				);
+			}
+
 			importArg = [
 				'db-myloader',
 				'--overwrite-tables',
-				`--source-db=${ dumpDetails.sourceDb }`,
+				...( dumpDetails.sourceDb ? [ `--source-db=${ dumpDetails.sourceDb }` ] : [] ),
 				`--threads=${ threadCount }`,
 				'--max-threads-for-schema-creation=10',
 				'--max-threads-for-index-creation=10',


### PR DESCRIPTION
## Description

Currently, when we are unable to detect the source db from the dump file, we are using `myloader --source-db=undefined`, which ends up skipping all the tables to import since myloader will not find any tables from `undefined` database.

This PR fixes that by only providing `--source-db` option when it's not `undefined`.


## Pull request checklist

- [ ] Update [SETUP.md](https://github.com/Automattic/vip-cli/blob/trunk/docs/SETUP.md#list-of-environmental-variables) with any new environmental variables.
- [ ] Update [the documentation](https://github.com/Automattic/vip-cli/blob/trunk/docs).
- [ ] [Manually test](https://github.com/Automattic/vip-cli/blob/trunk/docs/TESTING.md#manual-testing) the relevant changes.
- [ ] Follow the [pull request checklist](https://github.com/Automattic/vip-cli/blob/trunk/docs/RELEASING.md#new-pull-requests)
- [ ] Add/update [automated tests](https://github.com/Automattic/vip-cli/blob/trunk/docs/TESTING.md#automated-testing) as needed.

## New release checklist

- [ ] [Automated tests](https://github.com/Automattic/vip-cli/blob/trunk/docs/TESTING.md#automated-testing) pass.
- [ ] The [Preparing for release checklist](https://github.com/Automattic/vip-cli/blob/trunk/docs/RELEASING.md#preparing-for-release) is completed.

## Steps to Test

Outline the steps to test and verify the PR here.

Example:

1. Check out PR.
1. Run `npm run build`
1. Run `./dist/bin/vip-cookies.js nom`
1. Verify cookies are delicious.
