### PR TITLE
fix(dev-env): Support multisite subdirectory/subdomain values in vip-dev-env.yml files

### DIFF
--- a/__tests__/lib/dev-environment/dev-environment-cli.js
+++ b/__tests__/lib/dev-environment/dev-environment-cli.js
@@ -4,7 +4,6 @@ import { jest } from '@jest/globals';
 import chalk from 'chalk';
 import { prompt, selectRunMock, confirmRunMock } from 'enquirer';
 import nock from 'nock';
-import { readFile } from 'node:fs/promises';
 import os from 'os';
 
 import { DEV_ENVIRONMENT_PHP_VERSIONS } from '../../../src/lib/constants/dev-environment';
@@ -24,16 +23,6 @@ import * as devEnvConfiguration from '../../../src/lib/dev-environment/dev-envir
 import * as devEnvCore from '../../../src/lib/dev-environment/dev-environment-core';
 
 jest.spyOn( console, 'log' ).mockImplementation( () => {} );
-
-// Mock fs operations for configuration file tests
-jest.mock( 'node:fs/promises' );
-
-// Mock exit module to prevent actual process exits during tests
-jest.mock( '../../../src/lib/cli/exit', () => ( {
-	withError: jest.fn( message => {
-		throw new Error( message );
-	} ),
-} ) );
 
 jest.mock( 'enquirer', () => {
 	const _selectRunMock = jest.fn();
@@ -609,104 +598,5 @@ describe( 'lib/dev-environment/dev-environment-cli', () => {
 				);
 			}
 		);
-	} );
-
-	describe( 'configuration file multisite sanitization', () => {
-		const mockedReadFile = readFile;
-		const createConfigContent = multisiteValue => `
-configuration-version: 1
-slug: test-site
-multisite: ${ multisiteValue }
-mu-plugins: demo
-app-code: demo
-`;
-
-		beforeEach( () => {
-			jest.clearAllMocks();
-			jest.resetAllMocks();
-			// Mock process.cwd() to return a known directory
-			jest.spyOn( process, 'cwd' ).mockReturnValue( '/test/dir' );
-			// Default mock to reject all file reads
-			mockedReadFile.mockRejectedValue( new Error( 'File not found' ) );
-		} );
-
-		it.each( [
-			{ input: 'subdirectory', expected: 'subdirectory', description: 'subdirectory string' },
-			{ input: 'subdomain', expected: 'subdomain', description: 'subdomain string' },
-			{ input: 'y', expected: true, description: 'y (yes) results in true (subdomain multisite)' },
-			{ input: 'yes', expected: true, description: 'yes results in true (subdomain multisite)' },
-			{ input: 'true', expected: true, description: 'true results in true (subdomain multisite)' },
-			{ input: '1', expected: true, description: '1 results in true (subdomain multisite)' },
-			{ input: 'false', expected: false, description: 'false becomes boolean false' },
-			{ input: 'no', expected: false, description: 'no becomes boolean false' },
-			{ input: 'n', expected: false, description: 'n becomes boolean false' },
-			{ input: '0', expected: false, description: '0 becomes boolean false' },
-		] )(
-			'should sanitize multisite: $input to $expected ($description)',
-			async ( { input, expected } ) => {
-				const configContent = createConfigContent( input );
-
-				console.log( 'configContent', configContent );
-
-				mockedReadFile.mockResolvedValueOnce( configContent );
-
-				const result = await devEnvConfiguration.getConfigurationFileOptions();
-
-				expect( result.multisite ).toStrictEqual( expected );
-				expect( result.slug ).toBe( 'test-site' );
-				expect( result.version ).toBe( '1' );
-			}
-		);
-
-		it.each( [
-			{ input: 'SUBDIRECTORY', expected: false },
-			{ input: 'SubDomain', expected: false },
-			{ input: 'Y', expected: true },
-			{ input: 'TRUE', expected: true },
-			{ input: 'FALSE', expected: false },
-		] )(
-			'should handle case-sensitive multisite values (case changes result in false): $input to $expected',
-			async ( { input, expected } ) => {
-				const configContent = createConfigContent( input );
-
-				mockedReadFile.mockResolvedValueOnce( configContent );
-
-				const result = await devEnvConfiguration.getConfigurationFileOptions();
-
-				expect( result.multisite ).toStrictEqual( expected );
-				expect( result.slug ).toBe( 'test-site' );
-				expect( result.version ).toBe( '1' );
-			}
-		);
-
-		it( 'should ignore invalid multisite values and set to false', async () => {
-			const configContent = createConfigContent( 'invalid-value' );
-
-			mockedReadFile.mockResolvedValueOnce( configContent );
-
-			const result = await devEnvConfiguration.getConfigurationFileOptions();
-
-			// Invalid values should result in the default value (false)
-			expect( result.multisite ).toBe( false );
-			expect( result.slug ).toBe( 'test-site' );
-		} );
-
-		it( 'should handle non-string multisite values', async () => {
-			// Test with a config that has a non-string value (like a number or boolean from YAML)
-			const configContentWithBoolean = `
-configuration-version: 1
-slug: test-site
-multisite: true
-mu-plugins: demo
-app-code: demo
-`;
-
-			mockedReadFile.mockResolvedValueOnce( configContentWithBoolean );
-
-			const result = await devEnvConfiguration.getConfigurationFileOptions();
-
-			// Boolean true should be treated as multisite enabled (boolean true)
-			expect( result.multisite ).toStrictEqual( true );
-		} );
 	} );
 } );

