### PR TITLE
Replace 'subsite-id' with 'site-id'

### DIFF
--- a/__tests__/commands/export-sql.ts
+++ b/__tests__/commands/export-sql.ts
@@ -378,7 +378,7 @@ describe( 'commands/ExportSQLCommand', () => {
 						id: 123,
 						environmentId: 456,
 						config: {
-							subsite_ids: undefined,
+							site_ids: undefined,
 							type: 'tables',
 							tables: {
 								wp_users: {},
@@ -397,7 +397,7 @@ describe( 'commands/ExportSQLCommand', () => {
 			);
 		} );
 
-		it( 'should successfully create backup for specific subsites and download file', async () => {
+		it( 'should successfully create backup for specific network sites and download file', async () => {
 			const app = { id: 123, name: 'test-app' };
 			const env = { id: 456, name: 'test-env' };
 
@@ -406,7 +406,7 @@ describe( 'commands/ExportSQLCommand', () => {
 			const exportCommand = new ExportSQLCommand( app, env, {
 				liveBackupCopyCLIOptions: {
 					useLiveBackupCopy: true,
-					subsiteIds: [ 2, 3 ],
+					siteIds: [ 2, 3 ],
 				},
 				outputFile,
 			} );
@@ -427,8 +427,8 @@ describe( 'commands/ExportSQLCommand', () => {
 						id: 123,
 						environmentId: 456,
 						config: {
-							subsite_ids: [ 2, 3 ],
-							type: 'subsite_ids',
+							site_ids: [ 2, 3 ],
+							type: 'site_ids',
 							tables: undefined,
 							wpcli_command: undefined,
 						},
@@ -473,7 +473,7 @@ describe( 'commands/ExportSQLCommand', () => {
 						id: 123,
 						environmentId: 456,
 						config: {
-							subsite_ids: undefined,
+							site_ids: undefined,
 							type: 'wpcli_command',
 							tables: undefined,
 							wpcli_command: 'custom-db-export-config --include-users --include-posts',

--- a/src/bin/vip-dev-env-sync-sql.js
+++ b/src/bin/vip-dev-env-sync-sql.js
@@ -31,14 +31,14 @@ const examples = [
 			'Sync only the wp_posts and wp_comments tables using comma-separated syntax from the database of the develop environment in the "example-app" application to a local environment named "example-site".',
 	},
 	{
-		usage: `vip @example-app.develop dev-env sync sql --slug=example-site --subsite-id=2 --subsite-id=3`,
+		usage: `vip @example-app.develop dev-env sync sql --slug=example-site --site-id=2 --site-id=3`,
 		description:
-			'Sync only the tables for the subsites with IDs 2 and 3 from the database of the develop environment in the "example-app" application to a local environment named "example-site".',
+			'Sync only the tables for the network sites with IDs 2 and 3 from the database of the develop environment in the "example-app" application to a local environment named "example-site".',
 	},
 	{
-		usage: `vip @example-app.develop dev-env sync sql --slug=example-site --subsite-id=2,3`,
+		usage: `vip @example-app.develop dev-env sync sql --slug=example-site --site-id=2,3`,
 		description:
-			'Sync only the tables for the subsites with IDs 2 and 3 using comma-separated syntax from the database of the develop environment in the "example-app" application to a local environment named "example-site".',
+			'Sync only the tables for the network sites with IDs 2 and 3 using comma-separated syntax from the database of the develop environment in the "example-app" application to a local environment named "example-site".',
 	},
 	{
 		usage: `vip @example-app.develop dev-env sync sql --slug=example-site --config-file=~/dev-env-sync-config.json`,
@@ -89,9 +89,9 @@ command( {
 		'A table to sync from the remote environment to the local environment. Multiple tables can be specified with multiple --table flags or as a comma-separated list.'
 	)
 	.option(
-		'subsite-id',
+		'site-id',
 
-		'The ID of a subsite/network site to sync from the remote environment to the local environment. Multiple subsite IDs can be specified with multiple --subsite-id flags or as a comma-separated list.'
+		'The ID of a network site to sync from the remote environment to the local environment. Multiple site IDs can be specified with multiple --site-id flags or as a comma-separated list.'
 	)
 	.option(
 		'wpcli-command',
@@ -101,12 +101,12 @@ command( {
 	.option( 'force', 'Skip validations.', undefined, processBooleanOption )
 	.examples( examples )
 	.argv( process.argv, async ( arg, opt ) => {
-		const { app, env, configFile, table, subsiteId, wpcliCommand, ...optRest } = opt;
+		const { app, env, configFile, table, siteId, wpcliCommand, ...optRest } = opt;
 
 		const liveBackupCopyCLIOptions = parseLiveBackupCopyCLIOptions(
 			configFile,
 			table,
-			subsiteId,
+			siteId,
 			wpcliCommand
 		);
 

--- a/src/bin/vip-export-sql.js
+++ b/src/bin/vip-export-sql.js
@@ -32,14 +32,14 @@ const examples = [
 			'Generate a database backup including only the wp_posts and wp_comments tables using comma-separated syntax, and download a copy of that backup.',
 	},
 	{
-		usage: 'vip @example-app.develop export sql --subsite-id=2 --subsite-id=3',
+		usage: 'vip @example-app.develop export sql --site-id=2 --site-id=3',
 		description:
-			'Generate a database backup including only the tables related to the subsites with IDs 2 and 3, and download a copy of that backup.',
+			'Generate a database backup including only the tables related to the network sites with IDs 2 and 3, and download a copy of that backup.',
 	},
 	{
-		usage: 'vip @example-app.develop export sql --subsite-id=2,3',
+		usage: 'vip @example-app.develop export sql --site-id=2,3',
 		description:
-			'Generate a database backup including only the tables related to the subsites with IDs 2 and 3 using comma-separated syntax, and download a copy of that backup.',
+			'Generate a database backup including only the tables related to the network sites with IDs 2 and 3 using comma-separated syntax, and download a copy of that backup.',
 	},
 	{
 		usage: 'vip @example-app.develop export sql --config-file=~/db-export-config.json',
@@ -80,8 +80,8 @@ command( {
 		'A table to export from the remote environment. Multiple tables can be specified with multiple --table flags or as a comma-separated list.'
 	)
 	.option(
-		'subsite-id',
-		'The ID of a subsite/network site to export from the remote environment. Multiple subsite IDs can be specified with multiple --subsite-id flags or as a comma-separated list.'
+		'site-id',
+		'The ID of a network site to export from the remote environment. Multiple site IDs can be specified with multiple --site-id flags or as a comma-separated list.'
 	)
 	.option(
 		'wpcli-command',
@@ -94,12 +94,12 @@ command( {
 		process.argv,
 		async (
 			arg,
-			{ app, env, output, configFile, table, subsiteId, wpcliCommand, generateBackup }
+			{ app, env, output, configFile, table, siteId, wpcliCommand, generateBackup }
 		) => {
 			const liveBackupCopyCLIOptions = parseLiveBackupCopyCLIOptions(
 				configFile,
 				table,
-				subsiteId,
+				siteId,
 				wpcliCommand
 			);
 

--- a/src/commands/export-sql.ts
+++ b/src/commands/export-sql.ts
@@ -611,16 +611,16 @@ export class ExportSQLCommand {
 
 		let type = BackupLiveCopyType.TABLES;
 		let tables: DBLiveCopyConfig[ 'tables' ];
-		let subsiteIds: DBLiveCopyConfig[ 'subsite_ids' ];
+		let siteIds: DBLiveCopyConfig[ 'site_ids' ];
 		if ( this.liveBackupCopyCLIOptions?.tables ) {
 			tables = Object.fromEntries(
 				this.liveBackupCopyCLIOptions?.tables.map( key => [ key, {} ] )
 			);
 		}
 
-		if ( this.liveBackupCopyCLIOptions?.subsiteIds ) {
-			type = BackupLiveCopyType.SUBSITE_IDS;
-			subsiteIds = this.liveBackupCopyCLIOptions?.subsiteIds.map( id => Number( id ) );
+		if ( this.liveBackupCopyCLIOptions?.siteIds ) {
+			type = BackupLiveCopyType.SITE_IDS;
+			siteIds = this.liveBackupCopyCLIOptions?.siteIds.map( id => Number( id ) );
 		}
 
 		if ( this.liveBackupCopyCLIOptions?.wpcliCommand ) {
@@ -630,7 +630,7 @@ export class ExportSQLCommand {
 		return {
 			type,
 			tables,
-			subsite_ids: subsiteIds,
+			site_ids: siteIds,
 			wpcli_command: this.liveBackupCopyCLIOptions?.wpcliCommand,
 		};
 	}

--- a/src/graphqlTypes.d.ts
+++ b/src/graphqlTypes.d.ts
@@ -2788,7 +2788,7 @@ export type LiveBackupCopy = {
 
 export type LiveBackupCopyConfig = {
 	__typename?: 'LiveBackupCopyConfig';
-	subsiteIds?: Maybe< Array< Scalars[ 'Int' ][ 'output' ] > >;
+	siteIds?: Maybe< Array< Scalars[ 'Int' ][ 'output' ] > >;
 	tables?: Maybe< Array< LiveBackupCopyTableConfig > >;
 	tool: LiveBackupCopyTool;
 	type: LiveBackupCopyType;
@@ -2827,7 +2827,7 @@ export type LiveBackupCopyTableOptionConfigInput = {
 
 export type LiveBackupCopyTool = 'mydumper' | 'mysqldump';
 
-export type LiveBackupCopyType = 'full' | 'subsite_ids' | 'tables' | 'wpcli_command';
+export type LiveBackupCopyType = 'full' | 'site_ids' | 'tables' | 'wpcli_command';
 
 export type ManageIntegrationInput = {
 	appId?: InputMaybe< Scalars[ 'Int' ][ 'input' ] >;

--- a/src/lib/live-backup-copy.ts
+++ b/src/lib/live-backup-copy.ts
@@ -12,7 +12,7 @@ import API from '../lib/api';
 
 export interface LiveBackupCopyCLIOptions {
 	useLiveBackupCopy?: boolean;
-	subsiteIds?: number[];
+	siteIds?: number[];
 	tables?: string[];
 	wpcliCommand?: string;
 	configFile?: string;
@@ -21,20 +21,20 @@ export interface LiveBackupCopyCLIOptions {
 export function parseLiveBackupCopyCLIOptions(
 	configFile?: string,
 	table?: string | string[],
-	subsiteId?: number | number[],
+	siteId?: number | number[],
 	wpcliCommand?: string
 ): LiveBackupCopyCLIOptions {
 	const options: LiveBackupCopyCLIOptions = {};
 
-	if ( configFile && ( table || subsiteId || wpcliCommand ) ) {
+	if ( configFile && ( table || siteId || wpcliCommand ) ) {
 		throw new UserError(
-			'The --config-file option cannot be used with the --table, --subsite-id, or --wpcli-command options. Please use only one of these options at a time.'
+			'The --config-file option cannot be used with the --table, --site-id, or --wpcli-command options. Please use only one of these options at a time.'
 		);
 	}
 
-	if ( wpcliCommand && ( table || subsiteId ) ) {
+	if ( wpcliCommand && ( table || siteId ) ) {
 		throw new UserError(
-			'The --wpcli-command option cannot be used with the --table or --subsite-id options. Please use only one of these options at a time.'
+			'The --wpcli-command option cannot be used with the --table or --site-id options. Please use only one of these options at a time.'
 		);
 	}
 
@@ -51,15 +51,15 @@ export function parseLiveBackupCopyCLIOptions(
 		useLiveBackupCopy = true;
 	}
 
-	if ( subsiteId ) {
-		if ( Array.isArray( subsiteId ) ) {
-			options.subsiteIds = subsiteId.flatMap( id =>
+	if ( siteId ) {
+		if ( Array.isArray( siteId ) ) {
+			options.siteIds = siteId.flatMap( id =>
 				String( id )
 					.split( ',' )
 					.map( idStr => Number( idStr.trim() ) )
 			);
 		} else {
-			options.subsiteIds = String( subsiteId )
+			options.siteIds = String( siteId )
 				.split( ',' )
 				.map( idStr => Number( idStr.trim() ) );
 		}
@@ -108,7 +108,7 @@ export const GENERATE_LIVE_BACKUP_DOWNLOAD_URL_MUTATION = gql( `
 export enum BackupLiveCopyType {
 	FULL = 'full',
 	TABLES = 'tables',
-	SUBSITE_IDS = 'subsite_ids',
+	SITE_IDS = 'site_ids',
 	WP_CLI_COMMAND = 'wpcli_command',
 }
 
@@ -121,7 +121,7 @@ export interface DBLiveCopyConfig {
 	tool?: SQLDumpTool;
 	type: BackupLiveCopyType;
 	tables?: Record< string, Record< string, string | boolean > >;
-	subsite_ids?: number[];
+	site_ids?: number[];
 	wpcli_command?: string;
 }
 
@@ -154,7 +154,7 @@ export async function startLiveBackupCopy( {
 	if ( ! result.data?.startLiveBackupCopy.copyId ) {
 		// eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
 		throw new Error(
-			`Failed to start live backup copy: ${
+			`Failed to start partial database export: ${
 				result.data?.startLiveBackupCopy?.message
 					? result.data?.startLiveBackupCopy?.message
 					: 'Unknown error'


### PR DESCRIPTION
## Description

This pull request refactors the naming of "subsite" to "site" throughout the live backup copy codebase for consistency and clarity. It updates variable names, option keys, enum values, error messages, and configuration properties to use "siteId" and "site_ids" instead of "subsiteId" and "subsite_ids". Additionally, it improves the error message for failed partial database exports.

**Refactoring for naming consistency:**

* Renamed all references of `subsiteIds` and `subsite_id` to `siteIds` and `site_id` in the `LiveBackupCopyCLIOptions` interface, related functions, and throughout the codebase. [[1]](diffhunk://#diff-11788c2043515676722bdf307368d133f167e116e8a440ae31542ee04453eef4L15-R15) [[2]](diffhunk://#diff-11788c2043515676722bdf307368d133f167e116e8a440ae31542ee04453eef4L24-R37) [[3]](diffhunk://#diff-11788c2043515676722bdf307368d133f167e116e8a440ae31542ee04453eef4L54-R62)
* Updated the `BackupLiveCopyType` enum value from `SUBSITE_IDS` to `SITE_IDS` for consistency.
* Changed the configuration property in `DBLiveCopyConfig` from `subsite_ids` to `site_ids`.
* Modified the logic in `ExportSQLCommand` to use `siteIds` and `SITE_IDS` instead of `subsiteIds` and `SUBSITE_IDS`, including the returned config object. [[1]](diffhunk://#diff-f9c996a72c9d94099888715e40ec2b8e47e8403ece7a4bfdb7af75a413a79c1aL614-R623) [[2]](diffhunk://#diff-f9c996a72c9d94099888715e40ec2b8e47e8403ece7a4bfdb7af75a413a79c1aL633-R633)

**Error message improvement:**

* Updated the error message thrown when a live backup copy fails to start, clarifying that it is for a partial database export.

## Changelog Description

### Changed

- Partial Database Export (`vip export sql`) argument changed from `--subsite-id` to `--site-id`
- 

## Pull request checklist

- [ ] Update [SETUP.md](https://github.com/Automattic/vip-cli/blob/trunk/docs/SETUP.md#list-of-environmental-variables) with any new environmental variables.
- [ ] Update [the documentation](https://github.com/Automattic/vip-cli/blob/trunk/docs).
- [ ] [Manually test](https://github.com/Automattic/vip-cli/blob/trunk/docs/TESTING.md#manual-testing) the relevant changes.
- [ ] Follow the [pull request checklist](https://github.com/Automattic/vip-cli/blob/trunk/docs/RELEASING.md#new-pull-requests)
- [ ] Add/update [automated tests](https://github.com/Automattic/vip-cli/blob/trunk/docs/TESTING.md#automated-testing) as needed.

## New release checklist

- [ ] [Automated tests](https://github.com/Automattic/vip-cli/blob/trunk/docs/TESTING.md#automated-testing) pass.
- [ ] The [Preparing for release checklist](https://github.com/Automattic/vip-cli/blob/trunk/docs/RELEASING.md#preparing-for-release) is completed.

## Steps to Test

Outline the steps to test and verify the PR here.

Example:

1. Check out PR.
1. Run `npm run build`
1. Run `./dist/bin/vip-cookies.js nom`
1. Verify cookies are delicious.
