### PR TITLE
refactor(dev-env): deprecate `extended` option in `vip dev-env info`

### DIFF
--- a/src/bin/vip-dev-env-info.js
+++ b/src/bin/vip-dev-env-info.js
@@ -24,16 +24,11 @@ const usage = 'vip dev-env info';
 const examples = [
 	{
 		usage: `${ exampleUsage } --slug=example-site`,
-		description: 'Retrieve basic information about the local environment named "example-site".',
-	},
-	{
-		usage: `${ exampleUsage } --slug=example-site --extended`,
-		description:
-			'Retrieve a larger amount of information about the local environment named "example-site".',
+		description: 'Retrieve information about the local environment named "example-site".',
 	},
 	{
 		usage: `${ exampleUsage } --all`,
-		description: 'Retrieve basic information about all local environments.',
+		description: 'Retrieve information about all local environments.',
 	},
 ];
 
@@ -47,7 +42,7 @@ command( {
 		processSlug
 	)
 	.option( 'all', 'Retrieve information about all local environments.' )
-	.option( 'extended', 'Retrieve a larger amount of information.' )
+	.option( 'extended', 'Deprecated, not used.' )
 	.examples( examples )
 	.argv( process.argv, async ( arg, opt ) => {
 		let trackingInfo;
@@ -69,7 +64,7 @@ command( {
 
 		try {
 			const options = {
-				extended: Boolean( opt.extended ),
+				extended: true,
 				suppressWarnings: true,
 			};
 			if ( opt.all ) {


### PR DESCRIPTION
## Description

This PR deprecates the `extended` option in `vip dev-env info`. Now, `vip dev-env info` always shows complete information about the environment.

## Changelog Description

### Changed

- `vip dev-env info` always shows complete information about the environment.
- The `--extended` flag in `vip dev-env info` is now deprecated and is a no-op.

## Pull request checklist

- [ ] Update [SETUP.md](https://github.com/Automattic/vip-cli/blob/trunk/docs/SETUP.md#list-of-environmental-variables) with any new environmental variables.
- [ ] Update [the documentation](https://github.com/Automattic/vip-cli/blob/trunk/docs).
- [x] [Manually test](https://github.com/Automattic/vip-cli/blob/trunk/docs/TESTING.md#manual-testing) the relevant changes.
- [x] Follow the [pull request checklist](https://github.com/Automattic/vip-cli/blob/trunk/docs/RELEASING.md#new-pull-requests)
- [ ] Add/update [automated tests](https://github.com/Automattic/vip-cli/blob/trunk/docs/TESTING.md#automated-testing) as needed.

## New release checklist

- [ ] [Automated tests](https://github.com/Automattic/vip-cli/blob/trunk/docs/TESTING.md#automated-testing) pass.
- [ ] The [Preparing for release checklist](https://github.com/Automattic/vip-cli/blob/trunk/docs/RELEASING.md#preparing-for-release) is completed.

## Steps to Test

CI must pass.
