### PR TITLE
Update changelog workflow to use new endpoint, publish status, and terms

### DIFF
--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -13,13 +13,14 @@ jobs:
       pull-requests: read
     steps:
       - uses: actions/checkout@v5
-      - uses: Automattic/vip-actions/changelog@fa05dc9293764a50401a293f2c9312924afbaab3 # trunk
+      - uses: Automattic/vip-actions/changelog@trunk
         with:
-          endpoint: ${{ vars.CHANGELOG_POST_ENDPOINT }}
-          endpoint-token: ${{ secrets.CHANGELOG_POST_TOKEN }}
+          endpoint: 'https://docs.wpvip.com/wp-json/wp/v2/changelogs'
+          endpoint-token: ${{ secrets.CHANGELOG_DOCS_POST_TOKEN }}
           endpoint-auth-type: 'basic'
           repo-token: ${{ secrets.GITHUB_TOKEN }}
-          status: 'draft'
-          category-id: '26'
-          link-to-pr: true
+          status: 'publish'
+          terms: changelog_category:110
+          tag-id: '115'
+          link-to-pr: false
           source: 'last-release'

--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -13,7 +13,7 @@ jobs:
       pull-requests: read
     steps:
       - uses: actions/checkout@v5
-      - uses: Automattic/vip-actions/changelog@trunk
+      - uses: Automattic/vip-actions/changelog@a83b38ef1ac701c4d8ca2b27bac2d6ebad17e684
         with:
           endpoint: 'https://docs.wpvip.com/wp-json/wp/v2/changelogs'
           endpoint-token: ${{ secrets.CHANGELOG_DOCS_POST_TOKEN }}


### PR DESCRIPTION
## Description

This pull request updates the workflow for publishing changelogs to our docs.wpvip.com property.

**Changelog publishing workflow updates:**

* Updated the changelog action to explicitly use the `trunk` branch of `Automattic/vip-actions` (will be updated to specific commit once workflow change is committed upstream) and changed the endpoint to `https://docs.wpvip.com/wp-json/wp/v2/changelogs` for posting changelogs to the production documentation site.
* Changed the changelog status from `draft` to `publish`, and updated category and tag to use proper production IDs.

## Pull request checklist

- [ ] Update [SETUP.md](https://github.com/Automattic/vip-cli/blob/trunk/docs/SETUP.md#list-of-environmental-variables) with any new environmental variables.
- [ ] Update [the documentation](https://github.com/Automattic/vip-cli/blob/trunk/docs).
- [ ] [Manually test](https://github.com/Automattic/vip-cli/blob/trunk/docs/TESTING.md#manual-testing) the relevant changes.
- [ ] Follow the [pull request checklist](https://github.com/Automattic/vip-cli/blob/trunk/docs/RELEASING.md#new-pull-requests)
- [ ] Add/update [automated tests](https://github.com/Automattic/vip-cli/blob/trunk/docs/TESTING.md#automated-testing) as needed.

## New release checklist

- [ ] [Automated tests](https://github.com/Automattic/vip-cli/blob/trunk/docs/TESTING.md#automated-testing) pass.
- [ ] The [Preparing for release checklist](https://github.com/Automattic/vip-cli/blob/trunk/docs/RELEASING.md#preparing-for-release) is completed.