### PR TITLE
fix(wp): resource leak during reconnection

### DIFF
--- a/src/bin/vip-wp.js
+++ b/src/bin/vip-wp.js
@@ -273,10 +273,17 @@ const bindReconnectEvents = ( {
 
 		// create a new input stream so that we can still catch things like SIGINT while reconnecting
 		if ( currentJob.stdinStream ) {
-			process.stdin.unpipe( currentJob.stdinStream );
+			unpipeStreamsFromProcess( {
+				stdin: currentJob.stdinStream,
+				stdout: currentJob.stdoutStream,
+			} );
 		}
-		process.stdin.pipe( IOStream.createStream() );
+
+		currentJob.stdinStream = IOStream.createStream();
 		currentJob.stdoutStream = IOStream.createStream();
+
+		pipeStreamsToProcess( { stdin: currentJob.stdinStream, stdout: currentJob.stdoutStream } );
+
 		bindStreamEvents( {
 			subShellRl,
 			isSubShell,


### PR DESCRIPTION
## Description

This pull request fixes a resource leak involving EventEmitter in the vip wp command, which previously resulted in `MaxListenersExceededWarning` warnings. The proposed changes address the memory leak that occurs during reconnection.

## Changelog Description

### Fixed

- EventEmitter memory leak in `vip wp` manifesting in the `MaxListenersExceededWarning` warning.

## Pull request checklist

- [ ] Update [SETUP.md](https://github.com/Automattic/vip-cli/blob/trunk/docs/SETUP.md#list-of-environmental-variables) with any new environmental variables.
- [ ] Update [the documentation](https://github.com/Automattic/vip-cli/blob/trunk/docs).
- [x] [Manually test](https://github.com/Automattic/vip-cli/blob/trunk/docs/TESTING.md#manual-testing) the relevant changes.
- [x] Follow the [pull request checklist](https://github.com/Automattic/vip-cli/blob/trunk/docs/RELEASING.md#new-pull-requests)
- [ ] Add/update [automated tests](https://github.com/Automattic/vip-cli/blob/trunk/docs/TESTING.md#automated-testing) as needed.

## New release checklist

- [ ] [Automated tests](https://github.com/Automattic/vip-cli/blob/trunk/docs/TESTING.md#automated-testing) pass.
- [ ] The [Preparing for release checklist](https://github.com/Automattic/vip-cli/blob/trunk/docs/RELEASING.md#preparing-for-release) is completed.

## Steps to Test

```sh
NODE_OPTIONS=--trace-warnings vip @app.env wp shell
```

Leave it alone for about two hours.
If there are no warnings, we are good 🙂

