### PR TITLE
feat(dev-env): add initial support for `.env` files

### DIFF
--- a/__tests__/lib/dev-environment/dev-environment-core.js
+++ b/__tests__/lib/dev-environment/dev-environment-core.js
@@ -191,6 +191,7 @@ describe( 'lib/dev-environment/dev-environment-core', () => {
 						php: '',
 						wordpress: '',
 						integrations: {},
+						envVars: {},
 					},
 				},
 			},
@@ -251,6 +252,7 @@ describe( 'lib/dev-environment/dev-environment-core', () => {
 								},
 							},
 							integrations: {},
+							envVars: {},
 						},
 						{
 							name: 'prodName',
@@ -273,6 +275,7 @@ describe( 'lib/dev-environment/dev-environment-core', () => {
 						php: '8.1',
 						wordpress: '6.2',
 						integrations: {},
+						envVars: {},
 					},
 				},
 			},

--- a/assets/dev-env.lando.template.yml.ejs
+++ b/assets/dev-env.lando.template.yml.ejs
@@ -35,6 +35,8 @@ services:
       image: <%= php %>
       command: run.sh
       working_dir: /wp
+      env_file:
+        - .env
       environment:
         XDEBUG: <%= xdebug ? 'enable' : 'disable' %>
 <% if ( xdebugConfig ) { %>

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -31,7 +31,7 @@
         "ini": "5.0.0",
         "js-yaml": "^4.1.0",
         "jwt-decode": "4.0.0",
-        "lando": "github:automattic/lando-cli#6ca2668",
+        "lando": "github:automattic/lando-cli#2433e20",
         "node-fetch": "^2.6.1",
         "node-stream-zip": "1.15.0",
         "open": "^10.0.0",
@@ -2063,12 +2063,13 @@
       }
     },
     "node_modules/@babel/runtime": {
-      "version": "7.20.7",
-      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.20.7.tgz",
-      "integrity": "sha512-UF0tvkUtxwAgZ5W/KrkHf0Rn0fdnLDU9ScxBrEVNUprE/MzirjK4MJUX1/BVDv00Sv8cljtukVK1aky++X1SjQ==",
+      "version": "7.26.10",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.26.10.tgz",
+      "integrity": "sha512-2WJMeRQPHKSPemqk/awGrAiuFfzBmOIPXKizAsVhWH9YJqLZ0H+HS4c8loHGgW6utJ3E/ejXQUsiGaQy2NZ9Fw==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "regenerator-runtime": "^0.13.11"
+        "regenerator-runtime": "^0.14.0"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -2968,25 +2969,6 @@
         "@streamparser/json": "^0.0.20"
       }
     },
