### PR TITLE
fix(dev-env): strip trailing slash in URLs when doing sync

### DIFF
--- a/src/commands/dev-env-sync-sql.ts
+++ b/src/commands/dev-env-sync-sql.ts
@@ -68,8 +68,9 @@ async function extractSiteUrls( sqlFile: string ): Promise< string[] > {
 	return new Promise( ( resolve, reject ) => {
 		const urls: Set< string > = new Set();
 		readInterface.on( 'line', line => {
-			const url = findSiteHomeUrl( line );
+			let url = findSiteHomeUrl( line );
 			if ( url ) {
+				url = url.replace( /\/$/, '' );
 				urls.add( url );
 			}
 		} );
@@ -209,7 +210,7 @@ export class DevEnvSyncSQLCommand {
 			const url = site?.homeUrl;
 			if ( ! url ) continue;
 
-			const strippedUrl = stripProtocol( url );
+			const strippedUrl = stripProtocol( url ).replace( /\/$/, '' );
 			if ( ! this.searchReplaceMap[ strippedUrl ] ) continue;
 
 			const domain = new URL( url ).hostname;


### PR DESCRIPTION
## Description

This PR strips the trailing slash from the replaced URLs to ensure that URLs from the database match URLs from the SDS.

See: PLTFRM-361

## Pull request checklist

- [ ] Update [SETUP.md](https://github.com/Automattic/vip-cli/blob/trunk/docs/SETUP.md#list-of-environmental-variables) with any new environmental variables.
- [ ] Update [the documentation](https://github.com/Automattic/vip-cli/blob/trunk/docs).
- [x] [Manually test](https://github.com/Automattic/vip-cli/blob/trunk/docs/TESTING.md#manual-testing) the relevant changes.
- [x] Follow the [pull request checklist](https://github.com/Automattic/vip-cli/blob/trunk/docs/RELEASING.md#new-pull-requests)
- [ ] Add/update [automated tests](https://github.com/Automattic/vip-cli/blob/trunk/docs/TESTING.md#automated-testing) as needed.

## New release checklist

- [ ] [Automated tests](https://github.com/Automattic/vip-cli/blob/trunk/docs/TESTING.md#automated-testing) pass.
- [ ] The [Preparing for release checklist](https://github.com/Automattic/vip-cli/blob/trunk/docs/RELEASING.md#preparing-for-release) is completed.

## Steps to Test

See PLTFRM-361
