### PR TITLE
refactor(dev-env): use `isContainerRunning` for import and sync commands

### DIFF
--- a/src/bin/vip-dev-env-sync-sql.js
+++ b/src/bin/vip-dev-env-sync-sql.js
@@ -7,8 +7,7 @@ import {
 	processBooleanOption,
 	processSlug,
 } from '../lib/dev-environment/dev-environment-cli';
-import { getEnvironmentPath } from '../lib/dev-environment/dev-environment-core';
-import { bootstrapLando, isEnvUp } from '../lib/dev-environment/dev-environment-lando';
+import { bootstrapLando, isContainerRunning } from '../lib/dev-environment/dev-environment-lando';
 import { makeCommandTracker } from '../lib/tracker';
 import UserError from '../lib/user-error';
 
@@ -73,9 +72,15 @@ command( {
 		await trackerFn( 'execute' );
 
 		const lando = await bootstrapLando();
-		const envPath = getEnvironmentPath( slug );
 
-		if ( ! ( await isEnvUp( lando, envPath ) ) && ! opt.force ) {
+		const isUp = (
+			await Promise.all( [
+				isContainerRunning( lando, slug, 'php' ),
+				isContainerRunning( lando, slug, 'database' ),
+			] )
+		 ).every( Boolean );
+
+		if ( ! isUp && ! opt.force ) {
 			await trackerFn( 'env_not_running_error', { errorMessage: 'Environment was not running' } );
 			throw new UserError( 'Environment needs to be started first' );
 		}

--- a/src/commands/dev-env-import-sql.ts
+++ b/src/commands/dev-env-import-sql.ts
@@ -9,11 +9,7 @@ import {
 	processBooleanOption,
 	validateDependencies,
 } from '../lib/dev-environment/dev-environment-cli';
-import {
-	exec,
-	getEnvironmentPath,
-	resolveImportPath,
-} from '../lib/dev-environment/dev-environment-core';
+import { exec, resolveImportPath } from '../lib/dev-environment/dev-environment-core';
 import {
 	addAdminUser,
 	dataCleanup,
@@ -21,7 +17,7 @@ import {
 	flushCache,
 	reIndexSearch,
 } from '../lib/dev-environment/dev-environment-database';
-import { bootstrapLando, isEnvUp } from '../lib/dev-environment/dev-environment-lando';
+import { bootstrapLando, isContainerRunning } from '../lib/dev-environment/dev-environment-lando';
 import UserError from '../lib/user-error';
 import { makeTempDir } from '../lib/utils';
 import { validate as validateSQL, validateImportFileExtension } from '../lib/validations/sql';
@@ -84,7 +80,14 @@ export class DevEnvImportSQLCommand {
 		);
 
 		if ( ! this.options.skipValidate ) {
-			if ( ! ( await isEnvUp( lando, getEnvironmentPath( this.slug ) ) ) ) {
+			const isUp = (
+				await Promise.all( [
+					isContainerRunning( lando, this.slug, 'php' ),
+					isContainerRunning( lando, this.slug, 'database' ),
+				] )
+			 ).every( Boolean );
+
+			if ( ! isUp ) {
 				throw new UserError( 'Environment needs to be started first' );
 			}
 

--- a/src/lib/dev-environment/dev-environment-lando.ts
+++ b/src/lib/dev-environment/dev-environment-lando.ts
@@ -15,6 +15,7 @@ import xdgBasedir from 'xdg-basedir';
 
 import {
 	doesEnvironmentExist,
+	getEnvironmentPath,
 	readEnvironmentData,
 	updateEnvironment,
 	writeEnvironmentData,
@@ -785,4 +786,26 @@ export function validateDockerInstalled( lando: Lando ): void {
 			);
 		}
 	}
+}
+
+export async function isContainerRunning(
+	lando: Lando,
+	slug: string,
+	serviceName: string
+): Promise< boolean > {
+	const envPath = getEnvironmentPath( slug );
+	const app = await getLandoApplication( lando, envPath );
+
+	const { docker } = app.engine;
+	const containers = await docker.listContainers( {
+		filters: {
+			label: [
+				`com.docker.compose.project=${ app.project }`,
+				`com.docker.compose.service=${ serviceName }`,
+			],
+			status: [ 'running' ],
+		},
+	} );
+
+	return containers.length > 0;
 }

--- a/types/lando/lib/app.d.ts
+++ b/types/lando/lib/app.d.ts
@@ -67,7 +67,7 @@ declare class App {
 	 */
 	log: any;
 	shell: any;
-	engine: any;
+	engine: import('lando/lib/engine');
 	metrics: any;
 	Promise: any;
 	events: import('lando/lib/events');


### PR DESCRIPTION
## Description

This pull request refactors the code to check if the development environment is running before importing SQL data. Instead of checking if the whole environment is up, it now specifically checks if both the `php` and `database` containers are running. Additionally, it introduces a new utility function to check the running status of individual containers and updates imports accordingly.

**Improvements to environment status checks:**

* Replaced the broad `isEnvUp` check with explicit checks for the `php` and `database` containers using the new `isContainerRunning` function in `DevEnvImportSQLCommand`. This ensures a more accurate validation of required services before proceeding.

**New utility function:**

* Added `isContainerRunning` to `dev-environment-lando.ts`, which checks if a specific container for a given environment is running by querying Docker directly.

**Code cleanup and import updates:**

* Updated imports in `dev-env-import-sql.ts` and `dev-environment-lando.ts` to remove unused functions and add the new utility where needed. [[1]](diffhunk://#diff-67dc89449b01480be4324e2dab245b77b32a98e7aad67a3788e8b1be9af5ace2L12-R20) [[2]](diffhunk://#diff-15dbc43165de0e5b07bbd1cc20ebe7a756e8f08ac7cdb252729414a57bb04e22R18)

## Changelog Description

### Changed

- The environment status checks for `vip dev-env import sql` and `vip dev-env sync sql` commands now verify that the PHP and Database containers are running, rather than checking the status of the entire environment.

## Pull request checklist

- [ ] Update [SETUP.md](https://github.com/Automattic/vip-cli/blob/trunk/docs/SETUP.md#list-of-environmental-variables) with any new environmental variables.
- [ ] Update [the documentation](https://github.com/Automattic/vip-cli/blob/trunk/docs).
- [x] [Manually test](https://github.com/Automattic/vip-cli/blob/trunk/docs/TESTING.md#manual-testing) the relevant changes.
- [x] Follow the [pull request checklist](https://github.com/Automattic/vip-cli/blob/trunk/docs/RELEASING.md#new-pull-requests)
- [ ] Add/update [automated tests](https://github.com/Automattic/vip-cli/blob/trunk/docs/TESTING.md#automated-testing) as needed.

## New release checklist

- [ ] [Automated tests](https://github.com/Automattic/vip-cli/blob/trunk/docs/TESTING.md#automated-testing) pass.
- [ ] The [Preparing for release checklist](https://github.com/Automattic/vip-cli/blob/trunk/docs/RELEASING.md#preparing-for-release) is completed.

## Steps to Test

```shell
vip dev-env create --slug test-is-up < /dev/null
vip dev-env start --slug test-is-up
docker stop testisup-nginx-1 # or whatever the container is called
vip @app.env dev-env sync sql
```

Without this patch, synchronization will fail with the "Environment needs to be started first" message. With this patch, it will succeed.