-    "node_modules/@lando/compose": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@lando/compose/-/compose-1.0.0.tgz",
-      "integrity": "sha512-n7EelwK+1T22ueYiOWpniBo5508QJtGsXHENIdnew9e30T33GRUbXCeK7at+dv8CvpqgKsw76lD2Antna9b/Zg==",
-      "bundleDependencies": [
-        "lodash"
-      ],
-      "dependencies": {
-        "lodash": "^4.17.21"
-      },
-      "engines": {
-        "node": ">=16.0.0"
-      }
-    },
-    "node_modules/@lando/compose/node_modules/lodash": {
-      "version": "4.17.21",
-      "inBundle": true,
-      "license": "MIT"
-    },
     "node_modules/@nicolo-ribaudo/chokidar-2": {
       "version": "2.1.8-no-fsevents.3",
       "resolved": "https://registry.npmjs.org/@nicolo-ribaudo/chokidar-2/-/chokidar-2-2.1.8-no-fsevents.3.tgz",
@@ -3162,15 +3144,31 @@
       }
     },
     "node_modules/@octokit/endpoint": {
-      "version": "9.0.3",
-      "resolved": "https://registry.npmjs.org/@octokit/endpoint/-/endpoint-9.0.3.tgz",
-      "integrity": "sha512-TXVX57fJV7SA6LvRkeXPIOBr8AKvKDlhwNVBP/26O9DjIFi+CkYZGFLP9WtPdVOicRIhqGHxBCC6Fdj5AWWGgQ==",
+      "version": "9.0.6",
+      "resolved": "https://registry.npmjs.org/@octokit/endpoint/-/endpoint-9.0.6.tgz",
+      "integrity": "sha512-H1fNTMA57HbkFESSt3Y9+FBICv+0jFceJFPWDePYlR/iMGrwM5ph+Dd4XRQs+8X+PUFURLQgX9ChPfhJ/1uNQw==",
+      "license": "MIT",
       "dependencies": {
-        "@octokit/types": "^12.0.0",
+        "@octokit/types": "^13.1.0",
         "universal-user-agent": "^6.0.0"
       },
       "engines": {
         "node": ">= 18"
+      }
+    },
+    "node_modules/@octokit/endpoint/node_modules/@octokit/openapi-types": {
+      "version": "23.0.1",
+      "resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-23.0.1.tgz",
+      "integrity": "sha512-izFjMJ1sir0jn0ldEKhZ7xegCTj/ObmEDlEfpFrx4k/JyZSMRHbO3/rBwgE7f3m2DHt+RrNGIVw4wSmwnm3t/g==",
+      "license": "MIT"
+    },
+    "node_modules/@octokit/endpoint/node_modules/@octokit/types": {
+      "version": "13.8.0",
+      "resolved": "https://registry.npmjs.org/@octokit/types/-/types-13.8.0.tgz",
+      "integrity": "sha512-x7DjTIbEpEWXK99DMd01QfWy0hd5h4EN+Q7shkdKds3otGQP+oWE/y0A76i1OvH9fygo4ddvNf7ZvF0t78P98A==",
+      "license": "MIT",
+      "dependencies": {
+        "@octokit/openapi-types": "^23.0.1"
       }
     },
     "node_modules/@octokit/graphql": {
@@ -3244,17 +3242,33 @@
       }
     },
     "node_modules/@octokit/plugin-paginate-rest": {
-      "version": "9.1.4",
-      "resolved": "https://registry.npmjs.org/@octokit/plugin-paginate-rest/-/plugin-paginate-rest-9.1.4.tgz",
-      "integrity": "sha512-MvZx4WvfhBnt7PtH5XE7HORsO7bBk4er1FgRIUr1qJ89NR2I6bWjGyKsxk8z42FPQ34hFQm0Baanh4gzdZR4gQ==",
+      "version": "9.2.2",
+      "resolved": "https://registry.npmjs.org/@octokit/plugin-paginate-rest/-/plugin-paginate-rest-9.2.2.tgz",
+      "integrity": "sha512-u3KYkGF7GcZnSD/3UP0S7K5XUFT2FkOQdcfXZGZQPGv3lm4F2Xbf71lvjldr8c1H3nNbF+33cLEkWYbokGWqiQ==",
+      "license": "MIT",
       "dependencies": {
-        "@octokit/types": "^12.3.0"
+        "@octokit/types": "^12.6.0"
       },
       "engines": {
         "node": ">= 18"
       },
       "peerDependencies": {
-        "@octokit/core": ">=5"
+        "@octokit/core": "5"
+      }
+    },
+    "node_modules/@octokit/plugin-paginate-rest/node_modules/@octokit/openapi-types": {
+      "version": "20.0.0",
+      "resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-20.0.0.tgz",
+      "integrity": "sha512-EtqRBEjp1dL/15V7WiX5LJMIxxkdiGJnabzYx5Apx4FkQIFgAfKumXeYAqqJCj1s+BMX4cPFIFC4OLCR6stlnA==",
+      "license": "MIT"
+    },
+    "node_modules/@octokit/plugin-paginate-rest/node_modules/@octokit/types": {
+      "version": "12.6.0",
+      "resolved": "https://registry.npmjs.org/@octokit/types/-/types-12.6.0.tgz",
+      "integrity": "sha512-1rhSOfRa6H9w4YwK0yrf5faDaDTb+yLyBUKOCV4xtCDB5VmIPqd/v9yr9o6SAzOAlRxMiRiCic6JVM1/kunVkw==",
+      "license": "MIT",
+      "dependencies": {
+        "@octokit/openapi-types": "^20.0.0"
       }
     },
     "node_modules/@octokit/plugin-rest-endpoint-methods": {
@@ -3303,13 +3317,14 @@
       }
     },
     "node_modules/@octokit/request": {
-      "version": "8.1.6",
-      "resolved": "https://registry.npmjs.org/@octokit/request/-/request-8.1.6.tgz",
-      "integrity": "sha512-YhPaGml3ncZC1NfXpP3WZ7iliL1ap6tLkAp6MvbK2fTTPytzVUyUesBBogcdMm86uRYO5rHaM1xIWxigWZ17MQ==",
+      "version": "8.4.1",
+      "resolved": "https://registry.npmjs.org/@octokit/request/-/request-8.4.1.tgz",
+      "integrity": "sha512-qnB2+SY3hkCmBxZsR/MPCybNmbJe4KAlfWErXq+rBKkQJlbjdJeS85VI9r8UqeLYLvnAenU8Q1okM/0MBsAGXw==",
+      "license": "MIT",
       "dependencies": {
-        "@octokit/endpoint": "^9.0.0",
-        "@octokit/request-error": "^5.0.0",
-        "@octokit/types": "^12.0.0",
+        "@octokit/endpoint": "^9.0.6",
+        "@octokit/request-error": "^5.1.1",
+        "@octokit/types": "^13.1.0",
         "universal-user-agent": "^6.0.0"
       },
       "engines": {
@@ -3317,16 +3332,47 @@
       }
     },
     "node_modules/@octokit/request-error": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/@octokit/request-error/-/request-error-5.0.1.tgz",