--- a/__tests__/lib/dev-environment/dev-environment-cli.js
+++ b/__tests__/lib/dev-environment/dev-environment-cli.js
@@ -1,8 +1,10 @@
 /* eslint-disable jest/no-conditional-expect */
 
+import { jest } from '@jest/globals';
 import chalk from 'chalk';
 import { prompt, selectRunMock, confirmRunMock } from 'enquirer';
 import nock from 'nock';
+import { readFile } from 'node:fs/promises';
 import os from 'os';
 
 import { DEV_ENVIRONMENT_PHP_VERSIONS } from '../../../src/lib/constants/dev-environment';
@@ -22,6 +24,16 @@ import * as devEnvConfiguration from '../../../src/lib/dev-environment/dev-envir
 import * as devEnvCore from '../../../src/lib/dev-environment/dev-environment-core';
 
 jest.spyOn( console, 'log' ).mockImplementation( () => {} );
+
+// Mock fs operations for configuration file tests
+jest.mock( 'node:fs/promises' );
+
+// Mock exit module to prevent actual process exits during tests
+jest.mock( '../../../src/lib/cli/exit', () => ( {
+	withError: jest.fn( message => {
+		throw new Error( message );
+	} ),
+} ) );
 
 jest.mock( 'enquirer', () => {
 	const _selectRunMock = jest.fn();
@@ -597,5 +609,104 @@ describe( 'lib/dev-environment/dev-environment-cli', () => {
 				);
 			}
 		);
+	} );
+
+	describe( 'configuration file multisite sanitization', () => {
+		const mockedReadFile = readFile;
+		const createConfigContent = multisiteValue => `
+configuration-version: 1
+slug: test-site
+multisite: ${ multisiteValue }
+mu-plugins: demo
+app-code: demo
+`;
+
+		beforeEach( () => {
+			jest.clearAllMocks();
+			jest.resetAllMocks();
+			// Mock process.cwd() to return a known directory
+			jest.spyOn( process, 'cwd' ).mockReturnValue( '/test/dir' );
+			// Default mock to reject all file reads
+			mockedReadFile.mockRejectedValue( new Error( 'File not found' ) );
+		} );
+
+		it.each( [
+			{ input: 'subdirectory', expected: 'subdirectory', description: 'subdirectory string' },
+			{ input: 'subdomain', expected: 'subdomain', description: 'subdomain string' },
+			{ input: 'y', expected: 'subdomain', description: 'y (yes) defaults to subdomain' },
+			{ input: 'yes', expected: 'subdomain', description: 'yes defaults to subdomain' },
+			{ input: 'true', expected: 'subdomain', description: 'true defaults to subdomain' },
+			{ input: '1', expected: 'subdomain', description: '1 defaults to subdomain' },
+			{ input: 'false', expected: false, description: 'false becomes boolean false' },
+			{ input: 'no', expected: false, description: 'no becomes boolean false' },
+			{ input: 'n', expected: false, description: 'n becomes boolean false' },
+			{ input: '0', expected: false, description: '0 becomes boolean false' },
+		] )(
+			'should sanitize multisite: $input to $expected ($description)',
+			async ( { input, expected } ) => {
+				const configContent = createConfigContent( input );
+
+				console.log( 'configContent', configContent );
+
+				mockedReadFile.mockResolvedValueOnce( configContent );
+
+				const result = await devEnvConfiguration.getConfigurationFileOptions();
+
+				expect( result.multisite ).toStrictEqual( expected );
+				expect( result.slug ).toBe( 'test-site' );
+				expect( result.version ).toBe( '1' );
+			}
+		);
+
+		it.each( [
+			{ input: 'SUBDIRECTORY', expected: 'subdirectory' },
+			{ input: 'SubDomain', expected: 'subdomain' },
+			{ input: 'Y', expected: 'subdomain' },
+			{ input: 'TRUE', expected: 'subdomain' },
+			{ input: 'FALSE', expected: false },
+		] )(
+			'should handle case-insensitive multisite values: $input to $expected ($description)',
+			async ( { input, expected } ) => {
+				const configContent = createConfigContent( input );
+
+				mockedReadFile.mockResolvedValueOnce( configContent );
+
+				const result = await devEnvConfiguration.getConfigurationFileOptions();
+
+				expect( result.multisite ).toStrictEqual( expected );
+				expect( result.slug ).toBe( 'test-site' );
+				expect( result.version ).toBe( '1' );
+			}
+		);
+
+		it( 'should ignore invalid multisite values and not set the property', async () => {
+			const configContent = createConfigContent( 'invalid-value' );
+
+			mockedReadFile.mockResolvedValueOnce( configContent );
+
+			const result = await devEnvConfiguration.getConfigurationFileOptions();
+
+			// Invalid values should result in the property being undefined and removed
+			expect( result.multisite ).toBeUndefined();
+			expect( result.slug ).toBe( 'test-site' );
+		} );
+
+		it( 'should handle non-string multisite values', async () => {
+			// Test with a config that has a non-string value (like a number or boolean from YAML)
+			const configContentWithBoolean = `
+configuration-version: 1
+slug: test-site
+multisite: true
+mu-plugins: demo
+app-code: demo
+`;
+
+			mockedReadFile.mockResolvedValueOnce( configContentWithBoolean );
+
+			const result = await devEnvConfiguration.getConfigurationFileOptions();
+
+			// Boolean true should be treated as subdomain (like 'y' or 'true' string)
+			expect( result.multisite ).toStrictEqual( 'subdomain' );
+		} );
 	} );
 } );

