### PR TITLE
feat(dev-env): set random password for `vipgo` user

### DIFF
--- a/__tests__/devenv-e2e/005-update.spec.js
+++ b/__tests__/devenv-e2e/005-update.spec.js
@@ -23,6 +23,7 @@ describe( 'vip dev-env update', () => {
 		cliTest = new CliTest();
 
 		tmpPath = await mkdtemp( path.join( os.tmpdir(), 'vip-dev-env-' ) );
+		// @ts-expect-error we have to ignore that data is read-only
 		xdgBaseDir.data = tmpPath;
 
 		env = prepareEnvironment( tmpPath );
@@ -66,6 +67,8 @@ describe( 'vip dev-env update', () => {
 
 		delete dataBefore.autologinKey;
 		delete dataAfter.autologinKey;
+		delete dataBefore.adminPassword;
+		delete dataAfter.adminPassword;
 		expect( dataBefore ).toEqual( dataAfter );
 	} );
 

--- a/__tests__/devenv-e2e/helpers/cli-test.js
+++ b/__tests__/devenv-e2e/helpers/cli-test.js
@@ -13,7 +13,7 @@ export class CliTest {
 	 * @param {boolean}  printStderrOnError Whether to print stderr on error
 	 * @return {Promise<CliResult>} Return value of the command
 	 */
-	spawn( args, options, printStderrOnError ) {
+	spawn( args, options, printStderrOnError = false ) {
 		const [ command, ...commandArgs ] = args;
 
 		let stdout = '';

--- a/assets/dev-env.lando.template.yml.ejs
+++ b/assets/dev-env.lando.template.yml.ejs
@@ -93,6 +93,7 @@ services:
         --user root
         --domain "http://<%= siteSlug %>.<%= domain %>/"
         --title "<%= wpTitle %>"
+        --wpadmin_password "<%= adminPassword %>"
         <% if ( multisite ) { %>--ms-domain "<%= siteSlug %>.<%= domain %>" <% if ( multisite === true || multisite === 'subdomain' ) { %>--subdomain <% } %> <% } %>
 
   database:

--- a/src/bin/vip-dev-env-create.js
+++ b/src/bin/vip-dev-env-create.js
@@ -28,6 +28,7 @@ import {
 	doesEnvironmentExist,
 	getEnvironmentPath,
 } from '../lib/dev-environment/dev-environment-core';
+import { generatePassword } from '../lib/dev-environment/dev-environment-database';
 import { bootstrapLando } from '../lib/dev-environment/dev-environment-lando';
 import { trackEvent } from '../lib/tracker';
 
@@ -160,6 +161,7 @@ cmd.argv( process.argv, async ( arg, opt ) => {
 		true
 	);
 	instanceData.siteSlug = slug;
+	instanceData.adminPassword = generatePassword();
 
 	try {
 		await createEnvironment( lando, instanceData, integrationsConfig, envVars );

--- a/src/bin/vip-dev-env-update.js
+++ b/src/bin/vip-dev-env-update.js
@@ -115,6 +115,7 @@ cmd.argv( process.argv, async ( arg, opt ) => {
 			multisite: false,
 			title: '',
 			cron: currentInstanceData.cron,
+			adminPassword: currentInstanceData.adminPassword,
 		};
 
 		const providedOptions = Object.keys( opt )

--- a/src/lib/constants/dev-environment.ts
+++ b/src/lib/constants/dev-environment.ts
@@ -49,4 +49,4 @@ export const DEV_ENVIRONMENT_DEFAULTS = {
 	phpVersion: Object.keys( DEV_ENVIRONMENT_PHP_VERSIONS )[ 0 ],
 } as const;
 
-export const DEV_ENVIRONMENT_VERSION = '2.2.3';
+export const DEV_ENVIRONMENT_VERSION = '2.3.0';

--- a/src/lib/dev-environment/dev-environment-cli.ts
+++ b/src/lib/dev-environment/dev-environment-cli.ts
@@ -262,7 +262,7 @@ export async function promptForArguments(
 	try {
 		const currentUser = await getCurrentUserInfo( true );
 		isVIPUser = currentUser?.isVIP ?? false;
-	} catch ( err ) {
+	} catch {
 		isVIPUser = false;
 	}
 
@@ -320,6 +320,7 @@ export async function promptForArguments(
 		photon: false,
 		cron: false,
 		overrides: preselectedOptions.overrides,
+		adminPassword: preselectedOptions.adminPassword,
 	};
 
 	const promptLabels = {

--- a/src/lib/dev-environment/dev-environment-core.ts
+++ b/src/lib/dev-environment/dev-environment-core.ts
@@ -163,7 +163,7 @@ export async function stopEnvironment( lando: Lando, slug: string ): Promise< vo
 	await landoStop( lando, instancePath );
 }
 
-export async function createEnvironment(
+export function createEnvironment(
 	lando: Lando,
 	instanceData: InstanceData,
 	integrationsConfig?: Record< string, IntegrationConfig > | undefined,
@@ -187,7 +187,7 @@ export async function createEnvironment(
 
 	debug( 'Will create an environment', slug, 'with instanceData: ', preProcessedInstanceData );
 
-	await prepareLandoEnv(
+	return prepareLandoEnv(
 		lando,
 		preProcessedInstanceData,
 		instancePath,
@@ -241,9 +241,7 @@ function preProcessInstanceData( instanceData: InstanceData ): InstanceData {
 		newInstanceData.wordpress.tag = 'trunk';
 	}
 
-	if ( ! newInstanceData.xdebugConfig ) {
-		newInstanceData.xdebugConfig = '';
-	}
+	newInstanceData.xdebugConfig ??= '';
 
 	if ( ! newInstanceData.xdebug ) {
 		newInstanceData.xdebug = false;
@@ -265,9 +263,7 @@ function preProcessInstanceData( instanceData: InstanceData ): InstanceData {
 	newInstanceData.mailpit ??= false;
 
 	// MariaDB migration
-	if ( ! newInstanceData.mariadb ) {
-		newInstanceData.mariadb = undefined;
-	}
+	newInstanceData.mariadb ??= undefined;
 
 	// newInstanceData
 	newInstanceData.autologinKey = uuid();

--- a/src/lib/dev-environment/dev-environment-core.ts
+++ b/src/lib/dev-environment/dev-environment-core.ts
@@ -180,7 +180,7 @@ export function createEnvironment(
 	const alreadyExists = fs.existsSync( instancePath );
 
 	if ( alreadyExists ) {
-		throw new Error( 'Environment already exists.' );
+		return Promise.reject( new Error( 'Environment already exists.' ) );
 	}
 
 	const preProcessedInstanceData = preProcessInstanceData( instanceData );

--- a/src/lib/dev-environment/dev-environment-database.ts
+++ b/src/lib/dev-environment/dev-environment-database.ts
@@ -4,7 +4,7 @@ import { exec, readEnvironmentData, writeEnvironmentData } from './dev-environme
 
 import type Lando from 'lando';
 
-const generatePassword = (): string => {
+export const generatePassword = (): string => {
 	const chars = 'abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789-_';
 	const passwordLength = 12;
 	let password = '';

--- a/src/lib/dev-environment/types.ts
+++ b/src/lib/dev-environment/types.ts
@@ -17,6 +17,7 @@ export interface InstanceOptions {
 	photon?: boolean;
 	cron?: boolean;
 	overrides?: string;
+	adminPassword?: string;
 
 	[ index: string ]: unknown;
 }


### PR DESCRIPTION
## Description

Ref: BREAKING-1042

When creating the environment, set a random password for the `vipgo` user.

## Pull request checklist

- [ ] Update [SETUP.md](https://github.com/Automattic/vip-cli/blob/trunk/docs/SETUP.md#list-of-environmental-variables) with any new environmental variables.
- [ ] Update [the documentation](https://github.com/Automattic/vip-cli/blob/trunk/docs).
- [x] [Manually test](https://github.com/Automattic/vip-cli/blob/trunk/docs/TESTING.md#manual-testing) the relevant changes.
- [x] Follow the [pull request checklist](https://github.com/Automattic/vip-cli/blob/trunk/docs/RELEASING.md#new-pull-requests)
- [ ] Add/update [automated tests](https://github.com/Automattic/vip-cli/blob/trunk/docs/TESTING.md#automated-testing) as needed.

## New release checklist

- [ ] [Automated tests](https://github.com/Automattic/vip-cli/blob/trunk/docs/TESTING.md#automated-testing) pass.
- [ ] The [Preparing for release checklist](https://github.com/Automattic/vip-cli/blob/trunk/docs/RELEASING.md#preparing-for-release) is completed.

## Steps to Test

`vip dev-env create && vip dev-env start` and ensure that the admin password is not `password` and you can log in with it.
