### PR TITLE
Fix argument quoting for CLI options with equals syntax

### DIFF
--- a/__tests__/lib/cli/format.js
+++ b/__tests__/lib/cli/format.js
@@ -37,7 +37,11 @@ describe( 'utils/cli/format', () => {
 			},
 			{
 				input: [ '--foo=bar1 "bar2" "bar3"' ],
-				expected: [ '"--foo=bar1 \\"bar2\\" \\"bar3\\""' ],
+				expected: [ '--foo="bar1 \\"bar2\\" \\"bar3\\""' ],
+			},
+			{
+				input: [ 'post', 'list', '--posts_per_page=1' ],
+				expected: [ '"post"', '"list"', '--posts_per_page="1"' ],
 			},
 			{
 				input: [ '--foo', 'bar1 "bar2" "bar3"' ],

--- a/src/lib/cli/format.ts
+++ b/src/lib/cli/format.ts
@@ -140,7 +140,13 @@ export function keyValue( values: Tuple[] ): string {
 }
 
 export function requoteArgs( args: string[] ): string[] {
-	return args.map( arg => `"${ arg.replace( /"/g, '\\"' ) }"` );
+	return args.map( arg => {
+		if ( arg.startsWith( '--' ) && arg.includes( '=' ) ) {
+			return arg.replace( /"/g, '\\"' ).replace( /^--([^=]*)=(.*)$/, '--$1="$2"' );
+		}
+
+		return `"${ arg.replace( /"/g, '\\"' ) }"`;
+	} );
 }
 
 export function capitalize( str: unknown ): string {


### PR DESCRIPTION
## Description

This PR improves the `requoteArgs` function to properly handle CLI arguments that use the `--option=value` syntax.

### Changes
- Modified `requoteArgs` to detect arguments starting with `--` and containing `=`
- For these arguments, quotes are now placed around the value portion only (`--option="value"`) instead of the entire argument (`"--option=value"`)

### Example
- Before: `"--foo=bar1 \"bar2\" \"bar3\""`
- After: `--foo="bar1 \"bar2\" \"bar3\""`

This ensures CLI arguments maintain their proper syntax while still escaping quotes in values.


## Pull request checklist

- [ ] Update [SETUP.md](https://github.com/Automattic/vip-cli/blob/trunk/docs/SETUP.md#list-of-environmental-variables) with any new environmental variables.
- [ ] Update [the documentation](https://github.com/Automattic/vip-cli/blob/trunk/docs).
- [ ] [Manually test](https://github.com/Automattic/vip-cli/blob/trunk/docs/TESTING.md#manual-testing) the relevant changes.
- [ ] Follow the [pull request checklist](https://github.com/Automattic/vip-cli/blob/trunk/docs/RELEASING.md#new-pull-requests)
- [ ] Add/update [automated tests](https://github.com/Automattic/vip-cli/blob/trunk/docs/TESTING.md#automated-testing) as needed.

## New release checklist

- [ ] [Automated tests](https://github.com/Automattic/vip-cli/blob/trunk/docs/TESTING.md#automated-testing) pass.
- [ ] The [Preparing for release checklist](https://github.com/Automattic/vip-cli/blob/trunk/docs/RELEASING.md#preparing-for-release) is completed.

## Steps to Test

Outline the steps to test and verify the PR here.

Example:

1. Check out PR.
1. Run `npm run build`
1. Run `./dist/bin/vip-cookies.js nom`
1. Verify cookies are delicious.
