### PR TITLE
[PLTFRM-1781] Set memory limit for Elasticsearch to 1GB

### DIFF
--- a/assets/dev-env.lando.template.yml.ejs
+++ b/assets/dev-env.lando.template.yml.ejs
@@ -160,6 +160,10 @@ services:
     services:
       image: elasticsearch:8.18.2
       command: /usr/local/bin/docker-entrypoint.sh
+      deploy:
+        resources:
+          limits:
+            memory: 1GB
       environment:
         ELASTICSEARCH_IS_DEDICATED_NODE: 'no'
         ELASTICSEARCH_CLUSTER_NAME: 'bespin'

--- a/src/lib/constants/dev-environment.ts
+++ b/src/lib/constants/dev-environment.ts
@@ -39,7 +39,7 @@ export const DEV_ENVIRONMENT_PHP_VERSIONS: Record< string, PhpImage > = {
 	},
 	8.4: {
 		image: 'ghcr.io/automattic/vip-container-images/php-fpm:8.4',
-		label: '8.4 (experimental)',
+		label: '8.4',
 	},
 } as const;
 
@@ -49,4 +49,4 @@ export const DEV_ENVIRONMENT_DEFAULTS = {
 	phpVersion: Object.keys( DEV_ENVIRONMENT_PHP_VERSIONS )[ 0 ],
 } as const;
 
-export const DEV_ENVIRONMENT_VERSION = '2.3.0';
+export const DEV_ENVIRONMENT_VERSION = '2.3.1';


### PR DESCRIPTION
## Description

Elasticsearch's default behavior is to claim 50% available memory, which is undesirable. This PR introduces hard cap of 1GB.

It can be overridden via the `.lando.local.yml`, like so

```yml
services:
  elasticsearch:
    services:
      deploy:
        resources:
          limits:
            memory: 1GB
```

## Changelog Description

### Changed

- Local Dev Env: Elasticsearch container memory is capped at 1GB now

## Pull request checklist

- [ ] Update [SETUP.md](https://github.com/Automattic/vip-cli/blob/trunk/docs/SETUP.md#list-of-environmental-variables) with any new environmental variables.
- [ ] Update [the documentation](https://github.com/Automattic/vip-cli/blob/trunk/docs).
- [ ] [Manually test](https://github.com/Automattic/vip-cli/blob/trunk/docs/TESTING.md#manual-testing) the relevant changes.
- [ ] Follow the [pull request checklist](https://github.com/Automattic/vip-cli/blob/trunk/docs/RELEASING.md#new-pull-requests)
- [ ] Add/update [automated tests](https://github.com/Automattic/vip-cli/blob/trunk/docs/TESTING.md#automated-testing) as needed.

## New release checklist

- [ ] [Automated tests](https://github.com/Automattic/vip-cli/blob/trunk/docs/TESTING.md#automated-testing) pass.
- [ ] The [Preparing for release checklist](https://github.com/Automattic/vip-cli/blob/trunk/docs/RELEASING.md#preparing-for-release) is completed.

## Steps to Test

