### PR TITLE
Prevent raw bytes from JSON payloads from being written to a file

### DIFF
--- a/src/lib/media-import/status.ts
+++ b/src/lib/media-import/status.ts
@@ -147,10 +147,10 @@ function buildFileErrors(
 
 	let errorString = '';
 	for ( const fileError of fileErrors ) {
-		errorString += `File Name: ${ fileError?.fileName ?? 'N/A' }`;
-		errorString += `\n\nErrors:\n\t- ${
+		errorString += `File Name: ${ JSON.stringify( fileError?.fileName ?? 'N/A' ) }`;
+		errorString += `\n\nErrors:\n\t- ${ JSON.stringify(
 			fileError?.errors?.join( ', ' ) ?? 'unknown error'
-		}\n\n\n\n`;
+		) }\n\n\n\n`;
 	}
 	return errorString;
 }


### PR DESCRIPTION
## Description

As per the title, just a quick filter to ensure that we escape bytes before writing it to a string by using `JSON.stringify()`

## Changelog Description

### Fixed

- Prevent raw bytes from JSON payloads from being written to a file to prevent accidental execution.

## Pull request checklist

- [ ] Update [SETUP.md](https://github.com/Automattic/vip-cli/blob/trunk/docs/SETUP.md#list-of-environmental-variables) with any new environmental variables.
- [ ] Update [the documentation](https://github.com/Automattic/vip-cli/blob/trunk/docs).
- [ ] [Manually test](https://github.com/Automattic/vip-cli/blob/trunk/docs/TESTING.md#manual-testing) the relevant changes.
- [ ] Follow the [pull request checklist](https://github.com/Automattic/vip-cli/blob/trunk/docs/RELEASING.md#new-pull-requests)
- [ ] Add/update [automated tests](https://github.com/Automattic/vip-cli/blob/trunk/docs/TESTING.md#automated-testing) as needed.

## New release checklist

- [ ] [Automated tests](https://github.com/Automattic/vip-cli/blob/trunk/docs/TESTING.md#automated-testing) pass.
- [ ] The [Preparing for release checklist](https://github.com/Automattic/vip-cli/blob/trunk/docs/RELEASING.md#preparing-for-release) is completed.

## Steps to Test

We apparently have no automated tests for this function. I'll write one.
