### PR TITLE
ci: add AI Changelog workflow

### DIFF
--- a/.github/workflows/ai-changelog.yml
+++ b/.github/workflows/ai-changelog.yml
@@ -1,0 +1,103 @@
+name: Generate Changelog for PR
+
+on:
+  issue_comment:
+    types:
+      - created
+
+permissions:
+  contents: read
+
+jobs:
+  changelog:
+    name: Generate Changelog for PR
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
+    if: >
+      github.event.issue.pull_request &&
+      github.event.comment.body == '/changelog'
+    steps:
+      - name: Acknowledge request
+        uses: peter-evans/create-or-update-comment@71345be0265236311c031f5c7866368bd1eff043 # v4.0.0
+        with:
+          issue-number: ${{ github.event.issue.number }}
+          reactions: 'eyes'
+          comment-id: ${{ github.event.comment.id }}
+
+      - name: Verify OpenAI API Key is available
+        run: |
+          if [ -z "${OPENAI_API_KEY}" ]; then
+            echo "OPENAI_API_KEY is not set."
+            exit 1
+          fi
+        env:
+          OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+
+      - name: Check if user has write access
+        id: check_access
+        uses: actions/github-script@v7.0.1
+        with:
+          script: |
+            const { data: membership } = await github.rest.repos.getCollaboratorPermissionLevel({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              username: context.payload.comment.user.login
+            });
+            if (membership.permission !== 'write' && membership.permission !== 'admin' && membership.permission !== 'maintain') {
+              core.setFailed(`User ${context.payload.comment.user.login} does not have write access.`);
+            } else {
+              core.setOutput("authorized", 'true');
+            }
+
+      - name: Generate Changelog Entry
+        if: steps.check_access.outputs.authorized == 'true'
+        id: changelog
+        uses: Automattic/vip-actions/ai-changelog@1ca5877971f93f05fceaa0efd119c40218c1da1e # trunk
+        with:
+          pr_number: ${{ github.event.issue.number }}
+          openai_api_key: ${{ secrets.OPENAI_API_KEY }}
+
+      - name: Find Comment
+        uses: peter-evans/find-comment@3eae4d37986fb5a8592848f6a574fdf654e61f9e # v3.1.0
+        if: steps.check_access.outputs.authorized == 'true'
+        id: fc
+        with:
+          issue-number: ${{ github.event.issue.number }}
+          comment-author: 'github-actions[bot]'
+          body-includes: '## AI-Generated Changelog Entry'
+          direction: last
+
+      - name: Post Changelog Comment
+        if: >
+          steps.check_access.outputs.authorized == 'true' &&
+          steps.changelog.outputs.changelog_entry
+        uses: peter-evans/create-or-update-comment@71345be0265236311c031f5c7866368bd1eff043 # v4.0.0
+        with:
+          issue-number: ${{ github.event.issue.number }}
+          body: |
+            ## AI-Generated Changelog Entry
+
+            ${{ steps.changelog.outputs.changelog_entry }}
+
+          comment-id: ${{ steps.fc.outputs.comment-id }}
+          edit-mode: replace
+
+      - name: Set status (success)
+        uses: peter-evans/create-or-update-comment@71345be0265236311c031f5c7866368bd1eff043 # v4.0.0
+        if: success()
+        with:
+          issue-number: ${{ github.event.issue.number }}
+          reactions: 'hooray'
+          comment-id: ${{ github.event.comment.id }}
+          reactions-edit-mode: replace
+
+      - name: Set status (failure)
+        uses: peter-evans/create-or-update-comment@71345be0265236311c031f5c7866368bd1eff043 # v4.0.0
+        if: failure()
+        with:
+          issue-number: ${{ github.event.issue.number }}
+          reactions: '-1'
+          comment-id: ${{ github.event.comment.id }}
+          reactions-edit-mode: replace


### PR DESCRIPTION
## Description

This pull request introduces a new GitHub Actions workflow to automatically generate changelog entries for pull requests when a specific comment trigger is used. The workflow ensures that only users with write or admin access can trigger the changelog generation and posts the generated changelog as a comment on the pull request.

### New GitHub Actions Workflow:

* [`.github/workflows/ai-changelog.yml`](diffhunk://#diff-fe648599046a6c383677ee87dfeaed869eb7108a6f5652aea9c920804b25926dR1-R64): Added a workflow named "Generate Changelog for PR" that listens for the `/changelog` comment on pull requests. It verifies the user's permissions, generates a changelog entry using the AI-powered `Automattic/vip-actions/ai-changelog` action, and posts the changelog as a comment if the user is authorized.

## Pull request checklist

- [ ] Update [SETUP.md](https://github.com/Automattic/vip-cli/blob/trunk/docs/SETUP.md#list-of-environmental-variables) with any new environmental variables.
- [ ] Update [the documentation](https://github.com/Automattic/vip-cli/blob/trunk/docs).
- [ ] [Manually test](https://github.com/Automattic/vip-cli/blob/trunk/docs/TESTING.md#manual-testing) the relevant changes.
- [x] Follow the [pull request checklist](https://github.com/Automattic/vip-cli/blob/trunk/docs/RELEASING.md#new-pull-requests)
- [ ] Add/update [automated tests](https://github.com/Automattic/vip-cli/blob/trunk/docs/TESTING.md#automated-testing) as needed.

## New release checklist

- [x] [Automated tests](https://github.com/Automattic/vip-cli/blob/trunk/docs/TESTING.md#automated-testing) pass.
- [ ] The [Preparing for release checklist](https://github.com/Automattic/vip-cli/blob/trunk/docs/RELEASING.md#preparing-for-release) is completed.

## Steps to Test

Unfortunately, it is not possible to test this without merging the PR first. The workflow must be on the primary branch for GitHub to use it.
