### PR TITLE
feat(dev-env): allow `latest` as WP version

### DIFF
--- a/src/lib/dev-environment/dev-environment-cli.ts
+++ b/src/lib/dev-environment/dev-environment-cli.ts
@@ -434,11 +434,15 @@ async function processWordPress(
 	const versions = await getVersionList();
 	if ( versions.length ) {
 		versions.sort( ( before, after ) => ( before.tag < after.tag ? 1 : -1 ) );
-		const match = versions.find( ( { tag } ) => tag === result.tag );
+		const match = versions.find( ( { prerelease, tag } ) =>
+			result.tag === 'latest' ? ! prerelease : tag === result.tag
+		);
 
-		if ( typeof match === 'undefined' ) {
+		if ( match === undefined ) {
 			throw new UserError( `Unknown or unsupported WordPress version: ${ result.tag }.` );
 		}
+
+		result.tag = match.tag;
 	}
 
 	debug( result );


### PR DESCRIPTION
## Description

See PLTFRM-1258 for background.

As a side effect, `--wordpress=latest` is now allowed as a command line parameter.

## Changelog Description

### Added

- Dev Env: support for `--wordpress=latest`

## Pull request checklist

- [ ] Update [SETUP.md](https://github.com/Automattic/vip-cli/blob/trunk/docs/SETUP.md#list-of-environmental-variables) with any new environmental variables.
- [ ] Update [the documentation](https://github.com/Automattic/vip-cli/blob/trunk/docs).
- [x] [Manually test](https://github.com/Automattic/vip-cli/blob/trunk/docs/TESTING.md#manual-testing) the relevant changes.
- [x] Follow the [pull request checklist](https://github.com/Automattic/vip-cli/blob/trunk/docs/RELEASING.md#new-pull-requests)
- [ ] Add/update [automated tests](https://github.com/Automattic/vip-cli/blob/trunk/docs/TESTING.md#automated-testing) as needed.

## New release checklist

- [ ] [Automated tests](https://github.com/Automattic/vip-cli/blob/trunk/docs/TESTING.md#automated-testing) pass.
- [ ] The [Preparing for release checklist](https://github.com/Automattic/vip-cli/blob/trunk/docs/RELEASING.md#preparing-for-release) is completed.

## Steps to Test

See PLTFRM-1258
