### PR TITLE
fix: version check for Node.js compatibility

### DIFF
--- a/src/bin/vip.js
+++ b/src/bin/vip.js
@@ -1,28 +1,15 @@
 #!/usr/bin/env node
 
+import '../lib/node-version-check';
+
 import chalk from 'chalk';
 import debugLib from 'debug';
 import { prompt } from 'enquirer';
-import { satisfies } from 'semver';
 
 import command, { containsAppEnvArgument } from '../lib/cli/command';
 import config from '../lib/cli/config';
 import Token from '../lib/token';
 import { aliasUser, trackEvent } from '../lib/tracker';
-
-const { name, engines } = require( '../../package.json' );
-
-const version = engines.node;
-
-if ( version && ! satisfies( process.version, version ) ) {
-	console.warn(
-		`${ chalk.bgYellow( 'WARNING:' ) } The current version of Node (${
-			process.version
-		}) does not meet the minimum requirements; ` +
-			`${ name } requires Node version ${ version }.\n\n` +
-			'Please follow the installation instructions at https://nodejs.org/en/download/ to upgrade.'
-	);
-}
 
 const debug = debugLib( '@automattic/vip:bin:vip' );
 

--- a/src/lib/node-version-check.js
+++ b/src/lib/node-version-check.js
@@ -1,0 +1,23 @@
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { satisfies } from 'semver';
+
+const boldRed = process.stdout.isTTY ? '\x1b[1;31m' : '';
+const reset = process.stdout.isTTY ? '\x1b[0m' : '';
+
+try {
+	const json = readFileSync( join( __dirname, '..', '..', 'package.json' ), 'utf8' );
+	const { name, engines } = JSON.parse( json );
+
+	const version = engines.node;
+
+	if ( version && ! satisfies( process.version, version ) ) {
+		console.warn(
+			`${ boldRed }WARNING: The current version of Node (${ process.version }) does not meet the minimum requirements; ` +
+				`${ name } requires Node version ${ version }.\n\n` +
+				`Please follow the installation instructions at https://nodejs.org/en/download/ to upgrade.${ reset }\n`
+		);
+	}
+} catch {
+	// Do nothing
+}


### PR DESCRIPTION
## Description

### Purpose and Context

This change aims to prevent runtime issues caused by incompatible Node.js versions and to improve the developer and user experience by providing clear guidance.

### Key Changes

- Moved version check from `vip.js` into `node-version-check.js`. `node-version-check.js` is imported at the top of `vip.js` to ensure the check runs before any other code. This change ensures that users are immediately informed if their `Node.js` version is incompatible before they see the `ERR_REQUIRE_ESM` error.

### Impact and Considerations

Users are warned if their `Node.js` version does not meet the minimum requirements. No changes to existing command behavior. No configuration changes required.

### Security Considerations

No security impact. The version check only reads the local `package.json` and does not affect authentication, authorization, or data handling.

### Performance Considerations

Negligible performance impact. The version check runs once at startup and does not affect runtime performance.

### Testing and Validation

Manually tested with various `Node.js` versions to confirm correct warnings and behavior. No automated tests were added for this module.

## Changelog Description

### Fixed

- Node.js version check now runs before any other code to provide immediate feedback if Node.js is incompatible.

## Pull request checklist

- [ ] Update [SETUP.md](https://github.com/Automattic/vip-cli/blob/trunk/docs/SETUP.md#list-of-environmental-variables) with any new environmental variables.
- [ ] Update [the documentation](https://github.com/Automattic/vip-cli/blob/trunk/docs).
- [x] [Manually test](https://github.com/Automattic/vip-cli/blob/trunk/docs/TESTING.md#manual-testing) the relevant changes.
- [x] Follow the [pull request checklist](https://github.com/Automattic/vip-cli/blob/trunk/docs/RELEASING.md#new-pull-requests)
- [ ] Add/update [automated tests](https://github.com/Automattic/vip-cli/blob/trunk/docs/TESTING.md#automated-testing) as needed.

## New release checklist

- [ ] [Automated tests](https://github.com/Automattic/vip-cli/blob/trunk/docs/TESTING.md#automated-testing) pass.
- [ ] The [Preparing for release checklist](https://github.com/Automattic/vip-cli/blob/trunk/docs/RELEASING.md#preparing-for-release) is completed.

## Steps to Test

```
$ nvm install v18.20.8
$ npm run build
$ npm link --ignore-scripts
$ vip -v
WARNING: The current version of Node (v18.20.8) does not meet the minimum requirements; @automattic/vip requires Node version ^20.19.0 || ^22.12.0 || >=23.0.0.

Please follow the installation instructions at https://nodejs.org/en/download/ to upgrade.

/home/volodymyr/automattic/vip-cli/dist/bin/vip.js:5
var _chalk = _interopRequireDefault(require("chalk"));
                                    ^

Error [ERR_REQUIRE_ESM]: require() of ES Module /home/volodymyr/automattic/vip-cli/node_modules/chalk/source/index.js from /home/volodymyr/automattic/vip-cli/dist/bin/vip.js not supported.
Instead change the require of index.js in /home/volodymyr/automattic/vip-cli/dist/bin/vip.js to a dynamic import() which is available in all CommonJS modules.
    at Object.<anonymous> (/home/volodymyr/automattic/vip-cli/dist/bin/vip.js:5:37) {
  code: 'ERR_REQUIRE_ESM'
}

Node.js v18.20.8
```

Without this patch, the `WARNING` won't be shown.
