### PR TITLE
Add query name to the GraphQL endpoint as a query string

### DIFF
--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -101,7 +101,9 @@ export default function API( {
 	const proxyAgent = createProxyAgent( API_URL );
 
 	const httpLink = new HttpLink( {
-		uri: API_URL,
+		uri: operation => {
+			return `${ API_URL }?x_query=${ decodeURIComponent( operation.operationName ) }`;
+		},
 		fetch: http,
 		fetchOptions: {
 			agent: proxyAgent,

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -102,6 +102,10 @@ export default function API( {
 
 	const httpLink = new HttpLink( {
 		uri: operation => {
+			// to make it easier to write tests, we'll skip adding x_query for tests
+			if ( process.env.NODE_ENV === 'test' ) {
+				return API_URL;
+			}
 			return `${ API_URL }?x_query=${ decodeURIComponent( operation.operationName ) }`;
 		},
 		fetch: http,


### PR DESCRIPTION
## Description

It's to help with debugging i.e. MITM proxies can now differentiate between different `/graphql` requests.

## Testing

1. Run `npm run build:watch`
2. Run `node ./dist/bin/vip-whoami.js`
3. Should just run fine :)