### PR TITLE
fix(dev-env): handling of large media files in `vip dev-env import media`

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -20,7 +20,6 @@
         "cli-columns": "^4.0.0",
         "cli-table3": "^0.6.3",
         "configstore": "5.0.1",
-        "copy-dir": "0.4.0",
         "debug": "4.4.0",
         "ejs": "^3.1.8",
         "enquirer": "2.4.1",
@@ -5626,14 +5625,6 @@
       "integrity": "sha512-ASFBup0Mz1uyiIjANan1jzLQami9z1PoYSZCiiYW2FczPbenXc45FZdBZLzOT+r6+iciuEModtmCti+hjaAk0A==",
       "dev": true
     },
-    "node_modules/copy-dir": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/copy-dir/-/copy-dir-0.4.0.tgz",
-      "integrity": "sha512-mIefrD97nE1XX2th570tR5UQvW6/92czEPGe+oTtrxPAJl+KOKLpzcRa+e38WEpmt/IUN1n65KvRMzPblR+fDQ==",
-      "dependencies": {
-        "mkdir-p": "~0.0.4"
-      }
-    },
     "node_modules/core-js-compat": {
       "version": "3.40.0",
       "resolved": "https://registry.npmjs.org/core-js-compat/-/core-js-compat-3.40.0.tgz",
@@ -10194,11 +10185,6 @@
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
       }
-    },
-    "node_modules/mkdir-p": {
-      "version": "0.0.7",
-      "resolved": "https://registry.npmjs.org/mkdir-p/-/mkdir-p-0.0.7.tgz",
-      "integrity": "sha512-VkWaZNxDgZle/aJAemUAWdyYX7geyuleKYFfRejf/pFKjxBDbWrMAy41ijg5EiI1U00WR9JcvynuDedE/fTxLA=="
     },
     "node_modules/mkdirp": {
       "version": "3.0.1",
@@ -17720,14 +17706,6 @@
       "integrity": "sha512-ASFBup0Mz1uyiIjANan1jzLQami9z1PoYSZCiiYW2FczPbenXc45FZdBZLzOT+r6+iciuEModtmCti+hjaAk0A==",
       "dev": true
     },
-    "copy-dir": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/copy-dir/-/copy-dir-0.4.0.tgz",
-      "integrity": "sha512-mIefrD97nE1XX2th570tR5UQvW6/92czEPGe+oTtrxPAJl+KOKLpzcRa+e38WEpmt/IUN1n65KvRMzPblR+fDQ==",
-      "requires": {
-        "mkdir-p": "~0.0.4"
-      }
-    },
     "core-js-compat": {
       "version": "3.40.0",
       "resolved": "https://registry.npmjs.org/core-js-compat/-/core-js-compat-3.40.0.tgz",
@@ -21040,11 +21018,6 @@
           }
         }
       }