--- a/__tests__/lib/dev-environment/dev-environment-cli.js
+++ b/__tests__/lib/dev-environment/dev-environment-cli.js
@@ -633,10 +633,10 @@ app-code: demo
 		it.each( [
 			{ input: 'subdirectory', expected: 'subdirectory', description: 'subdirectory string' },
 			{ input: 'subdomain', expected: 'subdomain', description: 'subdomain string' },
-			{ input: 'y', expected: 'subdomain', description: 'y (yes) defaults to subdomain' },
-			{ input: 'yes', expected: 'subdomain', description: 'yes defaults to subdomain' },
-			{ input: 'true', expected: 'subdomain', description: 'true defaults to subdomain' },
-			{ input: '1', expected: 'subdomain', description: '1 defaults to subdomain' },
+			{ input: 'y', expected: true, description: 'y (yes) results in true (subdomain multisite)' },
+			{ input: 'yes', expected: true, description: 'yes results in true (subdomain multisite)' },
+			{ input: 'true', expected: true, description: 'true results in true (subdomain multisite)' },
+			{ input: '1', expected: true, description: '1 results in true (subdomain multisite)' },
 			{ input: 'false', expected: false, description: 'false becomes boolean false' },
 			{ input: 'no', expected: false, description: 'no becomes boolean false' },
 			{ input: 'n', expected: false, description: 'n becomes boolean false' },
@@ -659,13 +659,13 @@ app-code: demo
 		);
 
 		it.each( [
-			{ input: 'SUBDIRECTORY', expected: 'subdirectory' },
-			{ input: 'SubDomain', expected: 'subdomain' },
-			{ input: 'Y', expected: 'subdomain' },
-			{ input: 'TRUE', expected: 'subdomain' },
+			{ input: 'SUBDIRECTORY', expected: false },
+			{ input: 'SubDomain', expected: false },
+			{ input: 'Y', expected: true },
+			{ input: 'TRUE', expected: true },
 			{ input: 'FALSE', expected: false },
 		] )(
-			'should handle case-insensitive multisite values: $input to $expected ($description)',
+			'should handle case-sensitive multisite values (case changes result in false): $input to $expected',
 			async ( { input, expected } ) => {
 				const configContent = createConfigContent( input );
 
@@ -679,15 +679,15 @@ app-code: demo
 			}
 		);
 
-		it( 'should ignore invalid multisite values and not set the property', async () => {
+		it( 'should ignore invalid multisite values and set to false', async () => {
 			const configContent = createConfigContent( 'invalid-value' );
 
 			mockedReadFile.mockResolvedValueOnce( configContent );
 
 			const result = await devEnvConfiguration.getConfigurationFileOptions();
 
-			// Invalid values should result in the property being undefined and removed
-			expect( result.multisite ).toBeUndefined();
+			// Invalid values should result in the default value (false)
+			expect( result.multisite ).toBe( false );
 			expect( result.slug ).toBe( 'test-site' );
 		} );
 
@@ -705,8 +705,8 @@ app-code: demo
 
 			const result = await devEnvConfiguration.getConfigurationFileOptions();
 
-			// Boolean true should be treated as subdomain (like 'y' or 'true' string)
-			expect( result.multisite ).toStrictEqual( 'subdomain' );
+			// Boolean true should be treated as multisite enabled (boolean true)
+			expect( result.multisite ).toStrictEqual( true );
 		} );
 	} );
 } );

