### PR TITLE
test(backup-storage): show cursor after each test run

### DIFF
--- a/__tests__/lib/backup-storage-availability/backup-storage-availability.ts
+++ b/__tests__/lib/backup-storage-availability/backup-storage-availability.ts
@@ -12,6 +12,9 @@ const oneGiBInBytes = 1024 * 1024 * 1024;
 describe( 'backup-storage-availability', () => {
 	afterEach( () => {
 		confirmRunSpy.mockClear();
+		if ( process.stdout.isTTY ) {
+			process.stdout.write( '\x1B[?25h' ); // Show cursor
+		}
 	} );
 
 	describe( 'validateAndPromptDiskSpaceWarningForBackupImport', () => {


### PR DESCRIPTION
## Description

This pull request makes a slight improvement to the test cleanup process by ensuring the terminal cursor is shown after each test run, but only if the process is running in a TTY environment. This helps prevent the cursor from remaining hidden after tests that may alter the terminal state.

The video explains it:

https://github.com/user-attachments/assets/e7c9e86a-b37a-48e6-acec-76c734c957cf

* Test cleanup enhancement:
  * Updated the `afterEach` block in `__tests__/lib/backup-storage-availability/backup-storage-availability.ts` to restore the terminal cursor visibility if running in a TTY.

Related: enquirer/enquirer#116
