### PR TITLE
fix(dev-env): clear proxy cache before startup and after shutdown

### DIFF
--- a/src/lib/dev-environment/dev-environment-core.ts
+++ b/src/lib/dev-environment/dev-environment-core.ts
@@ -6,7 +6,7 @@ import { print } from 'graphql';
 import { dockerComposify } from 'lando/lib/utils';
 import fetch from 'node-fetch';
 import fs from 'node:fs';
-import { cp, readdir } from 'node:fs/promises';
+import { cp, readdir, unlink } from 'node:fs/promises';
 import path from 'node:path';
 import semver from 'semver';
 import { v4 as uuid } from 'uuid';
@@ -28,6 +28,7 @@ import {
 	landoLogs,
 	LandoLogsOptions,
 	LandoExecOptions,
+	getProxyContainer,
 } from './dev-environment-lando';
 import { AppEnvironment } from '../../graphqlTypes';
 import app from '../api/app';
@@ -137,6 +138,17 @@ export async function startEnvironment(
 		updated = await maybeUpdateWordPressImage( lando, slug );
 	}
 	updated = updated || ( await maybeUpdateVersion( lando, slug ) );
+
+	const proxyContainer = await getProxyContainer( lando );
+	if ( ! proxyContainer?.State.Running ) {
+		try {
+			await unlink(
+				path.join( lando.config.userConfRoot, 'cache', lando.config.proxyCache ?? 'proxyCache' )
+			);
+		} catch {
+			// Swallow
+		}
+	}
 
 	if ( options.skipRebuild && ! updated ) {
 		await landoStart( lando, instancePath );

--- a/src/lib/dev-environment/dev-environment-core.ts
+++ b/src/lib/dev-environment/dev-environment-core.ts
@@ -6,7 +6,7 @@ import { print } from 'graphql';
 import { dockerComposify } from 'lando/lib/utils';
 import fetch from 'node-fetch';
 import fs from 'node:fs';
-import { cp, readdir, unlink } from 'node:fs/promises';
+import { cp, readdir } from 'node:fs/promises';
 import path from 'node:path';
 import semver from 'semver';
 import { v4 as uuid } from 'uuid';
@@ -29,6 +29,7 @@ import {
 	LandoLogsOptions,
 	LandoExecOptions,
 	getProxyContainer,
+	removeProxyCache,
 } from './dev-environment-lando';
 import { AppEnvironment } from '../../graphqlTypes';
 import app from '../api/app';
@@ -141,13 +142,7 @@ export async function startEnvironment(
 
 	const proxyContainer = await getProxyContainer( lando );
 	if ( ! proxyContainer?.State.Running ) {
-		try {
-			await unlink(
-				path.join( lando.config.userConfRoot, 'cache', lando.config.proxyCache ?? 'proxyCache' )
-			);
-		} catch {
-			// Swallow
-		}
+		await removeProxyCache( lando );
 	}
 
 	if ( options.skipRebuild && ! updated ) {

--- a/src/lib/dev-environment/dev-environment-lando.ts
+++ b/src/lib/dev-environment/dev-environment-lando.ts
@@ -1,5 +1,6 @@
 import chalk from 'chalk';
 import debugLib from 'debug';
+import Dockerode from 'dockerode';
 import App, { type ScanResult } from 'lando/lib/app';
 import { buildConfig } from 'lando/lib/bootstrap';
 import Lando, { type LandoConfig } from 'lando/lib/lando';
@@ -711,6 +712,21 @@ export async function landoShell(
 	} );
 }
 
+export async function getProxyContainer(
+	lando: Lando
+): Promise< Dockerode.ContainerInspectInfo | null > {
+	const proxyContainerName = lando.config.proxyContainer as string;
+
+	const { docker } = lando.engine;
+	const containers = await docker.listContainers( { all: true } );
+	if ( containers.some( container => container.Names.includes( `/${ proxyContainerName }` ) ) ) {
+		const container = docker.getContainer( proxyContainerName );
+		return container.inspect();
+	}
+
+	return null;
+}
+
 /**
  * Sometimes the proxy network seems to disapper leaving only orphant stopped proxy container.
  * It seems to happen while restarting/powering off computer. This container would then failed
@@ -720,25 +736,11 @@ export async function landoShell(
  * can safely add a network and a new proxy container.
  */
 async function ensureNoOrphantProxyContainer( lando: Lando ): Promise< void > {
-	const proxyContainerName = lando.config.proxyContainer as string;
-
-	const docker = lando.engine.docker;
-	const containers = await docker.listContainers( { all: true } );
-	const proxyContainerExists = containers.some( container =>
-		container.Names.includes( `/${ proxyContainerName }` )
-	);
-
-	if ( ! proxyContainerExists ) {
-		return;
+	const proxyContainer = await getProxyContainer( lando );
+	if ( proxyContainer && ! proxyContainer.State.Running ) {
+		const container = lando.engine.docker.getContainer( proxyContainer.Name );
+		await container.remove();
 	}
-
-	const proxyContainer = docker.getContainer( proxyContainerName );
-	const status = await proxyContainer.inspect();
-	if ( status.State.Running ) {
-		return;
-	}
-
-	await proxyContainer.remove();
 }
 
 export function validateDockerInstalled( lando: Lando ): void {

--- a/src/lib/dev-environment/dev-environment-lando.ts
+++ b/src/lib/dev-environment/dev-environment-lando.ts
@@ -6,7 +6,7 @@ import Lando, { type LandoConfig } from 'lando/lib/lando';
 import landoUtils, { type AppInfo } from 'lando/plugins/lando-core/lib/utils';
 import landoBuildTask from 'lando/plugins/lando-tooling/lib/build';
 import { lookup } from 'node:dns/promises';
-import { mkdir, rename } from 'node:fs/promises';
+import { mkdir, rename, unlink } from 'node:fs/promises';
 import { tmpdir, userInfo } from 'node:os';
 import path, { dirname } from 'node:path';
 import { satisfies } from 'semver';
@@ -63,7 +63,7 @@ async function getLandoConfig(): Promise< LandoConfig > {
 
 	try {
 		await mkdir( fakeHomeDir, { recursive: true } );
-	} catch ( err ) {
+	} catch {
 		// Ignore
 	}
 
@@ -312,6 +312,14 @@ async function cleanUpLandoProxy( lando: Lando ): Promise< void > {
 			await proxy.remove( { force: true } );
 		} catch ( err ) {
 			debug( 'Error removing proxy container: %s', ( err as Error ).message );
+		}
+
+		try {
+			await unlink(
+				path.join( lando.config.userConfRoot, 'cache', lando.config.proxyCache ?? 'proxyCache' )
+			);
+		} catch {
+			// Swallow
 		}
 	}
 }

--- a/src/lib/dev-environment/dev-environment-lando.ts
+++ b/src/lib/dev-environment/dev-environment-lando.ts
@@ -305,6 +305,15 @@ async function getBridgeNetwork( lando: Lando ): Promise< NetworkInspectInfo | n
 	}
 }
 
