### PR TITLE
Remove MD5 requirement restrictions for URL imports in vip-import-sql

### DIFF
--- a/__tests__/bin/vip-import-sql.js
+++ b/__tests__/bin/vip-import-sql.js
@@ -210,28 +210,10 @@ describe( 'vip-import-sql', () => {
 		} );
 
 		describe( 'URL imports', () => {
-			it( 'fails if MD5 is not provided for URL import', async () => {
-				const url = 'https://example.com/dump.sql';
-				await expect( gates( opts.app, opts.env, url, true ) ).rejects.toThrow(
-					'MD5 hash is required when importing from a URL. Please provide the --md5 parameter with a valid MD5 hash of the remote file.'
-				);
-			} );
-
 			it( 'fails if MD5 is invalid for URL import', async () => {
 				const url = 'https://example.com/dump.sql';
 				await expect( gates( opts.app, opts.env, url, true, 'invalid-md5' ) ).rejects.toThrow(
 					'The provided MD5 hash is invalid. It should be a 32-character hexadecimal string.'
-				);
-			} );
-
-			it( 'fails if search/replace is provided with URL import', async () => {
-				const url = 'https://example.com/dump.sql';
-				await expect(
-					gates( opts.app, opts.env, url, true, 'b5b39269e9105d6e1e9cd50ff54e6282', [
-						'search,replace',
-					] )
-				).rejects.toThrow(
-					'Search and replace operations are not supported when importing from a URL. Please remove the --search-replace option.'
 				);
 			} );
 

--- a/src/bin/vip-import-sql.js
+++ b/src/bin/vip-import-sql.js
@@ -118,35 +118,11 @@ function isValidMd5( md5 ) {
  * @param {string} fileNameOrURL
  * @param {boolean} isUrl
  * @param {string|null} md5
- * @param searchReplace
  */
 // eslint-disable-next-line complexity
-export async function gates(
-	app,
-	env,
-	fileNameOrURL,
-	isUrl = false,
-	md5 = null,
-	searchReplace = []
-) {
+export async function gates( app, env, fileNameOrURL, isUrl = false, md5 = null ) {
 	const { id: envId, appId } = env;
 	const track = trackEventWithEnv.bind( null, appId, envId );
-
-	if ( isUrl ) {
-		if ( ! md5 ) {
-			await track( 'import_sql_command_error', { error_type: 'missing-md5' } );
-			exit.withError(
-				'MD5 hash is required when importing from a URL. Please provide the --md5 parameter with a valid MD5 hash of the remote file.'
-			);
-		}
-
-		if ( searchReplace.length > 0 ) {
-			await track( 'import_sql_command_error', { error_type: 'search-replace-with-url' } );
-			exit.withError(
-				'Search and replace operations are not supported when importing from a URL. Please remove the --search-replace option.'
-			);
-		}
-	}
 
 	if ( md5 && ! isValidMd5( md5 ) ) {
 		await track( 'import_sql_command_error', { error_type: 'invalid-md5' } );
@@ -268,8 +244,7 @@ const examples = [
 	},
 	// URL import
 	{
-		usage:
-			'vip @example-app.develop import sql https://example.org/file.sql --md5 b5b39269e9105d6e1e9cd50ff54e6282',
+		usage: 'vip @example-app.develop import sql https://example.org/file.sql',
 		description:
 			'Import a remote SQL database backup file from the URL with MD5 hash verification to the develop environment of the "example-app" application.',
 	},
@@ -483,7 +458,7 @@ void command( {
 	)
 	.option(
 		'md5',
-		'MD5 hash of the remote SQL file for verification. Required when importing from a URL.'
+		'MD5 hash of the remote SQL file for verification. If not provided, the verification will not be performed.'
 	)
 	.examples( examples )
 	// eslint-disable-next-line complexity
@@ -521,7 +496,7 @@ void command( {
 		await track( 'import_sql_command_execute', { is_url: isUrl } );
 
 		// halt operation of the import based on some rules
-		await gates( app, env, fileNameOrURL, isUrl, md5, searchReplace );
+		await gates( app, env, fileNameOrURL, isUrl, md5 );
 
 		// Log summary of import details
 		const domain = env?.primaryDomain?.name ? env.primaryDomain.name : `#${ env.id }`;


### PR DESCRIPTION
## Description

This PR simplifies the URL import functionality in the `import-sql` command by removing the mandatory MD5 hash requirement when importing from URLs. Previously, users were required to provide an MD5 hash for URL imports, which created unnecessary friction in the import process.

The MD5 parameter is now treated as optional verification rather than a mandatory requirement, allowing users to import SQL files from URLs without needing to calculate or provide hash values. If provided, the MD5 of the file is verified prior to importing.


## Pull request checklist

- [ ] Update [SETUP.md](https://github.com/Automattic/vip-cli/blob/trunk/docs/SETUP.md#list-of-environmental-variables) with any new environmental variables.
- [ ] Update [the documentation](https://github.com/Automattic/vip-cli/blob/trunk/docs).
- [ ] [Manually test](https://github.com/Automattic/vip-cli/blob/trunk/docs/TESTING.md#manual-testing) the relevant changes.
- [ ] Follow the [pull request checklist](https://github.com/Automattic/vip-cli/blob/trunk/docs/RELEASING.md#new-pull-requests)
- [ ] Add/update [automated tests](https://github.com/Automattic/vip-cli/blob/trunk/docs/TESTING.md#automated-testing) as needed.

## New release checklist

- [ ] [Automated tests](https://github.com/Automattic/vip-cli/blob/trunk/docs/TESTING.md#automated-testing) pass.
- [ ] The [Preparing for release checklist](https://github.com/Automattic/vip-cli/blob/trunk/docs/RELEASING.md#preparing-for-release) is completed.

## Steps to Test

Outline the steps to test and verify the PR here.

Example:

1. Check out PR.
1. Run `npm run build`
1. Run `./dist/bin/vip-cookies.js nom`
1. Verify cookies are delicious.
