### PR TITLE
Updated help menu descriptions for partial db export and sync

### DIFF
--- a/src/bin/vip-dev-env-sync-sql.js
+++ b/src/bin/vip-dev-env-sync-sql.js
@@ -42,7 +42,7 @@ const examples = [
 	{
 		usage: `vip @example-app.develop dev-env sync sql --slug=example-site --config-file=~/dev-env-sync-config.json`,
 		description:
-			'Reference a local configuration file that defines which tables to sync to a local environment.',
+			'Reference a local configuration file that specifies the data to sync to a local environment.',
 	},
 ];
 
@@ -85,7 +85,7 @@ command( {
 	)
 	.option(
 		'table',
-		'The name of a table to include in the partial database sync. Accepts a string value (can be passed more than once with different values), or multiple string values in a comma-separated list.'
+		'The name of a table to include in the partial database sync. Accepts a string value and can be passed more than once with a different value, or add multiple values in a comma-separated list.'
 	)
 	.option(
 		'site-id',
@@ -93,11 +93,11 @@ command( {
 	)
 	.option(
 		'wpcli-command',
-		'The WP-CLI command to run on the remote environment to retrieve the database export configuration.'
+		'Run a custom WP-CLI command that has logic to retrieve specific data for the partial database export.'
 	)
 	.option(
 		'config-file',
-		'A local configuration file that specifies the table data to include in the partial database sync. Accepts a relative or absolute path to the file.',
+		'A local configuration file that specifies the data to include in the partial database sync. Accepts a relative or absolute path to the file.',
 		undefined
 	)
 	.option( 'force', 'Skip validations.', undefined, processBooleanOption )

--- a/src/bin/vip-dev-env-sync-sql.js
+++ b/src/bin/vip-dev-env-sync-sql.js
@@ -18,32 +18,31 @@ const examples = [
 	{
 		usage: `vip @example-app.develop dev-env sync sql --slug=example-site`,
 		description:
-			'Sync the database of the develop environment in the "example-app" application to a local environment named "example-site".',
+			'Sync the entire database of the develop environment in the "example-app" application to a local environment named "example-site".',
 	},
 	{
 		usage: `vip @example-app.develop dev-env sync sql --slug=example-site --table=wp_posts --table=wp_comments`,
 		description:
-			'Sync only the wp_posts and wp_comments tables from the database of the develop environment in the "example-app" application to a local environment named "example-site".',
+			'Sync only the wp_posts and wp_comments tables from the database of the develop environment to a local environment named "example-site".',
 	},
 	{
 		usage: `vip @example-app.develop dev-env sync sql --slug=example-site --table=wp_posts,wp_comments`,
 		description:
-			'Sync only the wp_posts and wp_comments tables using comma-separated syntax from the database of the develop environment in the "example-app" application to a local environment named "example-site".',
+			'Use comma-separated syntax to specify that only the wp_posts and wp_comments tables are synced.',
 	},
 	{
 		usage: `vip @example-app.develop dev-env sync sql --slug=example-site --site-id=2 --site-id=3`,
-		description:
-			'Sync only the tables for the network sites with IDs 2 and 3 from the database of the develop environment in the "example-app" application to a local environment named "example-site".',
+		description: 'Sync only the tables related to network site ID 2 and network site ID 3.',
 	},
 	{
 		usage: `vip @example-app.develop dev-env sync sql --slug=example-site --site-id=2,3`,
 		description:
-			'Sync only the tables for the network sites with IDs 2 and 3 using comma-separated syntax from the database of the develop environment in the "example-app" application to a local environment named "example-site".',
+			'Use comma-separated syntax to specify that only the tables related to network site ID 2 and network site ID 3 are synced.',
 	},
 	{
 		usage: `vip @example-app.develop dev-env sync sql --slug=example-site --config-file=~/dev-env-sync-config.json`,
 		description:
-			'Use the specified config file to determine what to sync from the database of the develop environment in the "example-app" application to a local environment named "example-site".',
+			'Reference a local configuration file that defines which tables to sync to a local environment.',
 	},
 ];
 
@@ -86,18 +85,21 @@ command( {
 	)
 	.option(
 		'table',
-		'A table to sync from the remote environment to the local environment. Multiple tables can be specified with multiple --table flags or as a comma-separated list.'
+		'The name of a table to include in the partial database sync. Accepts a string value (can be passed more than once with different values), or multiple string values in a comma-separated list.'
 	)
 	.option(
 		'site-id',
-
-		'The ID of a network site to sync from the remote environment to the local environment. Multiple site IDs can be specified with multiple --site-id flags or as a comma-separated list.'
+		'The ID of a network site to include in the partial database sync. Accepts an integer value (can be passed more than once with different values), or multiple integer values in a comma-separated list.'
 	)
 	.option(
 		'wpcli-command',
 		'The WP-CLI command to run on the remote environment to retrieve the database export configuration.'
 	)
-	.option( 'config-file', 'The backup copy config file to use for the sync.', undefined )
+	.option(
+		'config-file',
+		'A local configuration file that specifies the table data to include in the partial database sync. Accepts a relative or absolute path to the file.',
+		undefined
+	)
 	.option( 'force', 'Skip validations.', undefined, processBooleanOption )
 	.examples( examples )
 	.argv( process.argv, async ( arg, opt ) => {

--- a/src/bin/vip-dev-env-sync.js
+++ b/src/bin/vip-dev-env-sync.js
@@ -7,7 +7,7 @@ const examples = [
 	{
 		usage: `vip @example-app.develop dev-env sync sql --slug=example-site`,
 		description:
-			'Sync the database of the develop environment in the "example-app" application to a local environment named "example-site".',
+			'Sync the entire database of the develop environment in the "example-app" application to a local environment named "example-site".',
 	},
 ];
 

--- a/src/bin/vip-export-sql.js
+++ b/src/bin/vip-export-sql.js
@@ -44,7 +44,7 @@ const examples = [
 	{
 		usage: 'vip @example-app.develop export sql --config-file=~/db-export-config.json',
 		description:
-			'Reference a local configuration file that defines the tables and structure for the partial database export file that is generated and dowloaded.',
+			'Reference a local configuration file that specifies the data to include in the partial database export file that is generated and dowloaded.',
 	},
 ];
 
@@ -77,19 +77,19 @@ command( {
 	)
 	.option(
 		'table',
-		'The name of a table to include in the partial database export. Accepts a string value (can be passed more than once with different values), or multiple string values in a comma-separated list.'
+		'The name of a table to include in the partial database export. Accepts a string value and can be passed more than once with a different value, or add multiple values in a comma-separated list.'
 	)
 	.option(
 		'site-id',
-		'The ID of a network site to include in the partial database export. Accepts an integer value (can be passed more than once with different values), or multiple integer values in a comma-separated list.'
+		'The ID of a network site to include in the partial database export. Accepts an integer value and can be passed more than once with a different value, or add multiple values in a comma-separated list.'
 	)
 	.option(
 		'wpcli-command',
-		'The WP-CLI command to run on the remote environment to retrieve the database export configuration.'
+		'Run a custom WP-CLI command that has logic to retrieve specific data for the partial database export.'
 	)
 	.option(
 		'config-file',
-		'A local configuration file that specifies the table data to include in the partial database export. Accepts a relative or absolute path to the file.',
+		'A local configuration file that specifies the data to include in the partial database export. Accepts a relative or absolute path to the file.',
 		undefined
 	)
 	.option(

--- a/src/bin/vip-export-sql.js
+++ b/src/bin/vip-export-sql.js
@@ -19,32 +19,32 @@ const examples = [
 	{
 		usage: 'vip @example-app.develop export sql --generate-backup',
 		description:
-			'Generate a fresh database backup for an environment and download a copy of that backup.',
+			'Generate a fresh database backup for an environment and download an archived copy of that backup.',
 	},
 	{
 		usage: 'vip @example-app.develop export sql --table=wp_posts --table=wp_comments',
 		description:
-			'Generate a database backup including only the wp_posts and wp_comments tables, and download a copy of that backup.',
+			'Generate and download an archived partial database export file that includes only the wp_posts and wp_comments tables.',
 	},
 	{
 		usage: 'vip @example-app.develop export sql --table=wp_posts,wp_comments',
 		description:
-			'Generate a database backup including only the wp_posts and wp_comments tables using comma-separated syntax, and download a copy of that backup.',
+			'Use comma-separated syntax to generate and download a partial database export file that includes only the wp_posts and wp_comments tables.',
 	},
 	{
 		usage: 'vip @example-app.develop export sql --site-id=2 --site-id=3',
 		description:
-			'Generate a database backup including only the tables related to the network sites with IDs 2 and 3, and download a copy of that backup.',
+			'Generate and download a partial database export file that includes only the tables related to network site ID 2 and network site ID 3.',
 	},
 	{
 		usage: 'vip @example-app.develop export sql --site-id=2,3',
 		description:
-			'Generate a database backup including only the tables related to the network sites with IDs 2 and 3 using comma-separated syntax, and download a copy of that backup.',
+			'Use comma-separated syntax to generate and download a partial database export file that includes only the tables related to the network site ID 2 and network site ID 3.',
 	},
 	{
 		usage: 'vip @example-app.develop export sql --config-file=~/db-export-config.json',
 		description:
-			'Generate a database backup using the specified config file, and download a copy of that backup.',
+			'Reference a local configuration file that defines the tables and structure for the partial database export file that is generated and dowloaded.',
 	},
 ];
 
@@ -77,18 +77,25 @@ command( {
 	)
 	.option(
 		'table',
-		'A table to export from the remote environment. Multiple tables can be specified with multiple --table flags or as a comma-separated list.'
+		'The name of a table to include in the partial database export. Accepts a string value (can be passed more than once with different values), or multiple string values in a comma-separated list.'
 	)
 	.option(
 		'site-id',
-		'The ID of a network site to export from the remote environment. Multiple site IDs can be specified with multiple --site-id flags or as a comma-separated list.'
+		'The ID of a network site to include in the partial database export. Accepts an integer value (can be passed more than once with different values), or multiple integer values in a comma-separated list.'
 	)
 	.option(
 		'wpcli-command',
 		'The WP-CLI command to run on the remote environment to retrieve the database export configuration.'
 	)
-	.option( 'config-file', 'The backup copy config file to use for the export.', undefined )
-	.option( 'generate-backup', 'Generate a fresh database backup and export a copy of that backup.' )
+	.option(
+		'config-file',
+		'A local configuration file that specifies the table data to include in the partial database export. Accepts a relative or absolute path to the file.',
+		undefined
+	)
+	.option(
+		'generate-backup',
+		'Generate a fresh database backup and export an archived copy of that backup.'
+	)
 	.examples( examples )
 	.argv(
 		process.argv,


### PR DESCRIPTION
## Changelog Description

### Changed

- Updated the voice, tense, and format of command descriptions, examples, and usage models for the `vip export sql` and `vip dev-env sync sql` command groups to follow the VIP-CLI style guide.

## Pull request checklist

- [ n/a ] Update [SETUP.md](https://github.com/Automattic/vip-cli/blob/trunk/docs/SETUP.md#list-of-environmental-variables) with any new environmental variables.
- [ ] Update [the documentation](https://github.com/Automattic/vip-cli/blob/trunk/docs).
- [ ] [Manually test](https://github.com/Automattic/vip-cli/blob/trunk/docs/TESTING.md#manual-testing) the relevant changes.
- [x] Follow the [pull request checklist](https://github.com/Automattic/vip-cli/blob/trunk/docs/RELEASING.md#new-pull-requests)
- [x] Add/update [automated tests](https://github.com/Automattic/vip-cli/blob/trunk/docs/TESTING.md#automated-testing) as needed.

## New release checklist

- [ ] [Automated tests](https://github.com/Automattic/vip-cli/blob/trunk/docs/TESTING.md#automated-testing) pass.
- [ ] The [Preparing for release checklist](https://github.com/Automattic/vip-cli/blob/trunk/docs/RELEASING.md#preparing-for-release) is completed.

## Steps to Test

Observe the results of the `--help` display for impacted commands:

- `vip dev-env sync`
- `vip dev-env sync sql`
- `vip export sql`
