### PR TITLE
fix(dev-env): validation of `--app-code` and `--mu-plugins` options

### DIFF
--- a/src/bin/vip-dev-env-create.js
+++ b/src/bin/vip-dev-env-create.js
@@ -16,7 +16,7 @@ import {
 	validateDependencies,
 	processStringOrBooleanOption,
 	processSlug,
-	validatePathsInOptions,
+	ensureValidPathsInOptions,
 } from '../lib/dev-environment/dev-environment-cli';
 import {
 	getConfigurationFileOptions,
@@ -146,7 +146,7 @@ cmd.argv( process.argv, async ( arg, opt ) => {
 		console.log( chalk.yellow( 'Warning:' ), message );
 	}
 
-	validatePathsInOptions( opt );
+	ensureValidPathsInOptions( opt );
 
 	let preselectedOptions = opt;
 	let suppressPrompts = false;

--- a/src/bin/vip-dev-env-create.js
+++ b/src/bin/vip-dev-env-create.js
@@ -16,6 +16,7 @@ import {
 	validateDependencies,
 	processStringOrBooleanOption,
 	processSlug,
+	validatePathsInOptions,
 } from '../lib/dev-environment/dev-environment-cli';
 import {
 	getConfigurationFileOptions,
@@ -144,6 +145,8 @@ cmd.argv( process.argv, async ( arg, opt ) => {
 		debug( `WARNING: ${ message }`, error.message );
 		console.log( chalk.yellow( 'Warning:' ), message );
 	}
+
+	validatePathsInOptions( opt );
 
 	let preselectedOptions = opt;
 	let suppressPrompts = false;

--- a/src/bin/vip-dev-env-update.js
+++ b/src/bin/vip-dev-env-update.js
@@ -16,7 +16,7 @@ import {
 	processSlug,
 	promptForArguments,
 	validateDependencies,
-	validatePathsInOptions,
+	ensureValidPathsInOptions,
 } from '../lib/dev-environment/dev-environment-cli';
 import {
 	getConfigurationFileOptions,
@@ -84,7 +84,7 @@ cmd.argv( process.argv, async ( arg, opt ) => {
 
 		debug( 'Read instance data', currentInstanceData );
 
-		validatePathsInOptions( opt );
+		ensureValidPathsInOptions( opt );
 
 		/** @type {InstanceOptions} */
 		const preselectedOptions = {

--- a/src/bin/vip-dev-env-update.js
+++ b/src/bin/vip-dev-env-update.js
@@ -16,6 +16,7 @@ import {
 	processSlug,
 	promptForArguments,
 	validateDependencies,
+	validatePathsInOptions,
 } from '../lib/dev-environment/dev-environment-cli';
 import {
 	getConfigurationFileOptions,
@@ -82,6 +83,8 @@ cmd.argv( process.argv, async ( arg, opt ) => {
 		const currentInstanceData = readEnvironmentData( slug );
 
 		debug( 'Read instance data', currentInstanceData );
+
+		validatePathsInOptions( opt );
 
 		/** @type {InstanceOptions} */
 		const preselectedOptions = {

--- a/src/lib/dev-environment/dev-environment-cli.ts
+++ b/src/lib/dev-environment/dev-environment-cli.ts
@@ -480,6 +480,26 @@ async function processComponent(
 	return result;
 }
 
+export function validatePathsInOptions( opt: Record< string, string | boolean | number > ) {
+	if ( opt.appCode ) {
+		const result = validateAppCodeLocalPath( `${ opt.appCode }` );
+		if ( ! result.result ) {
+			console.warn( chalk.yellow( 'Warning:' ), result.message );
+			delete opt.appCode;
+			delete opt.a;
+		}
+	}
+
+	if ( opt.muPlugins ) {
+		const result = validateMuPluginsLocalPath( `${ opt.muPlugins }` );
+		if ( ! result.result ) {
+			console.warn( chalk.yellow( 'Warning:' ), result.message );
+			delete opt.muPlugins;
+			delete opt.m;
+		}
+	}
+}
+
 async function validateLocalPath(
 	config: ComponentConfig,
 	validator: ComponentPathValidator,

--- a/src/lib/dev-environment/dev-environment-cli.ts
+++ b/src/lib/dev-environment/dev-environment-cli.ts
@@ -480,7 +480,7 @@ async function processComponent(
 	return result;
 }
 
-export function validatePathsInOptions( opt: Record< string, string | boolean | number > ) {
+export function ensureValidPathsInOptions( opt: Record< string, string | boolean | number > ) {
 	if ( opt.appCode ) {
 		const result = validateAppCodeLocalPath( `${ opt.appCode }` );
 		if ( ! result.result ) {


### PR DESCRIPTION
## Description

`vip dev-env create` and `vip dev-env update` do not validate values of the `-a` and `-u` options. This makes it possible to pass invalid or non-existent paths to those options and possibly crash the environment.

```
$ vip dev-env create -a -u < /dev/null
...
✓ Path to your local application code: true
✓ Path to your local VIP MU Plugins: true
...
```

The same happens with `vip dev-env update`.

Ref: PLTFRM-740

## Pull request checklist

- [ ] Update [SETUP.md](https://github.com/Automattic/vip-cli/blob/trunk/docs/SETUP.md#list-of-environmental-variables) with any new environmental variables.
- [ ] Update [the documentation](https://github.com/Automattic/vip-cli/blob/trunk/docs).
- [x] [Manually test](https://github.com/Automattic/vip-cli/blob/trunk/docs/TESTING.md#manual-testing) the relevant changes.
- [x] Follow the [pull request checklist](https://github.com/Automattic/vip-cli/blob/trunk/docs/RELEASING.md#new-pull-requests)
- [ ] Add/update [automated tests](https://github.com/Automattic/vip-cli/blob/trunk/docs/TESTING.md#automated-testing) as needed.

## New release checklist

- [ ] [Automated tests](https://github.com/Automattic/vip-cli/blob/trunk/docs/TESTING.md#automated-testing) pass.
- [ ] The [Preparing for release checklist](https://github.com/Automattic/vip-cli/blob/trunk/docs/RELEASING.md#preparing-for-release) is completed.

## Steps to Test

`vip dev-env create -a -u < /dev/null` and `vip dev-env update -a -u < /dev/null` should display warnings about invalid paths.
