### PR TITLE
Update/Org salesforceId

### DIFF
--- a/src/bin/vip-config-envvar-delete.js
+++ b/src/bin/vip-config-envvar-delete.js
@@ -34,6 +34,7 @@ export async function deleteEnvVarCommand( arg, opt ) {
 		command: `${ baseUsage } ${ name }`,
 		env_id: opt.env.id,
 		org_id: opt.app.organization.id,
+		org_sfid: opt.app.organization.salesforceId,
 		skip_confirm: Boolean( opt.skipConfirmation ),
 		variable_name: name,
 	};

--- a/src/bin/vip-config-envvar-get-all.js
+++ b/src/bin/vip-config-envvar-get-all.js
@@ -43,6 +43,7 @@ export async function getAllEnvVarsCommand( arg, opt ) {
 		env_id: opt.env.id,
 		format: opt.format,
 		org_id: opt.app.organization.id,
+		org_sfid: opt.app.organization.salesforceId,
 	};
 
 	debug( `Request: Get all environment variables for ${ getEnvContext( opt.app, opt.env ) }` );

--- a/src/bin/vip-config-envvar-get.js
+++ b/src/bin/vip-config-envvar-get.js
@@ -32,6 +32,7 @@ export async function getEnvVarCommand( arg, opt ) {
 		command: `${ baseUsage } ${ name }`,
 		env_id: opt.env.id,
 		org_id: opt.app.organization.id,
+		org_sfid: opt.app.organization.salesforceId,
 		variable_name: name,
 	};
 

--- a/src/bin/vip-config-envvar-list.js
+++ b/src/bin/vip-config-envvar-list.js
@@ -31,6 +31,7 @@ export async function listEnvVarsCommand( arg, opt ) {
 		env_id: opt.env.id,
 		format: opt.format,
 		org_id: opt.app.organization.id,
+		org_sfid: opt.app.organization.salesforceId,
 	};
 
 	debug( `Request: list environment variables for ${ getEnvContext( opt.app, opt.env ) }` );

--- a/src/bin/vip-config-envvar-set.js
+++ b/src/bin/vip-config-envvar-set.js
@@ -39,6 +39,7 @@ export async function setEnvVarCommand( arg, opt ) {
 		env_id: opt.env.id,
 		from_file: Boolean( opt.fromFile ),
 		org_id: opt.app.organization.id,
+		org_sfid: opt.app.organization.salesforceId,
 		skip_confirm: Boolean( opt.skipConfirmation ),
 		variable_name: name,
 	};

--- a/src/bin/vip-logs.js
+++ b/src/bin/vip-logs.js
@@ -130,6 +130,7 @@ function getBaseTrackingParams( opt ) {
 	return {
 		command: 'vip logs',
 		org_id: opt.app.organization.id,
+		org_sfid: opt.app.organization.salesforceId,
 		app_id: opt.app.id,
 		env_id: opt.env.id,
 		type: opt.type,

--- a/src/bin/vip-slowlogs.ts
+++ b/src/bin/vip-slowlogs.ts
@@ -138,6 +138,7 @@ function getBaseTrackingParams( opt: GetBaseTrackingParamsOptions ): BaseTrackin
 	return {
 		command: 'vip slowlogs',
 		org_id: opt.app.organization.id,
+		org_sfid: opt.app.organization.salesforceId,
 		app_id: opt.app.id,
 		env_id: opt.env.id,
 		limit: opt.limit,

--- a/src/lib/analytics/clients/pendo.ts
+++ b/src/lib/analytics/clients/pendo.ts
@@ -46,6 +46,7 @@ export default class Pendo implements AnalyticsClient {
 			...this.context,
 			org_id: eventProps.org_slug,
 			org_slug: eventProps.org_slug,
+			org_sfid: eventProps.org_sfid,
 			userAgent: this.userAgent,
 			userId: this.userId,
 		};
@@ -69,6 +70,7 @@ export default class Pendo implements AnalyticsClient {
 			timestamp: Date.now(),
 			type: 'track',
 			visitorId: `${ this.context.userId as string }`,
+			accountId: `${ this.context.org_sfid as string }`,
 		};
 
 		debug( 'send()', body );

--- a/src/lib/api/user.ts
+++ b/src/lib/api/user.ts
@@ -10,6 +10,7 @@ const QUERY_CURRENT_USER = gql`
 		me {
 			id
 			displayName
+			trackingUserId
 			isVIP
 			organizationRoles {
 				nodes {

--- a/src/lib/app-slowlogs/types.ts
+++ b/src/lib/app-slowlogs/types.ts
@@ -4,6 +4,7 @@ export interface DefaultOptions {
 		organization: {
 			id: number;
 			name: string;
+			salesforceId: string;
 		};
 	};
 	env: {
@@ -35,6 +36,7 @@ export interface GetBaseTrackingParamsOptions extends DefaultOptions {
 export interface BaseTrackingParams extends Record< string, unknown > {
 	command: string;
 	org_id: number;
+	org_sfid: string;
 	app_id: number;
 	env_id: number;
 	limit: number;


### PR DESCRIPTION
## For Automatticians!

Some pendo tracking is still being saved without the `accountId`. It should use the `salesforceId` from the organization.

## Pull request checklist

- [ ] Update [SETUP.md](https://github.com/Automattic/vip-cli/blob/trunk/docs/SETUP.md#list-of-environmental-variables) with any new environmental variables.
- [ ] Update [the documentation](https://github.com/Automattic/vip-cli/blob/trunk/docs).
- [ ] [Manually test](https://github.com/Automattic/vip-cli/blob/trunk/docs/TESTING.md#manual-testing) the relevant changes.
- [ ] Follow the [pull request checklist](https://github.com/Automattic/vip-cli/blob/trunk/docs/RELEASING.md#new-pull-requests)
- [ ] Add/update [automated tests](https://github.com/Automattic/vip-cli/blob/trunk/docs/TESTING.md#automated-testing) as needed.

## New release checklist

- [ ] [Automated tests](https://github.com/Automattic/vip-cli/blob/trunk/docs/TESTING.md#automated-testing) pass.
- [ ] The [Preparing for release checklist](https://github.com/Automattic/vip-cli/blob/trunk/docs/RELEASING.md#preparing-for-release) is completed.

## Steps to Test

Outline the steps to test and verify the PR here.

Example:

1. Check out PR.
1. Run `npm run build`
1. Run `node ./dist/bin/vip @SITE_ID.production slowlogs`
1. Verify if will send the salesforceId as the accountId on pendoTrack event