-    },
-    "mkdir-p": {
-      "version": "0.0.7",
-      "resolved": "https://registry.npmjs.org/mkdir-p/-/mkdir-p-0.0.7.tgz",
-      "integrity": "sha512-VkWaZNxDgZle/aJAemUAWdyYX7geyuleKYFfRejf/pFKjxBDbWrMAy41ijg5EiI1U00WR9JcvynuDedE/fTxLA=="
     },
     "mkdirp": {
       "version": "3.0.1",

--- a/package.json
+++ b/package.json
@@ -150,7 +150,6 @@
     "cli-columns": "^4.0.0",
     "cli-table3": "^0.6.3",
     "configstore": "5.0.1",
-    "copy-dir": "0.4.0",
     "debug": "4.4.0",
     "ejs": "^3.1.8",
     "enquirer": "2.4.1",

--- a/src/lib/dev-environment/dev-environment-core.ts
+++ b/src/lib/dev-environment/dev-environment-core.ts
@@ -821,8 +821,13 @@ export async function importMediaPath( slug: string, filePath: string ) {
 	const uploadsPath = path.join( environmentPath, uploadPathString );
 
 	console.log( `${ chalk.yellow( '-' ) } Started copying files` );
-	await cp( resolvedPath, uploadsPath, { recursive: true } );
-	console.log( `${ chalk.green( '✓' ) } Files successfully copied to ${ uploadsPath }.` );
+	try {
+		await cp( resolvedPath, uploadsPath, { recursive: true } );
+		console.log( `${ chalk.green( '✓' ) } Files successfully copied to ${ uploadsPath }.` );
+	} catch ( error ) {
+		console.error( `${ chalk.red( '✗' ) } Error copying files to ${ uploadsPath }.` );
+		throw error;
+	}
 }
 
 /**

--- a/src/lib/dev-environment/dev-environment-core.ts
+++ b/src/lib/dev-environment/dev-environment-core.ts
@@ -1,5 +1,4 @@
 import chalk from 'chalk';
-import copydir from 'copy-dir';
 import debugLib from 'debug';
 import ejs from 'ejs';
 import { prompt } from 'enquirer';
@@ -7,6 +6,7 @@ import { print } from 'graphql';
 import { dockerComposify } from 'lando/lib/utils';
 import fetch from 'node-fetch';
 import fs from 'node:fs';
+import { cp, readdir } from 'node:fs/promises';
 import path from 'node:path';
 import semver from 'semver';
 import { v4 as uuid } from 'uuid';
@@ -805,7 +805,7 @@ export async function importMediaPath( slug: string, filePath: string ) {
 		throw new Error( DEV_ENVIRONMENT_NOT_FOUND );
 	}
 
-	const files = fs.readdirSync( resolvedPath );
+	const files = await readdir( resolvedPath );
 	if ( files.includes( uploadPathString ) ) {
 		const confirm = await prompt( {
 			type: 'confirm',
@@ -821,7 +821,7 @@ export async function importMediaPath( slug: string, filePath: string ) {
 	const uploadsPath = path.join( environmentPath, uploadPathString );
 
 	console.log( `${ chalk.yellow( '-' ) } Started copying files` );
-	copydir.sync( resolvedPath, uploadsPath );
+	await cp( resolvedPath, uploadsPath, { recursive: true } );
 	console.log( `${ chalk.green( '✓' ) } Files successfully copied to ${ uploadsPath }.` );
 }
 


### PR DESCRIPTION
## Description

`vip dev-env import media` uses the [`copy-dir`](https://www.npmjs.com/package/copy-dir) packages to copy directories recursively. That miracle of technical thought uses `fs.readFile()` API to read the entire file to memory. And, of course, that fails for huge files because of the V8 limit on string length.

This PR ditches `copy-dir` and uses the `cp()` API of `node:fs/promises`.

## Pull request checklist

- [ ] Update [SETUP.md](https://github.com/Automattic/vip-cli/blob/trunk/docs/SETUP.md#list-of-environmental-variables) with any new environmental variables.
- [ ] Update [the documentation](https://github.com/Automattic/vip-cli/blob/trunk/docs).
- [x] [Manually test](https://github.com/Automattic/vip-cli/blob/trunk/docs/TESTING.md#manual-testing) the relevant changes.
- [x] Follow the [pull request checklist](https://github.com/Automattic/vip-cli/blob/trunk/docs/RELEASING.md#new-pull-requests)
- [ ] Add/update [automated tests](https://github.com/Automattic/vip-cli/blob/trunk/docs/TESTING.md#automated-testing) as needed.

## New release checklist

- [ ] [Automated tests](https://github.com/Automattic/vip-cli/blob/trunk/docs/TESTING.md#automated-testing) pass.
- [ ] The [Preparing for release checklist](https://github.com/Automattic/vip-cli/blob/trunk/docs/RELEASING.md#preparing-for-release) is completed.

## Steps to Test

```sh
vip dev-env create --slug pltfrm31 < /dev/null
vip dev-env start --slug pltfrm31 < /dev/null
mkdir uploads
dd if=/dev/urandom of=uploads/test.dat bs=1M count=1024
vip dev-env import media --slug pltfrm31 ./uploads
```

The expected behavior is the output similar to
```
- Started copying files
✓ Files successfully copied to /home/volodymyr/.local/share/vip/dev-environment/pltfrm31/uploads.
```