### PR TITLE
fix(dev-env): `mu-plugins` prompt logic

### DIFF
--- a/src/lib/dev-environment/dev-environment-cli.ts
+++ b/src/lib/dev-environment/dev-environment-cli.ts
@@ -222,7 +222,7 @@ export function processComponentOptionInput(
 
 	return {
 		mode: 'image',
-		tag: param === 'demo' ? undefined : param,
+		tag: param === 'demo' || param === 'image' ? undefined : param,
 	};
 }
 
@@ -257,6 +257,14 @@ export async function promptForArguments(
 	create: boolean
 ): Promise< InstanceData > {
 	debug( 'Provided preselected', preselectedOptions, 'and default', defaultOptions );
+
+	let isVIPUser: boolean;
+	try {
+		const currentUser = await getCurrentUserInfo( true );
+		isVIPUser = currentUser?.isVIP ?? false;
+	} catch ( err ) {
+		isVIPUser = false;
+	}
 
 	if ( suppressPrompts ) {
 		preselectedOptions = { ...defaultOptions, ...preselectedOptions };
@@ -330,18 +338,34 @@ export async function promptForArguments(
 	}
 
 	instanceData.wordpress = await processWordPress(
-		( preselectedOptions.wordpress ?? '' ).toString(),
-		( defaultOptions.wordpress ?? '' ).toString()
+		preselectedOptions.wordpress ?? '',
+		defaultOptions.wordpress ?? ''
 	);
 
-	for ( const component of DEV_ENVIRONMENT_COMPONENTS ) {
-		const option = ( preselectedOptions[ component ] ?? '' ).toString();
-		const defaultValue = ( defaultOptions[ component ] ?? '' ).toString();
+	instanceData.appCode = await processComponent(
+		'appCode',
+		preselectedOptions.appCode ?? '',
+		defaultOptions.appCode ?? '',
+		suppressPrompts,
+		validateAppCodeLocalPath
+	);
 
-		// eslint-disable-next-line no-await-in-loop
-		const result = await processComponent( component, option, defaultValue, suppressPrompts );
-		instanceData[ component ] = result;
+	let preselectedMU = preselectedOptions.muPlugins;
+	const defaultMU = defaultOptions.muPlugins;
+	if (
+		! preselectedMU &&
+		! isVIPUser &&
+		( ! defaultMU || [ 'demo', 'image' ].includes( defaultMU ) )
+	) {
+		preselectedMU = 'image';
 	}
+	instanceData.muPlugins = await processComponent(
+		'muPlugins',
+		preselectedMU ?? '',
+		defaultMU ?? '',
+		suppressPrompts,
+		validateMuPluginsLocalPath
+	);
 
 	debug( `Processing elasticsearch with preselected "%s"`, preselectedOptions.elasticsearch );
 	if ( 'elasticsearch' in preselectedOptions ) {
@@ -406,68 +430,73 @@ async function processWordPress(
 	return result;
 }
 
+type ComponentPathValidator = ( path: string ) => { result: boolean; message: string };
+
 async function processComponent(
-	component: keyof typeof componentDemoNames,
+	componentType: ( typeof DEV_ENVIRONMENT_COMPONENTS )[ number ],
 	preselectedValue: string,
 	defaultValue: string,
-	suppressPrompts: boolean = false
+	suppressPrompts: boolean,
+	localPathValidator: ComponentPathValidator
 ): Promise< ComponentConfig > {
 	debug(
-		`processing a component '${ component }', with preselected/default - ${ preselectedValue }/${ defaultValue }`
+		`Processing the '${ componentType }' component, with preselected = %s, default = %s`,
+		preselectedValue,
+		defaultValue
 	);
-	let result: ComponentConfig;
 
-	let allowLocal: boolean = true;
+	const defaultObject = defaultValue ? processComponentOptionInput( defaultValue, true ) : null;
 
-	if ( component === 'muPlugins' ) {
-		try {
-			const currentUser = await getCurrentUserInfo( true );
-			allowLocal = currentUser?.isVIP ?? false;
-		} catch ( err ) {
-			allowLocal = false;
-		}
+	if ( preselectedValue && ! suppressPrompts ) {
+		console.log(
+			'%s Path to your local %s: %s',
+			chalk.green( '✓' ),
+			componentDisplayNames[ componentType ],
+			preselectedValue
+		);
 	}
 
-	const defaultObject = defaultValue
-		? processComponentOptionInput( defaultValue, allowLocal as unknown as true )
-		: null;
-	if ( preselectedValue ) {
-		result = processComponentOptionInput( preselectedValue, allowLocal as unknown as true );
-
-		if ( ! suppressPrompts ) {
-			console.log(
-				`${ chalk.green( '✓' ) } Path to your local ${
-					componentDisplayNames[ component ]
-				}: ${ preselectedValue }`
-			);
-		}
-	} else {
-		result = await promptForComponent( component, allowLocal, defaultObject );
-	}
+	let result: ComponentConfig = preselectedValue
+		? processComponentOptionInput( preselectedValue, true )
+		: await promptForComponent( componentType, true, defaultObject );
 
 	debug( result );
 
-	while ( 'local' === result.mode ) {
-		const resolvedPath = resolvePath( result.dir ?? '' );
-		result.dir = resolvedPath;
+	if ( result.mode === 'local' ) {
+		result = await validateLocalPath( result, localPathValidator, componentType, defaultObject );
+	}
 
-		const { result: isPathValid, message } = validateLocalPath( component, resolvedPath );
+	debug( result );
+	return result;
+}
+
+async function validateLocalPath(
+	config: ComponentConfig,
+	validator: ComponentPathValidator,
+	componentName: ( typeof DEV_ENVIRONMENT_COMPONENTS )[ number ],
+	defaultObject: ComponentConfig | null
+): Promise< ComponentConfig > {
+	while ( config.mode === 'local' ) {
+		const resolvedPath = resolvePath( config.dir ?? '' );
+		config.dir = resolvedPath;
+
+		const { result: isPathValid, message } = validator( resolvedPath );
 
 		if ( isPathValid ) {
 			break;
 		} else if ( isStdinTTY ) {
 			console.log( chalk.yellow( 'Warning:' ), message );
 			// eslint-disable-next-line no-await-in-loop
-			result = await promptForComponent( component, allowLocal, defaultObject );
+			config = await promptForComponent( componentName, true, defaultObject );
 		} else {
 			throw new Error( message );
 		}
 	}
 
-	return result;
+	return config;
 }
 
-function validateLocalPath( component: string, providedPath: string ) {
+function validateMuPluginsLocalPath( providedPath: string ) {
 	if ( ! isNonEmptyDirectory( providedPath ) ) {
 		const message = `Provided path "${ providedPath }" does not point to a valid or existing directory.`;
 		return {
@@ -476,34 +505,47 @@ function validateLocalPath( component: string, providedPath: string ) {
 		};
 	}
 
-	if ( component === 'appCode' ) {
-		const files = [
-			'languages',
-			'plugins',
-			'themes',
-			'private',
-			'images',
-			'client-mu-plugins',
-			'vip-config',
-		];
+	return {
+		result: true,
+		message: '',
+	};
+}
 
-		const missingFiles = [];
-		for ( const file of files ) {
-			const filePath = path.resolve( providedPath, file );
-			if ( ! existsSync( filePath ) ) {
-				missingFiles.push( file );
-			}
+function validateAppCodeLocalPath( providedPath: string ) {
+	if ( ! isNonEmptyDirectory( providedPath ) ) {
+		const message = `Provided path "${ providedPath }" does not point to a valid or existing directory.`;
+		return {
+			result: false,
+			message,
+		};
+	}
+
+	const files = [
+		'languages',
+		'plugins',
+		'themes',
+		'private',
+		'images',
+		'client-mu-plugins',
+		'vip-config',
+	];
+
+	const missingFiles = [];
+	for ( const file of files ) {
+		const filePath = path.resolve( providedPath, file );
+		if ( ! existsSync( filePath ) ) {
+			missingFiles.push( file );
 		}
-		if ( missingFiles.length > 0 ) {
-			// eslint-disable-next-line max-len
-			const message = `Provided path "${ providedPath }" is missing following files/folders: ${ missingFiles.join(
-				', '
-			) }. Learn more: https://docs.wpvip.com/wordpress-skeleton/`;
-			return {
-				result: false,
-				message,
-			};
-		}
+	}
+	if ( missingFiles.length > 0 ) {
+		// eslint-disable-next-line max-len
+		const message = `Provided path "${ providedPath }" is missing following files/folders: ${ missingFiles.join(
+			', '
+		) }. Learn more: https://docs.wpvip.com/wordpress-skeleton/`;
+		return {
+			result: false,
+			message,
+		};
 	}
 
 	return {


### PR DESCRIPTION
## Description

This PR fixes the logic when a prompt for MU Plugins is displayed:
  * The `-u` option for `vip dev-env create` and `vip dev-env update` is always honored;
  * VIP users always see the prompt;
  * normal users see the prompt only when `mu-plugins` were previously set to `local`.

See: 202985-z

## Pull request checklist

- [ ] Update [SETUP.md](https://github.com/Automattic/vip-cli/blob/trunk/docs/SETUP.md#list-of-environmental-variables) with any new environmental variables.
- [ ] Update [the documentation](https://github.com/Automattic/vip-cli/blob/trunk/docs).
- [x] [Manually test](https://github.com/Automattic/vip-cli/blob/trunk/docs/TESTING.md#manual-testing) the relevant changes.
- [x] Follow the [pull request checklist](https://github.com/Automattic/vip-cli/blob/trunk/docs/RELEASING.md#new-pull-requests)
- [ ] Add/update [automated tests](https://github.com/Automattic/vip-cli/blob/trunk/docs/TESTING.md#automated-testing) as needed.

## New release checklist

- [ ] [Automated tests](https://github.com/Automattic/vip-cli/blob/trunk/docs/TESTING.md#automated-testing) pass.
- [ ] The [Preparing for release checklist](https://github.com/Automattic/vip-cli/blob/trunk/docs/RELEASING.md#preparing-for-release) is completed.

## Steps to Test

### As a non-VIP user

  * `vip dev-env create`. There must be no prompt for MU Plugins.
  * `vip dev-env update`. There must be no prompt for MU Plugins.
  * `vip dev-env update -u /path/to/mu-plugins`. `jq -c '.muPlugins' ~/.local/share/vip/dev-environment/vip-local/instance_data.json` must show `{"mode":"local","dir":"/path/to/mu-plugins"}`
  * `vip dev-env update`. There must be a prompt for MU Plugins.

### As a VIP user

There must always be a prompt for MU Plugins.

