### PR TITLE
chore(deps): update `lando` to `540a5e0`

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -31,7 +31,7 @@
         "ini": "5.0.0",
         "js-yaml": "^4.1.0",
         "jwt-decode": "4.0.0",
-        "lando": "github:automattic/lando-cli#2433e20",
+        "lando": "github:automattic/lando-cli#540a5e0",
         "node-fetch": "^2.6.1",
         "node-stream-zip": "1.15.0",
         "open": "^10.0.0",
@@ -9737,10 +9737,10 @@
     "node_modules/lando": {
       "name": "@lando/cli",
       "version": "3.6.5",
-      "resolved": "git+ssh://git@github.com/automattic/lando-cli.git#2433e2078bb191483ffb16ab2816a896e4900231",
+      "resolved": "git+ssh://git@github.com/automattic/lando-cli.git#540a5e035a4f679500f93d98112029b76a55f661",
       "license": "GPL-3.0",
       "dependencies": {
-        "axios": "^1.7.2",
+        "axios": "^1.8.2",
         "bluebird": "^3.4.1",
         "cli-table3": "^0.6.5",
         "copy-dir": "^1.3.0",
@@ -20679,10 +20679,10 @@
       "integrity": "sha512-tPhhoGUiEiU/WXR4rt8klIoLdnTtyu+9jVKHd/wauEjYud32jyn63mzKWQweaQrHWxBQtYoVtdcEnYX1LosnFQ=="
     },
     "lando": {
-      "version": "git+ssh://git@github.com/automattic/lando-cli.git#2433e2078bb191483ffb16ab2816a896e4900231",
-      "from": "lando@github:automattic/lando-cli#2433e20",
+      "version": "git+ssh://git@github.com/automattic/lando-cli.git#540a5e035a4f679500f93d98112029b76a55f661",
+      "from": "lando@github:automattic/lando-cli#540a5e0",
       "requires": {
-        "axios": "^1.7.2",
+        "axios": "^1.8.2",
         "bluebird": "^3.4.1",
         "cli-table3": "^0.6.5",
         "copy-dir": "^1.3.0",

--- a/package.json
+++ b/package.json
@@ -161,7 +161,7 @@
     "ini": "5.0.0",
     "js-yaml": "^4.1.0",
     "jwt-decode": "4.0.0",
-    "lando": "github:automattic/lando-cli#2433e20",
+    "lando": "github:automattic/lando-cli#540a5e0",
     "node-fetch": "^2.6.1",
     "node-stream-zip": "1.15.0",
     "open": "^10.0.0",


### PR DESCRIPTION
This is a follow-up to #2279.

Now that Automattic/lando-cli#92 is merged, update `lando` to the `main` branch.
