### PR TITLE
fix(wp): EventEmitter memory leak for `error` listeners

### DIFF
--- a/src/bin/vip-wp.js
+++ b/src/bin/vip-wp.js
@@ -110,7 +110,6 @@ const bindStreamEvents = ( { subShellRl, commonTrackingParams, isSubShell, stdou
 		if ( ! isSubShell ) {
 			subShellRl.close();
 			process.exit();
-			return;
 		}
 		subShellRl.resume();
 		subShellRl.prompt();

--- a/src/bin/vip-wp.js
+++ b/src/bin/vip-wp.js
@@ -141,6 +141,14 @@ const getTokenForCommand = async ( appId, envId, command ) => {
 	} );
 };
 
+/**
+ * Returns the error so it can be caught by the `socket.on('error')`.
+ *
+ * @param {Error} err
+ * @returns {Error}
+ */
+const onSocketError = err => err;
+
 const launchCommandAndGetStreams = async ( { socket, guid, inputToken, offset = 0 } ) => {
 	const stdoutStream = IOStream.createStream();
 	const stdinStream = IOStream.createStream();
@@ -172,10 +180,7 @@ const launchCommandAndGetStreams = async ( { socket, guid, inputToken, offset = 
 		exit.withError( `Cancel received from server: ${ message }` );
 	} );
 
-	IOStream( socket ).on( 'error', err => {
-		// This returns the error so it can be catched by the socket.on('error')
-		return err;
-	} );
+	IOStream( socket ).off( 'error', onSocketError ).on( 'error', onSocketError );
 
 	socket.on( 'error', err => {
 		if ( err === 'Rate limit exceeded' ) {


### PR DESCRIPTION
## Description

This PR fixes the EventEmitter memory leak that occurs when the application installs its `error` handler for an existing socket during reconnect.

## Changelog Description

### Fixed

- EventEmitter memory leak for socket's `error` listeners

## Pull request checklist

- [ ] Update [SETUP.md](https://github.com/Automattic/vip-cli/blob/trunk/docs/SETUP.md#list-of-environmental-variables) with any new environmental variables.
- [ ] Update [the documentation](https://github.com/Automattic/vip-cli/blob/trunk/docs).
- [x] [Manually test](https://github.com/Automattic/vip-cli/blob/trunk/docs/TESTING.md#manual-testing) the relevant changes.
- [x] Follow the [pull request checklist](https://github.com/Automattic/vip-cli/blob/trunk/docs/RELEASING.md#new-pull-requests)
- [ ] Add/update [automated tests](https://github.com/Automattic/vip-cli/blob/trunk/docs/TESTING.md#automated-testing) as needed.

## New release checklist

- [ ] [Automated tests](https://github.com/Automattic/vip-cli/blob/trunk/docs/TESTING.md#automated-testing) pass.
- [ ] The [Preparing for release checklist](https://github.com/Automattic/vip-cli/blob/trunk/docs/RELEASING.md#preparing-for-release) is completed.

## Steps to Test

```shell
npm run build
NODE_OPTIONS=--trace-warnings vip @app.env wp shell
```

Wait patiently and watch for warnings.

See PLTFRM-1407 for how to add a debug code to make it easier.