--- a/__tests__/lib/dev-environment/dev-environment-cli.js
+++ b/__tests__/lib/dev-environment/dev-environment-cli.js
@@ -1,6 +1,5 @@
 /* eslint-disable jest/no-conditional-expect */
 
-import { jest } from '@jest/globals';
 import chalk from 'chalk';
 import { prompt, selectRunMock, confirmRunMock } from 'enquirer';
 import nock from 'nock';

--- a/__tests__/lib/dev-environment/dev-environment-configuration-file.js
+++ b/__tests__/lib/dev-environment/dev-environment-configuration-file.js
@@ -127,4 +127,4 @@ app-code: demo
 			expect( result ).toEqual( {} );
 		} );
 	} );
-} ); 
+} );

--- a/__tests__/lib/dev-environment/dev-environment-configuration-file.js
+++ b/__tests__/lib/dev-environment/dev-environment-configuration-file.js
@@ -1,0 +1,130 @@
+/**
+ * @format
+ */
+
+import { jest } from '@jest/globals';
+import { readFile } from 'node:fs/promises';
+
+import { getConfigurationFileOptions } from '../../../src/lib/dev-environment/dev-environment-configuration-file';
+
+// Mock fs operations
+jest.mock( 'node:fs/promises' );
+
+// Mock exit module to prevent actual process exits during tests
+jest.mock( '../../../src/lib/cli/exit', () => ( {
+	withError: jest.fn( message => {
+		throw new Error( message );
+	} ),
+} ) );
+
+const mockedReadFile = readFile;
+
+describe( 'dev-environment-configuration-file', () => {
+	describe( 'multisite configuration sanitization', () => {
+		const createConfigContent = multisiteValue => `
+configuration-version: 1
+slug: test-site
+multisite: ${ multisiteValue }
+mu-plugins: demo
+app-code: demo
+`;
+
+		beforeEach( () => {
+			jest.clearAllMocks();
+			jest.resetAllMocks();
+			// Mock process.cwd() to return a known directory
+			jest.spyOn( process, 'cwd' ).mockReturnValue( '/test/dir' );
+			// Default mock to reject all file reads
+			mockedReadFile.mockRejectedValue( new Error( 'File not found' ) );
+		} );
+
+		afterEach( () => {
+			jest.restoreAllMocks();
+		} );
+
+		it.each( [
+			{ input: 'subdirectory', expected: 'subdirectory', description: 'subdirectory string' },
+			{ input: 'subdomain', expected: 'subdomain', description: 'subdomain string' },
+			{ input: 'y', expected: true, description: 'y (yes) results in true (subdomain multisite)' },
+			{ input: 'yes', expected: true, description: 'yes results in true (subdomain multisite)' },
+			{ input: 'true', expected: true, description: 'true results in true (subdomain multisite)' },
+			{ input: '1', expected: true, description: '1 results in true (subdomain multisite)' },
+			{ input: 'false', expected: false, description: 'false becomes boolean false' },
+			{ input: 'no', expected: false, description: 'no becomes boolean false' },
+			{ input: 'n', expected: false, description: 'n becomes boolean false' },
+			{ input: '0', expected: false, description: '0 becomes boolean false' },
+		] )(
+			'should sanitize multisite: $input to $expected ($description)',
+			async ( { input, expected } ) => {
+				const configContent = createConfigContent( input );
+
+				mockedReadFile.mockResolvedValueOnce( configContent );
+
+				const result = await getConfigurationFileOptions();
+
+				expect( result.multisite ).toStrictEqual( expected );
+				expect( result.slug ).toBe( 'test-site' );
+				expect( result.version ).toBe( '1' );
+			}
+		);
+
+		it.each( [
+			{ input: 'SUBDIRECTORY', expected: false },
+			{ input: 'SubDomain', expected: false },
+			{ input: 'Y', expected: true },
+			{ input: 'TRUE', expected: true },
+			{ input: 'FALSE', expected: false },
+		] )(
+			'should handle case-sensitive multisite values (case changes result in false): $input to $expected',
+			async ( { input, expected } ) => {
+				const configContent = createConfigContent( input );
+
+				mockedReadFile.mockResolvedValueOnce( configContent );
+
+				const result = await getConfigurationFileOptions();
+
+				expect( result.multisite ).toStrictEqual( expected );
+				expect( result.slug ).toBe( 'test-site' );
+				expect( result.version ).toBe( '1' );
+			}
+		);
+
+		it( 'should ignore invalid multisite values and set to false', async () => {
+			const configContent = createConfigContent( 'invalid-value' );
+
+			mockedReadFile.mockResolvedValueOnce( configContent );
+
+			const result = await getConfigurationFileOptions();
+
+			// Invalid values should result in the default value (false)
+			expect( result.multisite ).toBe( false );
+			expect( result.slug ).toBe( 'test-site' );
+		} );
+
+		it( 'should handle non-string multisite values', async () => {
+			// Test with a config that has a non-string value (like a number or boolean from YAML)
+			const configContentWithBoolean = `
+configuration-version: 1
+slug: test-site
+multisite: true
+mu-plugins: demo
+app-code: demo
+`;
+
+			mockedReadFile.mockResolvedValueOnce( configContentWithBoolean );
+
+			const result = await getConfigurationFileOptions();
+
+			// Boolean true should be treated as multisite enabled (boolean true)
+			expect( result.multisite ).toStrictEqual( true );
+		} );
+
+		it( 'should return empty object when no configuration file is found', async () => {
+			mockedReadFile.mockRejectedValue( new Error( 'File not found' ) );
+
+			const result = await getConfigurationFileOptions();
+
+			expect( result ).toEqual( {} );
+		} );
+	} );
+} ); 

