### PR TITLE
fix: fields that are only assigned in the constructor should be "readonly"

### DIFF
--- a/src/commands/backup-db.ts
+++ b/src/commands/backup-db.ts
@@ -87,28 +87,26 @@ async function createBackupJob( appId: number, envId: number ) {
 
 // Library for a possible command in the future: vip backup db @app.env
 export class BackupDBCommand {
-	public app: App;
-	public env: AppEnvironment;
 	public job?: Job;
 	public jobStatus?: string;
 	public jobAge?: number;
 	public backupName?: string;
 	public silent?: boolean;
-	public steps = {
+	private readonly steps = {
 		PREPARE: 'prepare',
 		GENERATE: 'generate',
 	};
-	public track: CommandTracker;
-	private progressTracker: ProgressTracker;
+	private readonly progressTracker: ProgressTracker;
 
-	constructor( app: App, env: AppEnvironment, trackerFn: CommandTracker = async () => {} ) {
-		this.app = app;
-		this.env = env;
+	constructor(
+		private readonly app: App,
+		private readonly env: AppEnvironment,
+		private readonly track: CommandTracker = async () => {}
+	) {
 		this.progressTracker = new ProgressTracker( [
 			{ id: this.steps.PREPARE, name: 'Preparing for backup generation' },
 			{ id: this.steps.GENERATE, name: 'Generating backup' },
 		] );
-		this.track = trackerFn;
 	}
 
 	public log( msg: string ) {

--- a/src/commands/phpmyadmin.ts
+++ b/src/commands/phpmyadmin.ts
@@ -118,20 +118,18 @@ async function getPhpMyAdminStatus( appId: number, envId: number ): Promise< str
 }
 
 export class PhpMyAdminCommand {
-	private app: App;
-	private env: AppEnvironment;
 	private silent?: boolean;
-	private track: CommandTracker;
-	private steps = {
+	private readonly steps = {
 		ENABLE: 'enable',
 		GENERATE: 'generate',
 	};
-	private progressTracker: ProgressTracker;
+	private readonly progressTracker: ProgressTracker;
 
-	constructor( app: App, env: AppEnvironment, trackerFn: CommandTracker = async () => {} ) {
-		this.app = app;
-		this.env = env;
-		this.track = trackerFn;
+	constructor(
+		private readonly app: App,
+		private readonly env: AppEnvironment,
+		private readonly track: CommandTracker = async () => {}
+	) {
 		this.progressTracker = new ProgressTracker( [
 			{ id: this.steps.ENABLE, name: 'Enabling PHPMyAdmin for this environment' },
 			{ id: this.steps.GENERATE, name: 'Generating access link' },

--- a/src/commands/wp-ssh.ts
+++ b/src/commands/wp-ssh.ts
@@ -65,17 +65,12 @@ export class NonZeroExitCodeError extends Error {
 }
 
 export class WPCliCommandOverSSH {
-	private app: App;
-	private env: AppEnvironment;
-	private track: CommandTracker;
+	private readonly track: CommandTracker;
 
-	constructor( app: App, env: AppEnvironment ) {
-		this.app = app;
-		this.env = env;
-
+	constructor( private readonly app: App, private readonly env: AppEnvironment ) {
 		this.track = makeCommandTracker( 'wp', {
-			app: this.app.id,
-			env: this.env.id,
+			app: app.id,
+			env: env.id,
 			execution_type: 'ssh',
 		} );
 	}

--- a/src/lib/analytics/clients/pendo.ts
+++ b/src/lib/analytics/clients/pendo.ts
@@ -18,9 +18,9 @@ interface PendoOptions {
  * Pendo analytics client.
  */
 export default class Pendo implements AnalyticsClient {
-	private eventPrefix: string;
-	private userAgent: string;
-	private userId: string;
+	private readonly eventPrefix: string;
+	private readonly userAgent: string;
+	private readonly userId: string;
 	private context: Env & Record< string, unknown > & { userId?: string };
 
 	public static readonly ENDPOINT = '/pendo';

--- a/src/lib/analytics/clients/tracks.ts
+++ b/src/lib/analytics/clients/tracks.ts
@@ -31,15 +31,12 @@ export type TrackFunction = (
 // TODO: add batch support (can include multiples in `events` array)
 
 export default class Tracks implements AnalyticsClient {
-	private eventPrefix: string;
-	private userAgent: string;
-	private baseParams: BaseParams;
+	private readonly userAgent: string;
+	private readonly baseParams: BaseParams;
 
 	public static readonly ENDPOINT = 'https://public-api.wordpress.com/rest/v1.1/tracks/record';
 
-	constructor( userId: string, userType: string, eventPrefix: string, env: Env ) {
-		this.eventPrefix = eventPrefix;
-
+	constructor( userId: string, userType: string, private readonly eventPrefix: string, env: Env ) {
 		this.userAgent = env.userAgent;
 
 		this.baseParams = {

--- a/src/lib/analytics/index.ts
+++ b/src/lib/analytics/index.ts
@@ -17,11 +17,7 @@ const client_info = {
 /* eslint-enable camelcase */
 
 export default class Analytics {
-	private clients: AnalyticsClient[];
-
-	constructor( clients: AnalyticsClient[] ) {
-		this.clients = clients;
-	}
+	constructor( private readonly clients: AnalyticsClient[] ) {}
 
 	public async trackEvent(
 		name: string,

--- a/src/lib/backup-storage-availability/backup-storage-availability.ts
+++ b/src/lib/backup-storage-availability/backup-storage-availability.ts
@@ -17,11 +17,7 @@ export interface PromptStatus {
 }
 
 export class BackupStorageAvailability {
-	private archiveSize: number;
-
-	constructor( archiveSize: number ) {
-		this.archiveSize = archiveSize;
-	}
+	constructor( private readonly archiveSize: number ) {}
 
 	public static createFromDbCopyJob( job: Job ): BackupStorageAvailability {
 		const bytesWrittenMeta = job.metadata?.find( meta => meta?.name === 'bytesWritten' );

--- a/src/lib/keychain/insecure.ts
+++ b/src/lib/keychain/insecure.ts
@@ -3,12 +3,9 @@ import Configstore from 'configstore';
 import type { Keychain } from './keychain';
 
 export default class Insecure implements Keychain {
-	private file: string;
-	private configstore: Configstore;
+	private readonly configstore: Configstore;
 
-	constructor( file: string ) {
-		this.file = file;
-
+	constructor( private readonly file: string ) {
 		this.configstore = new Configstore( this.file );
 	}
 

--- a/src/lib/token.ts
+++ b/src/lib/token.ts
@@ -13,10 +13,10 @@ interface Payload {
 // Config
 export const SERVICE = 'vip-go-cli';
 export default class Token {
-	private _raw?: string;
-	private _id?: number;
-	private iat?: Date;
-	private exp?: Date;
+	private readonly _raw?: string;
+	private readonly _id?: number;
+	private readonly iat?: Date;
+	private readonly exp?: Date;
 
 	constructor( token: string ) {
 		if ( ! token ) {


### PR DESCRIPTION
## Description

This PR fixes the maintainability-related code smell detected by SonarCloud.

> `readonly` fields can only be assigned in a class constructor. If a class has a field that’s not marked `readonly` but is only set in the constructor, it could cause confusion about the field’s intended use. To avoid confusion, such fields should be marked `readonly` to make their intended use explicit, and to prevent future maintainers from inadvertently changing their use.

## Changelog Description

### Fixed

- S2933: marked fields only assigned in the constructor as `readonly`

## Pull request checklist

- [ ] Update [SETUP.md](https://github.com/Automattic/vip-cli/blob/trunk/docs/SETUP.md#list-of-environmental-variables) with any new environmental variables.
- [ ] Update [the documentation](https://github.com/Automattic/vip-cli/blob/trunk/docs).
- [x] [Manually test](https://github.com/Automattic/vip-cli/blob/trunk/docs/TESTING.md#manual-testing) the relevant changes.
- [x] Follow the [pull request checklist](https://github.com/Automattic/vip-cli/blob/trunk/docs/RELEASING.md#new-pull-requests)
- [ ] Add/update [automated tests](https://github.com/Automattic/vip-cli/blob/trunk/docs/TESTING.md#automated-testing) as needed.

## New release checklist

- [x] [Automated tests](https://github.com/Automattic/vip-cli/blob/trunk/docs/TESTING.md#automated-testing) pass.
- [ ] The [Preparing for release checklist](https://github.com/Automattic/vip-cli/blob/trunk/docs/RELEASING.md#preparing-for-release) is completed.

## Steps to Test

CI must pass.