+export async function removeProxyCache( lando: Lando ): Promise< void > {
+	const { userConfRoot, proxyCache } = lando.config;
+	try {
+		await unlink( path.join( userConfRoot, 'cache', proxyCache ?? 'proxyCache' ) );
+	} catch {
+		// Swallow
+	}
+}
+
 async function cleanUpLandoProxy( lando: Lando ): Promise< void > {
 	const network = await getBridgeNetwork( lando );
 	if ( network?.Containers && Object.keys( network.Containers ).length === 1 ) {
@@ -315,13 +324,7 @@ async function cleanUpLandoProxy( lando: Lando ): Promise< void > {
 			debug( 'Error removing proxy container: %s', ( err as Error ).message );
 		}
 
-		try {
-			await unlink(
-				path.join( lando.config.userConfRoot, 'cache', lando.config.proxyCache ?? 'proxyCache' )
-			);
-		} catch {
-			// Swallow
-		}
+		await removeProxyCache( lando );
 	}
 }
 
@@ -738,7 +741,10 @@ export async function getProxyContainer(
 async function ensureNoOrphantProxyContainer( lando: Lando ): Promise< void > {
 	const proxyContainer = await getProxyContainer( lando );
 	if ( proxyContainer && ! proxyContainer.State.Running ) {
-		const container = lando.engine.docker.getContainer( proxyContainer.Name );
+		const containerName = proxyContainer.Name.startsWith( '/' )
+			? proxyContainer.Name.slice( 1 )
+			: proxyContainer.Name;
+		const container = lando.engine.docker.getContainer( containerName );
 		await container.remove();
 	}
 }

--- a/types/lando/lib/lando.d.ts
+++ b/types/lando/lib/lando.d.ts
@@ -43,6 +43,8 @@ export interface LandoConfig extends Record< string, unknown > {
 
 	tooling?: Record< string, Record< string, unknown > >;
 	services?: Record< string, LandoService >;
+
+	proxyCache?: string;
 }
 
 export interface LandoTask {


### PR DESCRIPTION
## Description

Lando caches proxy ports between runs. However, if one of the cached ports becomes unavailable, Lando may still use the cached value instead of doing the port scan. As a result, it may attempt to assign a busy port to Traefik, and this will result in a failure.

Fixes: #2414

## Pull request checklist

- [ ] Update [SETUP.md](https://github.com/Automattic/vip-cli/blob/trunk/docs/SETUP.md#list-of-environmental-variables) with any new environmental variables.
- [ ] Update [the documentation](https://github.com/Automattic/vip-cli/blob/trunk/docs).
- [x] [Manually test](https://github.com/Automattic/vip-cli/blob/trunk/docs/TESTING.md#manual-testing) the relevant changes.
- [x] Follow the [pull request checklist](https://github.com/Automattic/vip-cli/blob/trunk/docs/RELEASING.md#new-pull-requests)
- [ ] Add/update [automated tests](https://github.com/Automattic/vip-cli/blob/trunk/docs/TESTING.md#automated-testing) as needed.

## New release checklist

- [ ] [Automated tests](https://github.com/Automattic/vip-cli/blob/trunk/docs/TESTING.md#automated-testing) pass.
- [ ] The [Preparing for release checklist](https://github.com/Automattic/vip-cli/blob/trunk/docs/RELEASING.md#preparing-for-release) is completed.

## Steps to Test

1. Make sure all environments are stopped.
2. Update `~/.local/share/vip/lando/cache/proxyCache` to `{"http":"80","https":"444"}` (provided that the default proxy ports are 80 and 443).
3. Run a web server on port 80 (like [dummyhttp](https://github.com/svenstaro/dummyhttp))
4. Start an environment.
