### PR TITLE
fix: Promise rejection is not caught by `try`

### DIFF
--- a/src/commands/wp-ssh.ts
+++ b/src/commands/wp-ssh.ts
@@ -252,7 +252,7 @@ export class WPCliCommandOverSSH {
 		const api = API();
 
 		try {
-			return api.mutate< TriggerWPCLICommandMutationResponse >( {
+			return await api.mutate< TriggerWPCLICommandMutationResponse >( {
 				mutation: TRIGGER_WP_CLI_COMMAND_MUTATION,
 				variables: {
 					input: {


### PR DESCRIPTION
## Description

A nesting `try` block will not catch an exception thrown inside a promise due to the asynchronous nature of execution.

Promises are designed to propagate errors to the next error handler or `catch()` block in the promise chain. Promises are asynchronous and operate outside of the normal call stack. When a `Promise` is created, it is added to the microtask queue, which is processed after the current call stack has completed. This means that the try-catch block surrounding the Promise will have already completed by the time the Promise is resolved or rejected. Therefore, any error occurring within the Promise will not be caught by the try-catch block.

## Changelog Description

### Fixed

- Fixed error handling in `getSSHAuthForCommand()` which could result in unhandled promise rejections and abnormal script termination.

## Pull request checklist

- [ ] Update [SETUP.md](https://github.com/Automattic/vip-cli/blob/trunk/docs/SETUP.md#list-of-environmental-variables) with any new environmental variables.
- [ ] Update [the documentation](https://github.com/Automattic/vip-cli/blob/trunk/docs).
- [ ] [Manually test](https://github.com/Automattic/vip-cli/blob/trunk/docs/TESTING.md#manual-testing) the relevant changes.
- [x] Follow the [pull request checklist](https://github.com/Automattic/vip-cli/blob/trunk/docs/RELEASING.md#new-pull-requests)
- [ ] Add/update [automated tests](https://github.com/Automattic/vip-cli/blob/trunk/docs/TESTING.md#automated-testing) as needed.

## New release checklist

- [x] [Automated tests](https://github.com/Automattic/vip-cli/blob/trunk/docs/TESTING.md#automated-testing) pass.
- [ ] The [Preparing for release checklist](https://github.com/Automattic/vip-cli/blob/trunk/docs/RELEASING.md#preparing-for-release) is completed.

## Steps to Test

CI must pass.