--- a/src/lib/dev-environment/dev-environment-cli.ts
+++ b/src/lib/dev-environment/dev-environment-cli.ts
@@ -41,6 +41,7 @@ import type {
 	InstanceData,
 	WordPressConfig,
 	ConfigurationFileOptions,
+	MultisiteKind,
 } from './types';
 
 const debug = debugLib( '@automattic/vip:bin:dev-environment' );
@@ -662,7 +663,7 @@ export async function promptForURL( message: string, initial: string ): Promise<
 	return retval === 'n' ? '' : retval;
 }
 
-const multisiteOptions = [ 'subdomain', 'subdirectory' ] as const;
+const multisiteOptions = [ 'subdomain', 'subdirectory' ] as MultisiteKind[];
 
 export async function promptForMultisite(
 	message: string,
@@ -722,7 +723,7 @@ export function promptForBoolean( message: string, initial: boolean ): Promise< 
 	return Promise.resolve( initial );
 }
 
-function resolveMultisite( value: string | boolean ): 'subdomain' | 'subdirectory' | boolean {
+export function resolveMultisite( value: string | boolean ): MultisiteKind | boolean {
 	const isMultisiteOption = (
 		val: unknown
 	): val is ( typeof multisiteOptions )[ number ] | boolean =>

--- a/src/lib/dev-environment/dev-environment-configuration-file.ts
+++ b/src/lib/dev-environment/dev-environment-configuration-file.ts
@@ -5,10 +5,15 @@ import yaml, { FAILSAFE_SCHEMA } from 'js-yaml';
 import { readFile } from 'node:fs/promises';
 import path from 'node:path';
 
-import { CONFIGURATION_FOLDER } from './dev-environment-cli';
+import { CONFIGURATION_FOLDER, resolveMultisite } from './dev-environment-cli';
 import * as exit from '../cli/exit';
 
-import type { ConfigurationFileMeta, ConfigurationFileOptions, InstanceOptions } from './types';
+import type {
+	ConfigurationFileMeta,
+	ConfigurationFileOptions,
+	InstanceOptions,
+	MultisiteKind,
+} from './types';
 
 const debug = debugLib( '@automattic/vip:bin:dev-environment' );
 
@@ -106,7 +111,7 @@ function sanitizeConfiguration(
 		// eslint-disable-next-line @typescript-eslint/no-base-to-string
 		slug: configuration.slug.toString(), // NOSONAR
 		title: configuration.title?.toString(),
-		multisite: stringToBooleanIfDefined( configuration.multisite ),
+		multisite: resolveMultisite( configuration.multisite as MultisiteKind | boolean ),
 		php: configuration.php?.toString(),
 		wordpress: configuration.wordpress?.toString(),
 		'mu-plugins': configuration[ 'mu-plugins' ]?.toString(),

--- a/src/lib/dev-environment/dev-environment-configuration-file.ts
+++ b/src/lib/dev-environment/dev-environment-configuration-file.ts
@@ -5,7 +5,11 @@ import yaml, { FAILSAFE_SCHEMA } from 'js-yaml';
 import { readFile } from 'node:fs/promises';
 import path from 'node:path';
 
-import { CONFIGURATION_FOLDER, resolveMultisite } from './dev-environment-cli';
+import {
+	CONFIGURATION_FOLDER,
+	resolveMultisite,
+	processStringOrBooleanOption,
+} from './dev-environment-cli';
 import * as exit from '../cli/exit';
 
 import type {
@@ -111,7 +115,9 @@ function sanitizeConfiguration(
 		// eslint-disable-next-line @typescript-eslint/no-base-to-string
 		slug: configuration.slug.toString(), // NOSONAR
 		title: configuration.title?.toString(),
-		multisite: resolveMultisite( configuration.multisite as MultisiteKind | boolean ),
+		multisite: resolveMultisite(
+			processStringOrBooleanOption( configuration.multisite as MultisiteKind | boolean )
+		),
 		php: configuration.php?.toString(),
 		wordpress: configuration.wordpress?.toString(),
 		'mu-plugins': configuration[ 'mu-plugins' ]?.toString(),

--- a/src/lib/dev-environment/types.ts
+++ b/src/lib/dev-environment/types.ts
@@ -76,7 +76,7 @@ export interface ConfigurationFileOptions {
 	version?: string;
 	slug?: string;
 	title?: string;
-	multisite?: boolean | 'subdomain' | 'subdirectory';
+	multisite?: boolean | MultisiteKind;
 	php?: string;
 	wordpress?: string;
 	'mu-plugins'?: string;
@@ -103,7 +103,7 @@ export interface InstanceData {
 	[ index: string ]: unknown;
 	siteSlug: string;
 	wpTitle: string;
-	multisite: boolean | 'subdomain' | 'subdirectory';
+	multisite: boolean | MultisiteKind;
 	wordpress: WordPressConfig;
 	muPlugins: ComponentConfig;
 	appCode: ComponentConfig;


### PR DESCRIPTION
## Description

When using a VIP Local Development Environment creation config file "vip-dev-env.yml", the config setting multisite: subdirectory is ignored.

This pull request introduces enhancements to the handling of multisite configuration in the development environment CLI, including improved sanitization, type safety, and test coverage. The changes aim to standardize how multisite values are interpreted, validated, and processed.

## Pull request checklist

- [ ] Update [SETUP.md](https://github.com/Automattic/vip-cli/blob/trunk/docs/SETUP.md#list-of-environmental-variables) with any new environmental variables.
- [ ] Update [the documentation](https://github.com/Automattic/vip-cli/blob/trunk/docs).
- [x] [Manually test](https://github.com/Automattic/vip-cli/blob/trunk/docs/TESTING.md#manual-testing) the relevant changes.
- [ ] Follow the [pull request checklist](https://github.com/Automattic/vip-cli/blob/trunk/docs/RELEASING.md#new-pull-requests)
- [x] Add/update [automated tests](https://github.com/Automattic/vip-cli/blob/trunk/docs/TESTING.md#automated-testing) as needed.

## New release checklist

- [x] [Automated tests](https://github.com/Automattic/vip-cli/blob/trunk/docs/TESTING.md#automated-testing) pass.
- [ ] The [Preparing for release checklist](https://github.com/Automattic/vip-cli/blob/trunk/docs/RELEASING.md#preparing-for-release) is completed.

## Steps to Reproduce & Test

1. Install `vip` using `npm install -g @automattic/vip`
2. If you have a `.vip-dev-env.yml` configuration file set up already, update or add this key value in it: `multisite: subdirectory` . If not, you can create one at your locally checked-out project directory's root and add the same key-value pair in yaml.
3. Run `vip dev-env create --slug testing1 --debug @automattic/vip:bin:dev-environment`
4. Notice that the debug logs do not pick up the configuration for `multisite` and you then get prompted for it as well.
5. Checkout the PR branch: `git fetch && git checkout fix/config-file-multisite`
6. Run `vip dev-env create --slug testing1 --debug @automattic/vip:bin:dev-environment`
7. This time the debug logs should list the `multisite` config property and its value and you should not have been prompted for this again. 