-      "integrity": "sha512-X7pnyTMV7MgtGmiXBwmO6M5kIPrntOXdyKZLigNfQWSEQzVxR4a4vo49vJjTWX70mPndj8KhfT4Dx+2Ng3vnBQ==",
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/@octokit/request-error/-/request-error-5.1.1.tgz",
+      "integrity": "sha512-v9iyEQJH6ZntoENr9/yXxjuezh4My67CBSu9r6Ve/05Iu5gNgnisNWOsoJHTP6k0Rr0+HQIpnH+kyammu90q/g==",
+      "license": "MIT",
       "dependencies": {
-        "@octokit/types": "^12.0.0",
+        "@octokit/types": "^13.1.0",
         "deprecation": "^2.0.0",
         "once": "^1.4.0"
       },
       "engines": {
         "node": ">= 18"
+      }
+    },
+    "node_modules/@octokit/request-error/node_modules/@octokit/openapi-types": {
+      "version": "23.0.1",
+      "resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-23.0.1.tgz",
+      "integrity": "sha512-izFjMJ1sir0jn0ldEKhZ7xegCTj/ObmEDlEfpFrx4k/JyZSMRHbO3/rBwgE7f3m2DHt+RrNGIVw4wSmwnm3t/g==",
+      "license": "MIT"
+    },
+    "node_modules/@octokit/request-error/node_modules/@octokit/types": {
+      "version": "13.8.0",
+      "resolved": "https://registry.npmjs.org/@octokit/types/-/types-13.8.0.tgz",
+      "integrity": "sha512-x7DjTIbEpEWXK99DMd01QfWy0hd5h4EN+Q7shkdKds3otGQP+oWE/y0A76i1OvH9fygo4ddvNf7ZvF0t78P98A==",
+      "license": "MIT",
+      "dependencies": {
+        "@octokit/openapi-types": "^23.0.1"
+      }
+    },
+    "node_modules/@octokit/request/node_modules/@octokit/openapi-types": {
+      "version": "23.0.1",
+      "resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-23.0.1.tgz",
+      "integrity": "sha512-izFjMJ1sir0jn0ldEKhZ7xegCTj/ObmEDlEfpFrx4k/JyZSMRHbO3/rBwgE7f3m2DHt+RrNGIVw4wSmwnm3t/g==",
+      "license": "MIT"
+    },
+    "node_modules/@octokit/request/node_modules/@octokit/types": {
+      "version": "13.8.0",
+      "resolved": "https://registry.npmjs.org/@octokit/types/-/types-13.8.0.tgz",
+      "integrity": "sha512-x7DjTIbEpEWXK99DMd01QfWy0hd5h4EN+Q7shkdKds3otGQP+oWE/y0A76i1OvH9fygo4ddvNf7ZvF0t78P98A==",
+      "license": "MIT",
+      "dependencies": {
+        "@octokit/openapi-types": "^23.0.1"
       }
     },
     "node_modules/@octokit/types": {
@@ -4487,9 +4533,9 @@
       }
     },
     "node_modules/axios": {
-      "version": "1.7.4",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.7.4.tgz",
-      "integrity": "sha512-DukmaFRnY6AzAALSH4J2M3k6PkaC+MfaAGdEERRWcC9q3/TWQwLpHR8ZRLKTdQ3aBDL64EdluRDjJqKw+BPZEw==",
+      "version": "1.8.3",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.8.3.tgz",
+      "integrity": "sha512-iP4DebzoNlP/YN2dpwCgb8zoCmhtkajzS48JvwmkSkXvPI3DHc7m+XYL5tGnSlJtR6nImXZmdCuN5aP8dh1d8A==",
       "license": "MIT",
       "dependencies": {
         "follow-redirects": "^1.15.6",
@@ -9690,10 +9736,9 @@
     "node_modules/lando": {
       "name": "@lando/cli",
       "version": "3.6.5",
-      "resolved": "git+ssh://git@github.com/automattic/lando-cli.git#4d8465ece983ee6242528b54de6738f00804ca0d",
+      "resolved": "git+ssh://git@github.com/automattic/lando-cli.git#2433e2078bb191483ffb16ab2816a896e4900231",
       "license": "GPL-3.0",
       "dependencies": {
-        "@lando/compose": "1.0.0",
         "axios": "^1.7.2",
         "bluebird": "^3.4.1",
         "cli-table3": "^0.6.5",
@@ -9712,7 +9757,7 @@
         "string-argv": "0.1.1",
         "through": "^2.3.8",
         "transliteration": "^2.3.5",
-        "uuid": "^10.0.0",
+        "uuid": "^11.0.0",
         "valid-url": "^1.0.9",
         "winston": "2.4.5",
         "yargonaut": "^1.1.4",
@@ -9786,18 +9831,6 @@
       },
       "engines": {
         "node": ">=8"
-      }
-    },
-    "node_modules/lando/node_modules/uuid": {
-      "version": "10.0.0",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-10.0.0.tgz",
-      "integrity": "sha512-8XkAphELsDnEGrDxUOHB3RGvXz6TeuYSGEZBOjtTtPm2lwhGBjLgOzLHB63IUWfBpNucQjND6d3AOudO+H3RWQ==",
-      "funding": [
-        "https://github.com/sponsors/broofa",
-        "https://github.com/sponsors/ctavan"
-      ],
-      "bin": {
-        "uuid": "dist/bin/uuid"
       }
     },
     "node_modules/lando/node_modules/yargs": {
@@ -11125,10 +11158,11 @@
       }
     },
     "node_modules/regenerator-runtime": {
-      "version": "0.13.11",
-      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.11.tgz",
-      "integrity": "sha512-kY1AZVr2Ra+t+piVaJ4gxaFaReZVH40AKNo7UCX6W+dEwBo/2oZJzqfuN1qLq1oL45o56cPaTXELwrTh8Fpggg==",
-      "dev": true
+      "version": "0.14.1",
+      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.14.1.tgz",
+      "integrity": "sha512-dYnhHh0nJoMfnkZs6GmmhFknAGRrLznOu5nc9ML+EJxGvrx6H7teuevqVqCuPcPK//3eDrrjQhehXVx9cnkGdw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/regenerator-transform": {
       "version": "0.15.2",
@@ -14973,12 +15007,12 @@
       }
     },
     "@babel/runtime": {
-      "version": "7.20.7",
-      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.20.7.tgz",
-      "integrity": "sha512-UF0tvkUtxwAgZ5W/KrkHf0Rn0fdnLDU9ScxBrEVNUprE/MzirjK4MJUX1/BVDv00Sv8cljtukVK1aky++X1SjQ==",
+      "version": "7.26.10",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.26.10.tgz",
+      "integrity": "sha512-2WJMeRQPHKSPemqk/awGrAiuFfzBmOIPXKizAsVhWH9YJqLZ0H+HS4c8loHGgW6utJ3E/ejXQUsiGaQy2NZ9Fw==",
       "dev": true,
       "requires": {
-        "regenerator-runtime": "^0.13.11"
+        "regenerator-runtime": "^0.14.0"
       }
     },
     "@babel/template": {
@@ -15652,20 +15686,6 @@
         "@streamparser/json": "^0.0.20"
       }
     },
