### PR TITLE
fix(dev-env): make URL extraction less error-prone

### DIFF
--- a/__tests__/commands/dev-env-sync-sql.ts
+++ b/__tests__/commands/dev-env-sync-sql.ts
@@ -4,7 +4,7 @@ import Lando from 'lando';
 import path from 'path';
 
 import { DevEnvImportSQLCommand } from '../../src/commands/dev-env-import-sql';
-import { DevEnvSyncSQLCommand } from '../../src/commands/dev-env-sync-sql';
+import { DevEnvSyncSQLCommand, findSiteHomeUrl } from '../../src/commands/dev-env-sync-sql';
 import { ExportSQLCommand } from '../../src/commands/export-sql';
 import * as clientFileUploader from '../../src/lib/client-file-uploader';
 
@@ -189,5 +189,19 @@ describe( 'commands/DevEnvSyncSQLCommand', () => {
 			expect( searchReplaceSpy ).toHaveBeenCalled();
 			expect( importSpy ).toHaveBeenCalled();
 		} );
+	} );
+} );
+
+describe( 'findSiteHomeUrl', () => {
+	it.each( [
+		[ `'siteurl', 'https://test.go-vip.com'`, 'https://test.go-vip.com' ],
+		[ `"siteurl", "https://test.go-vip.com"`, 'https://test.go-vip.com' ],
+		[ `'siteurl', "https://test.go-vip.com"`, null ],
+		[ `'home',    'HtTp://test.go-vip.com'`, 'HtTp://test.go-vip.com' ],
+		[ `'home','HTTP://test.go-vip.com'`, 'HTTP://test.go-vip.com' ],
+		[ `'home','Photo: istockphoto.com'`, null ],
+	] )( 'should return the correct home URL for %s', ( input, expected ) => {
+		const actual = findSiteHomeUrl( input );
+		expect( actual ).toBe( expected );
 	} );
 } );

--- a/src/commands/dev-env-sync-sql.ts
+++ b/src/commands/dev-env-sync-sql.ts
@@ -48,7 +48,7 @@ function stripProtocol( url: string ): string {
  * @return Site home url. null if not found
  */
 function findSiteHomeUrl( sql: string ): string | null {
-	const regex = /(['"])(?:siteurl|home)\1,\s?\1([Hh][Tt][Tt][Pp][Ss]?:\/\/.+?)\1/;
+	const regex = /(['"])(?:siteurl|home)\1,\s*\1([Hh][Tt][Tt][Pp][Ss]?:\/\/.+?)\1/;
 	const url = regex.exec( sql )?.[ 2 ] ?? '';
 	try {
 		const parsed = new URL( url );

--- a/src/commands/dev-env-sync-sql.ts
+++ b/src/commands/dev-env-sync-sql.ts
@@ -48,11 +48,11 @@ function stripProtocol( url: string ): string {
  * @return Site home url. null if not found
  */
 function findSiteHomeUrl( sql: string ): string | null {
-	const regex = `['"](siteurl|home)['"],\\s?['"](.*?)['"]`;
-	const url = sql.match( regex )?.[ 2 ] || '';
+	const regex = /(['"])(?:siteurl|home)\1,\s?\1([Hh][Tt][Tt][Pp][Ss]?:\/\/.+?)\1/;
+	const url = regex.exec( sql )?.[ 2 ] ?? '';
 	try {
-		new URL( url );
-		return url;
+		const parsed = new URL( url );
+		return parsed.hostname ? url : null;
 	} catch {
 		return null;
 	}

--- a/src/commands/dev-env-sync-sql.ts
+++ b/src/commands/dev-env-sync-sql.ts
@@ -47,7 +47,7 @@ function stripProtocol( url: string ): string {
  * @param sql A line in a SQL file
  * @return Site home url. null if not found
  */
-function findSiteHomeUrl( sql: string ): string | null {
+export function findSiteHomeUrl( sql: string ): string | null {
 	const regex = /(['"])(?:siteurl|home)\1,\s*\1([Hh][Tt][Tt][Pp][Ss]?:\/\/.+?)\1/;
 	const url = regex.exec( sql )?.[ 2 ] ?? '';
 	try {


### PR DESCRIPTION
## Description

This PR makes the `extractSiteUrls()` function less error-prone by ensuring that the URL always starts with `http://` or `https://` and that the URL domain is not empty.

Related: #2439
Related: PLTFRM-1243

## Changelog Description

### Fixed

- false positives during URL extraction in `vip dev-env sync sql`

## Pull request checklist

- [ ] Update [SETUP.md](https://github.com/Automattic/vip-cli/blob/trunk/docs/SETUP.md#list-of-environmental-variables) with any new environmental variables.
- [ ] Update [the documentation](https://github.com/Automattic/vip-cli/blob/trunk/docs).
- [x] [Manually test](https://github.com/Automattic/vip-cli/blob/trunk/docs/TESTING.md#manual-testing) the relevant changes.
- [x] Follow the [pull request checklist](https://github.com/Automattic/vip-cli/blob/trunk/docs/RELEASING.md#new-pull-requests)
- [x] Add/update [automated tests](https://github.com/Automattic/vip-cli/blob/trunk/docs/TESTING.md#automated-testing) as needed.

## New release checklist

- [ ] [Automated tests](https://github.com/Automattic/vip-cli/blob/trunk/docs/TESTING.md#automated-testing) pass.
- [ ] The [Preparing for release checklist](https://github.com/Automattic/vip-cli/blob/trunk/docs/RELEASING.md#preparing-for-release) is completed.

## Steps to Test

See #2439
