### PR TITLE
chore: remove overrides for `@lando/compose`

### DIFF
--- a/package.json
+++ b/package.json
@@ -184,9 +184,6 @@
   "overrides": {
     "node-fetch@^2.6.1": {
       "whatwg-url": "^14.0.0"
-    },
-    "@lando/compose": {
-      "js-yaml": "^4.1.0"
     }
   },
   "publishConfig": {


### PR DESCRIPTION
## Description

Because we have fused `@lando/compose` into `lando` in Automattic/lando-cli#92, we no longer need overrides for `@lando/compose` in `package.json`.

## Pull request checklist

- [ ] Update [SETUP.md](https://github.com/Automattic/vip-cli/blob/trunk/docs/SETUP.md#list-of-environmental-variables) with any new environmental variables.
- [ ] Update [the documentation](https://github.com/Automattic/vip-cli/blob/trunk/docs).
- [x] [Manually test](https://github.com/Automattic/vip-cli/blob/trunk/docs/TESTING.md#manual-testing) the relevant changes.
- [x] Follow the [pull request checklist](https://github.com/Automattic/vip-cli/blob/trunk/docs/RELEASING.md#new-pull-requests)
- [ ] Add/update [automated tests](https://github.com/Automattic/vip-cli/blob/trunk/docs/TESTING.md#automated-testing) as needed.

## New release checklist

- [ ] [Automated tests](https://github.com/Automattic/vip-cli/blob/trunk/docs/TESTING.md#automated-testing) pass.
- [ ] The [Preparing for release checklist](https://github.com/Automattic/vip-cli/blob/trunk/docs/RELEASING.md#preparing-for-release) is completed.

## Steps to Test

There are no functional changes.