-    "@lando/compose": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@lando/compose/-/compose-1.0.0.tgz",
-      "integrity": "sha512-n7EelwK+1T22ueYiOWpniBo5508QJtGsXHENIdnew9e30T33GRUbXCeK7at+dv8CvpqgKsw76lD2Antna9b/Zg==",
-      "requires": {
-        "lodash": "^4.17.21"
-      },
-      "dependencies": {
-        "lodash": {
-          "version": "4.17.21",
-          "bundled": true
-        }
-      }
-    },
     "@nicolo-ribaudo/chokidar-2": {
       "version": "2.1.8-no-fsevents.3",
       "resolved": "https://registry.npmjs.org/@nicolo-ribaudo/chokidar-2/-/chokidar-2-2.1.8-no-fsevents.3.tgz",
@@ -15809,12 +15829,27 @@
       }
     },
     "@octokit/endpoint": {
-      "version": "9.0.3",
-      "resolved": "https://registry.npmjs.org/@octokit/endpoint/-/endpoint-9.0.3.tgz",
-      "integrity": "sha512-TXVX57fJV7SA6LvRkeXPIOBr8AKvKDlhwNVBP/26O9DjIFi+CkYZGFLP9WtPdVOicRIhqGHxBCC6Fdj5AWWGgQ==",
+      "version": "9.0.6",
+      "resolved": "https://registry.npmjs.org/@octokit/endpoint/-/endpoint-9.0.6.tgz",
+      "integrity": "sha512-H1fNTMA57HbkFESSt3Y9+FBICv+0jFceJFPWDePYlR/iMGrwM5ph+Dd4XRQs+8X+PUFURLQgX9ChPfhJ/1uNQw==",
       "requires": {
-        "@octokit/types": "^12.0.0",
+        "@octokit/types": "^13.1.0",
         "universal-user-agent": "^6.0.0"
+      },
+      "dependencies": {
+        "@octokit/openapi-types": {
+          "version": "23.0.1",
+          "resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-23.0.1.tgz",
+          "integrity": "sha512-izFjMJ1sir0jn0ldEKhZ7xegCTj/ObmEDlEfpFrx4k/JyZSMRHbO3/rBwgE7f3m2DHt+RrNGIVw4wSmwnm3t/g=="
+        },
+        "@octokit/types": {
+          "version": "13.8.0",
+          "resolved": "https://registry.npmjs.org/@octokit/types/-/types-13.8.0.tgz",
+          "integrity": "sha512-x7DjTIbEpEWXK99DMd01QfWy0hd5h4EN+Q7shkdKds3otGQP+oWE/y0A76i1OvH9fygo4ddvNf7ZvF0t78P98A==",
+          "requires": {
+            "@octokit/openapi-types": "^23.0.1"
+          }
+        }
       }
     },
     "@octokit/graphql": {
@@ -15871,11 +15906,26 @@
       "requires": {}
     },
     "@octokit/plugin-paginate-rest": {
-      "version": "9.1.4",
-      "resolved": "https://registry.npmjs.org/@octokit/plugin-paginate-rest/-/plugin-paginate-rest-9.1.4.tgz",
-      "integrity": "sha512-MvZx4WvfhBnt7PtH5XE7HORsO7bBk4er1FgRIUr1qJ89NR2I6bWjGyKsxk8z42FPQ34hFQm0Baanh4gzdZR4gQ==",
+      "version": "9.2.2",
+      "resolved": "https://registry.npmjs.org/@octokit/plugin-paginate-rest/-/plugin-paginate-rest-9.2.2.tgz",
+      "integrity": "sha512-u3KYkGF7GcZnSD/3UP0S7K5XUFT2FkOQdcfXZGZQPGv3lm4F2Xbf71lvjldr8c1H3nNbF+33cLEkWYbokGWqiQ==",
       "requires": {
-        "@octokit/types": "^12.3.0"
+        "@octokit/types": "^12.6.0"
+      },
+      "dependencies": {
+        "@octokit/openapi-types": {
+          "version": "20.0.0",
+          "resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-20.0.0.tgz",
+          "integrity": "sha512-EtqRBEjp1dL/15V7WiX5LJMIxxkdiGJnabzYx5Apx4FkQIFgAfKumXeYAqqJCj1s+BMX4cPFIFC4OLCR6stlnA=="
+        },
+        "@octokit/types": {
+          "version": "12.6.0",
+          "resolved": "https://registry.npmjs.org/@octokit/types/-/types-12.6.0.tgz",
+          "integrity": "sha512-1rhSOfRa6H9w4YwK0yrf5faDaDTb+yLyBUKOCV4xtCDB5VmIPqd/v9yr9o6SAzOAlRxMiRiCic6JVM1/kunVkw==",
+          "requires": {
+            "@octokit/openapi-types": "^20.0.0"
+          }
+        }
       }
     },
     "@octokit/plugin-rest-endpoint-methods": {
@@ -15906,24 +15956,54 @@
       }
     },
     "@octokit/request": {
-      "version": "8.1.6",
-      "resolved": "https://registry.npmjs.org/@octokit/request/-/request-8.1.6.tgz",
-      "integrity": "sha512-YhPaGml3ncZC1NfXpP3WZ7iliL1ap6tLkAp6MvbK2fTTPytzVUyUesBBogcdMm86uRYO5rHaM1xIWxigWZ17MQ==",
+      "version": "8.4.1",
+      "resolved": "https://registry.npmjs.org/@octokit/request/-/request-8.4.1.tgz",
+      "integrity": "sha512-qnB2+SY3hkCmBxZsR/MPCybNmbJe4KAlfWErXq+rBKkQJlbjdJeS85VI9r8UqeLYLvnAenU8Q1okM/0MBsAGXw==",
       "requires": {
-        "@octokit/endpoint": "^9.0.0",
-        "@octokit/request-error": "^5.0.0",
-        "@octokit/types": "^12.0.0",
+        "@octokit/endpoint": "^9.0.6",
+        "@octokit/request-error": "^5.1.1",
+        "@octokit/types": "^13.1.0",
         "universal-user-agent": "^6.0.0"
+      },
+      "dependencies": {
+        "@octokit/openapi-types": {
+          "version": "23.0.1",
+          "resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-23.0.1.tgz",
+          "integrity": "sha512-izFjMJ1sir0jn0ldEKhZ7xegCTj/ObmEDlEfpFrx4k/JyZSMRHbO3/rBwgE7f3m2DHt+RrNGIVw4wSmwnm3t/g=="
+        },
+        "@octokit/types": {
+          "version": "13.8.0",
+          "resolved": "https://registry.npmjs.org/@octokit/types/-/types-13.8.0.tgz",
+          "integrity": "sha512-x7DjTIbEpEWXK99DMd01QfWy0hd5h4EN+Q7shkdKds3otGQP+oWE/y0A76i1OvH9fygo4ddvNf7ZvF0t78P98A==",
+          "requires": {
+            "@octokit/openapi-types": "^23.0.1"
+          }
+        }
       }
     },
     "@octokit/request-error": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/@octokit/request-error/-/request-error-5.0.1.tgz",
