### PR TITLE
feat(dev-env): add some logging to `DevEnvSyncSQLCommand`

### DIFF
--- a/src/commands/dev-env-sync-sql.ts
+++ b/src/commands/dev-env-sync-sql.ts
@@ -2,6 +2,7 @@
 
 import { replace } from '@automattic/vip-search-replace';
 import chalk from 'chalk';
+import debugLib from 'debug';
 import fs from 'fs';
 import Lando from 'lando';
 import { pipeline } from 'node:stream/promises';
@@ -16,6 +17,8 @@ import { unzipFile } from '../lib/client-file-uploader';
 import { fixMyDumperTransform, getSqlDumpDetails, SqlDumpType } from '../lib/database';
 import { makeTempDir } from '../lib/utils';
 import { getReadInterface } from '../lib/validations/line-by-line';
+
+const debug = debugLib( '@automattic/vip:bin:dev-environment' );
 
 /**
  * Replaces the domain in the given URL
@@ -203,6 +206,12 @@ export class DevEnvSyncSQLCommand {
 
 		const primaryUrl = networkSites.find( site => site?.blogId === 1 )?.homeUrl;
 		const primaryDomain = primaryUrl ? new URL( primaryUrl ).hostname : '';
+		debug(
+			'Network sites: %j, primary URL: %s, primary domain: %s',
+			networkSites,
+			primaryUrl,
+			primaryDomain
+		);
 
 		for ( const site of networkSites ) {
 			if ( ! site?.blogId || site.blogId === 1 ) continue;
@@ -343,6 +352,7 @@ DROP PROCEDURE vip_sync_update_blog_domains;
 		try {
 			console.log( 'Extracting site urls from the SQL file...' );
 			this.siteUrls = await extractSiteUrls( this.sqlFile );
+			debug( 'Extracted site URLs: %j', this.siteUrls );
 		} catch ( err ) {
 			const error = err as Error;
 			await this.track( 'error', {

--- a/src/commands/dev-env-sync-sql.ts
+++ b/src/commands/dev-env-sync-sql.ts
@@ -208,7 +208,7 @@ export class DevEnvSyncSQLCommand {
 		const primaryDomain = primaryUrl ? new URL( primaryUrl ).hostname : '';
 		debug(
 			'Network sites: %j, primary URL: %s, primary domain: %s',
-			networkSites,
+			networkSites.map( site => ( { blogId: site?.blogId, homeUrl: site?.homeUrl } ) ),
 			primaryUrl,
 			primaryDomain
 		);


### PR DESCRIPTION
## Description

This PR adds logging to the `DevEnvSyncSQLCommand` to facilitate easier troubleshooting of search/replace issues.

## Changelog Description

### Added

- Logging to the `vip dev-env sync sql` command

## Pull request checklist

- [ ] Update [SETUP.md](https://github.com/Automattic/vip-cli/blob/trunk/docs/SETUP.md#list-of-environmental-variables) with any new environmental variables.
- [ ] Update [the documentation](https://github.com/Automattic/vip-cli/blob/trunk/docs).
- [x] [Manually test](https://github.com/Automattic/vip-cli/blob/trunk/docs/TESTING.md#manual-testing) the relevant changes.
- [x] Follow the [pull request checklist](https://github.com/Automattic/vip-cli/blob/trunk/docs/RELEASING.md#new-pull-requests)
- [ ] Add/update [automated tests](https://github.com/Automattic/vip-cli/blob/trunk/docs/TESTING.md#automated-testing) as needed.

## New release checklist

- [x] [Automated tests](https://github.com/Automattic/vip-cli/blob/trunk/docs/TESTING.md#automated-testing) pass.
- [ ] The [Preparing for release checklist](https://github.com/Automattic/vip-cli/blob/trunk/docs/RELEASING.md#preparing-for-release) is completed.

## Steps to Test

Run `vip dev-env sync sql` with `--debug=@automattic/vip:bin:dev-environment`.
