### PR TITLE
Clarifying descriptions of options for `vip config envvar`

### DIFF
--- a/src/bin/vip-config-envvar-delete.js
+++ b/src/bin/vip-config-envvar-delete.js
@@ -108,5 +108,5 @@ command( {
 	usage: `${ baseUsage } <VARIABLE_NAME>`,
 } )
 	.examples( examples )
-	.option( 'skip-confirmation', 'Skip manual confirmation of input (USE WITH CAUTION)', false )
+	.option( 'skip-confirmation', 'Skip the confirmation prompt (USE WITH CAUTION).', false )
 	.argv( process.argv, deleteEnvVarCommand );

--- a/src/bin/vip-config-envvar-set.js
+++ b/src/bin/vip-config-envvar-set.js
@@ -134,7 +134,10 @@ command( {
 	requiredArgs: 1,
 	usage: `${ baseUsage } <VARIABLE_NAME>`,
 } )
-	.option( 'from-file', 'Read environment variable value from file (useful for multiline input)' )
-	.option( 'skip-confirmation', 'Skip manual confirmation of input (USE WITH CAUTION)', false )
+	.option(
+		'from-file',
+		'Read environment variable value from a UTF-8-encoded text file (useful for multiline input). Accepts a relative or absolute path.'
+	)
+	.option( 'skip-confirmation', 'Skip the confirmation prompt (USE WITH CAUTION).', false )
 	.examples( examples )
 	.argv( process.argv, setEnvVarCommand );

--- a/src/bin/vip-config-envvar.js
+++ b/src/bin/vip-config-envvar.js
@@ -8,8 +8,9 @@ const exampleUsage = 'vip @example-app.develop config envvar';
 // Command examples
 const examples = [
 	{
-		usage: `${ exampleUsage } delete MY_VARIABLE`,
-		description: 'Delete the environment variable "MY_VARIABLE" from the environment.',
+		usage: `${ exampleUsage } set MY_VARIABLE`,
+		description:
+			'Add or update the environment variable "MY_VARIABLE" and assign its value at the prompt.',
 	},
 	{
 		usage: `${ exampleUsage } get MY_VARIABLE`,
@@ -24,9 +25,8 @@ const examples = [
 		description: 'List the names of all environment variables.',
 	},
 	{
-		usage: `${ exampleUsage } set MY_VARIABLE`,
-		description:
-			'Add or update the environment variable "MY_VARIABLE" and assign its value at the prompt.',
+		usage: `${ exampleUsage } delete MY_VARIABLE`,
+		description: 'Delete the environment variable "MY_VARIABLE" from the environment.',
 	},
 ];
 


### PR DESCRIPTION
## Description

Information related to the use of `--from-file` was in the Docs but not in the VIP-CLI help menu. This pull request amends that oversight. Examples for the `vip config envvar set` command are put in a more logical order. 

## Pull request checklist

- [ n/a ] Update [SETUP.md](https://github.com/Automattic/vip-cli/blob/trunk/docs/SETUP.md#list-of-environmental-variables) with any new environmental variables.
- [ ] Update [the documentation](https://github.com/Automattic/vip-cli/blob/trunk/docs).
- [ ] [Manually test](https://github.com/Automattic/vip-cli/blob/trunk/docs/TESTING.md#manual-testing) the relevant changes.
- [x] Follow the [pull request checklist](https://github.com/Automattic/vip-cli/blob/trunk/docs/RELEASING.md#new-pull-requests)
- [x] Add/update [automated tests](https://github.com/Automattic/vip-cli/blob/trunk/docs/TESTING.md#automated-testing) as needed.

## New release checklist

- [ ] [Automated tests](https://github.com/Automattic/vip-cli/blob/trunk/docs/TESTING.md#automated-testing) pass.
- [ ] The [Preparing for release checklist](https://github.com/Automattic/vip-cli/blob/trunk/docs/RELEASING.md#preparing-for-release) is completed.

## Steps to Test

Observe the results of the `--help` display for impacted commands:

- `vip config envvar`
- `vip config envvar set`
- `vip config envvar delete`