-      "integrity": "sha512-X7pnyTMV7MgtGmiXBwmO6M5kIPrntOXdyKZLigNfQWSEQzVxR4a4vo49vJjTWX70mPndj8KhfT4Dx+2Ng3vnBQ==",
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/@octokit/request-error/-/request-error-5.1.1.tgz",
+      "integrity": "sha512-v9iyEQJH6ZntoENr9/yXxjuezh4My67CBSu9r6Ve/05Iu5gNgnisNWOsoJHTP6k0Rr0+HQIpnH+kyammu90q/g==",
       "requires": {
-        "@octokit/types": "^12.0.0",
+        "@octokit/types": "^13.1.0",
         "deprecation": "^2.0.0",
         "once": "^1.4.0"
+      },
+      "dependencies": {
+        "@octokit/openapi-types": {
+          "version": "23.0.1",
+          "resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-23.0.1.tgz",
+          "integrity": "sha512-izFjMJ1sir0jn0ldEKhZ7xegCTj/ObmEDlEfpFrx4k/JyZSMRHbO3/rBwgE7f3m2DHt+RrNGIVw4wSmwnm3t/g=="
+        },
+        "@octokit/types": {
+          "version": "13.8.0",
+          "resolved": "https://registry.npmjs.org/@octokit/types/-/types-13.8.0.tgz",
+          "integrity": "sha512-x7DjTIbEpEWXK99DMd01QfWy0hd5h4EN+Q7shkdKds3otGQP+oWE/y0A76i1OvH9fygo4ddvNf7ZvF0t78P98A==",
+          "requires": {
+            "@octokit/openapi-types": "^23.0.1"
+          }
+        }
       }
     },
     "@octokit/types": {
@@ -16867,9 +16947,9 @@
       "dev": true
     },
     "axios": {
-      "version": "1.7.4",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.7.4.tgz",
-      "integrity": "sha512-DukmaFRnY6AzAALSH4J2M3k6PkaC+MfaAGdEERRWcC9q3/TWQwLpHR8ZRLKTdQ3aBDL64EdluRDjJqKw+BPZEw==",
+      "version": "1.8.3",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.8.3.tgz",
+      "integrity": "sha512-iP4DebzoNlP/YN2dpwCgb8zoCmhtkajzS48JvwmkSkXvPI3DHc7m+XYL5tGnSlJtR6nImXZmdCuN5aP8dh1d8A==",
       "requires": {
         "follow-redirects": "^1.15.6",
         "form-data": "^4.0.0",
@@ -20598,10 +20678,9 @@
       "integrity": "sha512-tPhhoGUiEiU/WXR4rt8klIoLdnTtyu+9jVKHd/wauEjYud32jyn63mzKWQweaQrHWxBQtYoVtdcEnYX1LosnFQ=="
     },
     "lando": {
-      "version": "git+ssh://git@github.com/automattic/lando-cli.git#4d8465ece983ee6242528b54de6738f00804ca0d",
-      "from": "lando@github:automattic/lando-cli#6ca2668",
+      "version": "git+ssh://git@github.com/automattic/lando-cli.git#2433e2078bb191483ffb16ab2816a896e4900231",
+      "from": "lando@github:automattic/lando-cli#2433e20",
       "requires": {
-        "@lando/compose": "1.0.0",
         "axios": "^1.7.2",
         "bluebird": "^3.4.1",
         "cli-table3": "^0.6.5",
@@ -20620,7 +20699,7 @@
         "string-argv": "0.1.1",
         "through": "^2.3.8",
         "transliteration": "^2.3.5",
-        "uuid": "^10.0.0",
+        "uuid": "^11.0.0",
         "valid-url": "^1.0.9",
         "winston": "2.4.5",
         "yargonaut": "^1.1.4",
@@ -20669,11 +20748,6 @@
           "requires": {
             "ansi-regex": "^5.0.1"
           }
-        },
-        "uuid": {
-          "version": "10.0.0",
-          "resolved": "https://registry.npmjs.org/uuid/-/uuid-10.0.0.tgz",
-          "integrity": "sha512-8XkAphELsDnEGrDxUOHB3RGvXz6TeuYSGEZBOjtTtPm2lwhGBjLgOzLHB63IUWfBpNucQjND6d3AOudO+H3RWQ=="
         },
         "yargs": {
           "version": "16.2.0",
@@ -21658,9 +21732,9 @@
       }
     },
     "regenerator-runtime": {
-      "version": "0.13.11",
-      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.11.tgz",
-      "integrity": "sha512-kY1AZVr2Ra+t+piVaJ4gxaFaReZVH40AKNo7UCX6W+dEwBo/2oZJzqfuN1qLq1oL45o56cPaTXELwrTh8Fpggg==",
+      "version": "0.14.1",
+      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.14.1.tgz",
+      "integrity": "sha512-dYnhHh0nJoMfnkZs6GmmhFknAGRrLznOu5nc9ML+EJxGvrx6H7teuevqVqCuPcPK//3eDrrjQhehXVx9cnkGdw==",
       "dev": true
     },
     "regenerator-transform": {

--- a/package.json
+++ b/package.json
@@ -161,7 +161,7 @@
     "ini": "5.0.0",
     "js-yaml": "^4.1.0",
     "jwt-decode": "4.0.0",
-    "lando": "github:automattic/lando-cli#6ca2668",
+    "lando": "github:automattic/lando-cli#2433e20",
     "node-fetch": "^2.6.1",
     "node-stream-zip": "1.15.0",
     "open": "^10.0.0",

--- a/src/bin/vip-dev-env-create.js
+++ b/src/bin/vip-dev-env-create.js
@@ -127,11 +127,14 @@ cmd.argv( process.argv, async ( arg, opt ) => {
 	let defaultOptions = {};
 	/** @type {Record<string,import('../lib/dev-environment/types').IntegrationConfig>} */
 	let integrationsConfig = {};
+	/** @type {Record<string,string>} */
+	let envVars = {};
 
 	try {
 		if ( opt.app ) {
 			const appInfo = await getApplicationInformation( opt.app, opt.env );
 			integrationsConfig = appInfo.environment?.integrations ?? {};
+			envVars = appInfo.environment?.envVars ?? {};
 			defaultOptions = getOptionsFromAppInfo( appInfo );
 		}
 	} catch ( error ) {
@@ -159,7 +162,7 @@ cmd.argv( process.argv, async ( arg, opt ) => {
 	instanceData.siteSlug = slug;
 
 	try {
-		await createEnvironment( lando, instanceData, integrationsConfig );
+		await createEnvironment( lando, instanceData, integrationsConfig, envVars );
 
 		await printEnvironmentInfo( lando, slug, { extended: false, suppressWarnings: true } );
 

--- a/src/lib/dev-environment/dev-environment-core.ts
+++ b/src/lib/dev-environment/dev-environment-core.ts
@@ -599,10 +599,8 @@ async function prepareLandoEnv(
 
 	if ( envVars !== undefined ) {
 		const env: string[] = [];
-		Object.entries( envVars ?? {} ).forEach( ( [ key, value ] ) => {
-			// See https://docs.docker.com/reference/compose-file/services/#env_file-format
-			value = value.replace( /([$"\\])/g, '\\$1' );
-			env.push( `${ key }="${ value }"` );
+		Object.entries( envVars ?? {} ).forEach( ( [ key ] ) => {
+			env.push( `VIP_ENV_VAR_${ key }=` );
 		} );
 
 		await fs.promises.writeFile( envFilePath, env.join( '\n' ) );
@@ -672,10 +670,8 @@ export async function getApplicationInformation(
 			branch,
 			isMultisite,
 			environmentVariables {
-				total
 				nodes {
 					name
-					value
 				}
 			}
 			getIntegrationsDevEnvConfig {
@@ -725,8 +721,8 @@ export async function getApplicationInformation(
 		if ( envData ) {
 			const envVars: Record< string, string > = {};
 			envData.environmentVariables?.nodes?.forEach( envvar => {
-				if ( envvar?.name && envvar?.value ) {
-					envVars[ envvar.name ] = envvar.value;
+				if ( envvar?.name ) {
+					envVars[ envvar.name ] = '';
 				}
 			} );
 

--- a/src/lib/dev-environment/dev-environment-core.ts
+++ b/src/lib/dev-environment/dev-environment-core.ts
@@ -116,12 +116,17 @@ export async function startEnvironment(
 
 	const instancePath = getEnvironmentPath( slug );
 
-	debug( 'Instance path for', slug, 'is:', instancePath );
+	debug( 'Instance path for %s is %s', slug, instancePath );
 
 	const environmentExists = fs.existsSync( instancePath );
 
 	if ( ! environmentExists ) {
 		throw new Error( DEV_ENVIRONMENT_NOT_FOUND );
+	}
+
+	const envFilePath = path.join( instancePath, '.env' );
+	if ( ! fs.existsSync( envFilePath ) ) {
+		fs.writeFileSync( envFilePath, '' );
 	}
 
 	let updated = false;
@@ -565,6 +570,7 @@ async function prepareLandoEnv(
 	const nginxFolderPath = path.join( instancePath, nginxPathString );
 	const nginxFileTargetPath = path.join( nginxFolderPath, nginxFileName );
 	const instanceDataTargetPath = path.join( instancePath, instanceDataFileName );
+	const envFilePath = path.join( instancePath, '.env' );
 
 	await fs.promises.mkdir( instancePath, { recursive: true } );
 	await fs.promises.mkdir( nginxFolderPath, { recursive: true } );
@@ -583,6 +589,7 @@ async function prepareLandoEnv(
 		fs.promises.writeFile( landoFileTargetPath, landoFile ),
 		fs.promises.writeFile( nginxFileTargetPath, nginxFile ),
 		fs.promises.writeFile( instanceDataTargetPath, instanceDataFile ),
+		fs.promises.appendFile( envFilePath, '' ),
 	] );
 
 	debug( `Lando file created in ${ landoFileTargetPath }` );

--- a/src/lib/dev-environment/dev-environment-core.ts
+++ b/src/lib/dev-environment/dev-environment-core.ts
@@ -161,7 +161,8 @@ export async function stopEnvironment( lando: Lando, slug: string ): Promise< vo
 export async function createEnvironment(
 	lando: Lando,
 	instanceData: InstanceData,
-	integrationsConfig?: Record< string, IntegrationConfig > | undefined
+	integrationsConfig?: Record< string, IntegrationConfig > | undefined,
+	envVars?: Record< string, string > | undefined
 ): Promise< void > {
 	const slug = instanceData.siteSlug;
 	integrationsConfig ??= {};
@@ -181,7 +182,13 @@ export async function createEnvironment(
 
 	debug( 'Will create an environment', slug, 'with instanceData: ', preProcessedInstanceData );
 
-	await prepareLandoEnv( lando, preProcessedInstanceData, instancePath, integrationsConfig );
+	await prepareLandoEnv(
+		lando,
+		preProcessedInstanceData,
+		instancePath,
+		integrationsConfig,
+		envVars
+	);
 }
 
 export async function updateEnvironment(
@@ -204,7 +211,7 @@ export async function updateEnvironment(
 	const preProcessedInstanceData = preProcessInstanceData( instanceData );
 	debug( 'Will create an environment', slug, 'with instanceData: ', preProcessedInstanceData );
 
-	await prepareLandoEnv( lando, preProcessedInstanceData, instancePath, undefined );
+	await prepareLandoEnv( lando, preProcessedInstanceData, instancePath, undefined, undefined );
 }
 
 function preProcessInstanceData( instanceData: InstanceData ): InstanceData {
@@ -551,7 +558,8 @@ async function prepareLandoEnv(
 	lando: Lando,
 	instanceData: InstanceData,
 	instancePath: string,
-	integrationsConfig: Record< string, unknown > | undefined
+	integrationsConfig: Record< string, unknown > | undefined,
+	envVars: Record< string, string > | undefined
 ): Promise< void > {
 	const templateData = {
 		...instanceData,
@@ -587,8 +595,22 @@ async function prepareLandoEnv(
 		fs.promises.writeFile( landoFileTargetPath, landoFile ),
 		fs.promises.writeFile( nginxFileTargetPath, nginxFile ),
 		fs.promises.writeFile( instanceDataTargetPath, instanceDataFile ),
-		fs.promises.appendFile( envFilePath, '' ),
 	] );
+
+	if ( envVars !== undefined ) {
+		const env: string[] = [];
+		Object.entries( envVars ?? {} ).forEach( ( [ key, value ] ) => {
+			// See https://docs.docker.com/reference/compose-file/services/#env_file-format
+			// We don't want interpolation, hence single quotes.
+			// Inner quotes must be escaped.
+			value = value.replace( /'/g, "\\'" );
+			env.push( `${ key }='${ value }'` );
+		} );
+
+		await fs.promises.writeFile( envFilePath, env.join( '\n' ) );
+	} else {
+		await fs.promises.appendFile( envFilePath, '' );
+	}
 
 	debug( `Lando file created in ${ landoFileTargetPath }` );
 	debug( `Nginx file created in ${ nginxFileTargetPath }` );
@@ -651,6 +673,13 @@ export async function getApplicationInformation(
 			type,
 			branch,
 			isMultisite,
+			environmentVariables {
+				total
+				nodes {
+					name
+					value
+				}
+			}
 			getIntegrationsDevEnvConfig {
 				data
 			}
@@ -696,6 +725,13 @@ export async function getApplicationInformation(
 		}
 
 		if ( envData ) {
+			const envVars: Record< string, string > = {};
+			envData.environmentVariables?.nodes?.forEach( envvar => {
+				if ( envvar?.name && envvar?.value ) {
+					envVars[ envvar.name ] = envvar.value;
+				}
+			} );
+
 			appData.environment = {
 				name: envData.name,
 				branch: envData.branch,
@@ -707,6 +743,7 @@ export async function getApplicationInformation(
 				integrations:
 					( envData.getIntegrationsDevEnvConfig?.data as Record< string, IntegrationConfig > ) ??
 					{},
+				envVars,
 			};
 		}
 	}

--- a/src/lib/dev-environment/dev-environment-core.ts
+++ b/src/lib/dev-environment/dev-environment-core.ts
@@ -125,9 +125,7 @@ export async function startEnvironment(
 	}
 
 	const envFilePath = path.join( instancePath, '.env' );
-	if ( ! fs.existsSync( envFilePath ) ) {
-		fs.writeFileSync( envFilePath, '' );
-	}
+	fs.appendFileSync( envFilePath, '' );
 
 	let updated = false;
 	if ( ! options.skipWpVersionsCheck && process.stdin.isTTY ) {

--- a/src/lib/dev-environment/dev-environment-core.ts
+++ b/src/lib/dev-environment/dev-environment-core.ts
@@ -601,10 +601,8 @@ async function prepareLandoEnv(
 		const env: string[] = [];
 		Object.entries( envVars ?? {} ).forEach( ( [ key, value ] ) => {
 			// See https://docs.docker.com/reference/compose-file/services/#env_file-format
-			// We don't want interpolation, hence single quotes.
-			// Inner quotes must be escaped.
-			value = value.replace( /'/g, "\\'" );
-			env.push( `${ key }='${ value }'` );
+			value = value.replace( /([$"\\])/g, '\\$1' );
+			env.push( `${ key }="${ value }"` );
 		} );
 
 		await fs.promises.writeFile( envFilePath, env.join( '\n' ) );

--- a/src/lib/dev-environment/dev-environment-lando.ts
+++ b/src/lib/dev-environment/dev-environment-lando.ts
@@ -42,10 +42,8 @@ const debug = debugLib( DEBUG_KEY );
 async function getLandoConfig(): Promise< LandoConfig > {
 	// The path will be smth like `yarn/global/node_modules/lando/lib/lando.js`; we need the path up to `lando` (inclusive)
 	const landoPath = dirname( dirname( require.resolve( 'lando' ) ) );
-	// The path will be smth like `yarn/global/node_modules/@lando/compose/index.js`; we need the path up to `@lando` (inclusive)
-	const atLandoPath = dirname( dirname( require.resolve( '@lando/compose' ) ) );
 
-	debug( `Getting Lando config, using paths '${ landoPath }' and '${ atLandoPath }' for plugins` );
+	debug( `Getting Lando config, using paths '${ landoPath }' for plugins` );
 
 	const isLandoDebugSelected = debugLib.enabled( DEBUG_KEY );
 	const isAllDebugSelected = debugLib.enabled( '"*"' );
@@ -75,14 +73,7 @@ async function getLandoConfig(): Promise< LandoConfig > {
 		landoFile: '.lando.yml',
 		preLandoFiles: [ '.lando.base.yml', '.lando.dist.yml', '.lando.upstream.yml' ],
 		postLandoFiles: [ '.lando.local.yml' ],
-		pluginDirs: [
-			landoPath,
-			{
-				path: atLandoPath,
-				subdir: '.',
-				namespace: '@lando',
-			},
-		],
+		pluginDirs: [ landoPath ],
 		disablePlugins: [],
 		proxyName: 'vip-dev-env-proxy',
 		userConfRoot: landoDir,

--- a/src/lib/dev-environment/types.ts
+++ b/src/lib/dev-environment/types.ts
@@ -46,6 +46,7 @@ export interface AppInfo {
 		php: string;
 		wordpress: string;
 		integrations: Record< string, IntegrationConfig >;
+		envVars: Record< string, string >;
 	};
 }
 


### PR DESCRIPTION
## Description

This PR adds initial support for `.env` files.

It requires a custom version of Lando: Automattic/lando-cli#92 (make sure to run `npm ci before testing this PR).

A new `.env` file is created in `~/.local/share/vip/dev-environment/<slug>` when an environment is created. Docker automatically loads it.

For now, the file needs to be updated manually (and then the environment must be restarted).

**UPDATE:** `vip @app.env dev-env create` syntax is supported; in this case, environment variables are fetched from the specified environment.

## Pull request checklist

- [ ] Update [SETUP.md](https://github.com/Automattic/vip-cli/blob/trunk/docs/SETUP.md#list-of-environmental-variables) with any new environmental variables.
- [ ] Update [the documentation](https://github.com/Automattic/vip-cli/blob/trunk/docs).
- [x] [Manually test](https://github.com/Automattic/vip-cli/blob/trunk/docs/TESTING.md#manual-testing) the relevant changes.
- [x] Follow the [pull request checklist](https://github.com/Automattic/vip-cli/blob/trunk/docs/RELEASING.md#new-pull-requests)
- [ ] Add/update [automated tests](https://github.com/Automattic/vip-cli/blob/trunk/docs/TESTING.md#automated-testing) as needed.

## New release checklist

- [ ] [Automated tests](https://github.com/Automattic/vip-cli/blob/trunk/docs/TESTING.md#automated-testing) pass.
- [ ] The [Preparing for release checklist](https://github.com/Automattic/vip-cli/blob/trunk/docs/RELEASING.md#preparing-for-release) is completed.

## Steps to Test

1. Check out the PR, `npm ci && npm run build`
2. `vip dev-env create --slug=test-env < /dev/null`
3. `echo "FOO=bar" >> ~/.local/share/vip/dev-environment/test-env/.env`
4. `vip dev-env start --slug=test-env`
5. Verify that `vip dev-env shell --slug=test-env -- env | grep FOO` displays `BAR`.

Grab variables from the environment:

1. Check out the PR, `npm ci && npm run build`
2. `vip dev-env create @<app>.<env> < /dev/null`
4. `vip dev-env start --slug=...`
5. Verify that `vip dev-env shell --slug=test-env -- env` shows variables fetched from the env (variables from `vip config envvar get-all` should be there).
