### PR TITLE
fix: drop superfluous `as unknown` casts

### DIFF
--- a/__tests__/commands/wp-ssh.ts
+++ b/__tests__/commands/wp-ssh.ts
@@ -105,7 +105,7 @@ describe( 'WPCommand', () => {
 
 				// Simulate the SSH connection closing right after the command is executed
 				dummyStream.emit( 'close' );
-			} ) as unknown as Client[ 'exec' ] );
+			} ) as Client[ 'exec' ] );
 
 			await cmd.run( 'plugin list' );
 
@@ -129,7 +129,7 @@ describe( 'WPCommand', () => {
 				callback: ( err: Error, stream: Stream ) => void
 			) => {
 				callback( new Error( 'ops!' ), dummyStream );
-			} ) as unknown as Client[ 'exec' ] );
+			} ) as Client[ 'exec' ] );
 
 			const result = cmd.run( 'plugin list' );
 
@@ -150,7 +150,7 @@ describe( 'WPCommand', () => {
 				// Simulate the SSH connection closing right after the command is executed
 				dummyStream.emit( 'exit', 23 );
 				dummyStream.emit( 'close' );
-			} ) as unknown as Client[ 'exec' ] );
+			} ) as Client[ 'exec' ] );
 
 			const result = cmd.run( 'plugin list' );
 

--- a/src/commands/export-sql.ts
+++ b/src/commands/export-sql.ts
@@ -387,9 +387,7 @@ export class ExportSQLCommand {
 			return await this.confirmEnoughStorageHook( job );
 		}
 
-		const storageAvailability = BackupStorageAvailability.createFromDbCopyJob(
-			job as unknown as Job
-		);
+		const storageAvailability = BackupStorageAvailability.createFromDbCopyJob( job );
 		return await storageAvailability.validateAndPromptDiskSpaceWarningForBackupImport();
 	}
 

--- a/src/lib/dev-environment/dev-environment-core.ts
+++ b/src/lib/dev-environment/dev-environment-core.ts
@@ -951,7 +951,7 @@ export function fetchVersionList(): Promise< WordPressTag[] > {
 	// TODO: remove this cast once the typings are fixed
 	const proxyAgent = createProxyAgent( url ) as unknown as Agent;
 	return fetch( url, { agent: proxyAgent ?? undefined } ).then(
-		res => res.json() as unknown as WordPressTag[]
+		res => res.json() as Promise< WordPressTag[] >
 	);
 }
 

--- a/src/lib/media-import/config.ts
+++ b/src/lib/media-import/config.ts
@@ -24,5 +24,5 @@ export async function getMediaImportConfig(): Promise< MediaImportConfig | null 
 		fetchPolicy: 'network-only',
 	} );
 
-	return response?.data?.mediaImportConfig as unknown as MediaImportConfig | null;
+	return response?.data?.mediaImportConfig ?? null;
 }

--- a/src/lib/media-import/status.ts
+++ b/src/lib/media-import/status.ts
@@ -363,9 +363,7 @@ Downloading errors details from ${ fileErrorsUrl }
 		progressTracker.print();
 
 		if ( results.failureDetails?.fileErrorsUrl ) {
-			await promptFailureDetailsDownload(
-				results.failureDetails.fileErrorsUrl as unknown as string
-			);
+			await promptFailureDetailsDownload( results.failureDetails.fileErrorsUrl );
 		} else if ( 'ABORTED' !== overallStatus ) {
 			// print report link expired if required
 			// do not print this message if the import was aborted


### PR DESCRIPTION
## Description

This PR removes `as unknown` casts from the codebase where they are unnecessary or can be replaced with a safe alternative.

The use of `as unknown` in TypeScript is often considered a "code smell" because it circumvents TypeScript's type safety mechanisms. While `unknown` itself is a type-safe alternative to `any`, chaining it with `as Type` effectively bypasses the compiler's checks:
* Disables type safety: Using `as unknown as Type` tells the compiler to trust the developer completely, even if the types are demonstrably incompatible. This eliminates the benefits of type checking for that specific operation.
* Hides errors: If the underlying value is not truly of `DesiredType`, this double assertion will not produce a compile-time error. Instead, it will lead to a runtime error when the code attempts to access properties or methods that do not exist on the actual type of value. This makes debugging more difficult as the error surfaces later in the development cycle.
* Indicates a design flaw: Frequent use of `as unknown as Type` can suggest that the developer does not fully understand the types involved, or that there's a design flaw in the code that makes proper type handling difficult.

## Changelog Description

### Fixed

- Removed unnecessary type casts to `unknown`

## Pull request checklist

- [ ] Update [SETUP.md](https://github.com/Automattic/vip-cli/blob/trunk/docs/SETUP.md#list-of-environmental-variables) with any new environmental variables.
- [ ] Update [the documentation](https://github.com/Automattic/vip-cli/blob/trunk/docs).
- [x] [Manually test](https://github.com/Automattic/vip-cli/blob/trunk/docs/TESTING.md#manual-testing) the relevant changes.
- [x] Follow the [pull request checklist](https://github.com/Automattic/vip-cli/blob/trunk/docs/RELEASING.md#new-pull-requests)
- [ ] Add/update [automated tests](https://github.com/Automattic/vip-cli/blob/trunk/docs/TESTING.md#automated-testing) as needed.

## New release checklist

- [x] [Automated tests](https://github.com/Automattic/vip-cli/blob/trunk/docs/TESTING.md#automated-testing) pass.
- [ ] The [Preparing for release checklist](https://github.com/Automattic/vip-cli/blob/trunk/docs/RELEASING.md#preparing-for-release) is completed.

## Steps to Test

CI must pass.
