### PR TITLE
fix(dev-env): `sync sql` with many network sites

### DIFF
--- a/__tests__/commands/dev-env-sync-sql.ts
+++ b/__tests__/commands/dev-env-sync-sql.ts
@@ -77,6 +77,7 @@ describe( 'commands/DevEnvSyncSQLCommand', () => {
 		it( 'should return a map of search-replace values for multisite', () => {
 			const cmd = new DevEnvSyncSQLCommand( app, msEnv, 'test-slug', lando );
 			cmd.slug = 'test-slug';
+			cmd.sdsSiteUrls = msEnv.wpSitesSDS.nodes;
 			cmd.siteUrls = msEnv.wpSitesSDS.nodes.map( node => node.homeUrl );
 			cmd.generateSearchReplaceMap();
 
@@ -156,6 +157,7 @@ describe( 'commands/DevEnvSyncSQLCommand', () => {
 	describe( '.run', () => {
 		const syncCommand = new DevEnvSyncSQLCommand( app, env, 'test-slug', lando );
 		const exportSpy = jest.spyOn( syncCommand, 'generateExport' );
+		const getSiteUrlsFromSDSSpy = jest.spyOn( syncCommand, 'getSiteUrlsFromSDS' );
 		const generateSearchReplaceMapSpy = jest.spyOn( syncCommand, 'generateSearchReplaceMap' );
 		const searchReplaceSpy = jest.spyOn( syncCommand, 'runSearchReplace' );
 		const importSpy = jest.spyOn( syncCommand, 'runImport' );
@@ -170,6 +172,7 @@ describe( 'commands/DevEnvSyncSQLCommand', () => {
 				syncCommand.sqlFile
 			);
 			exportSpy.mockResolvedValue();
+			getSiteUrlsFromSDSSpy.mockResolvedValue( [] );
 			searchReplaceSpy.mockResolvedValue();
 			importSpy.mockResolvedValue();
 		} );
@@ -185,6 +188,7 @@ describe( 'commands/DevEnvSyncSQLCommand', () => {
 
 			expect( exportSpy ).toHaveBeenCalled();
 			expect( clientFileUploader.unzipFile ).toHaveBeenCalled();
+			expect( getSiteUrlsFromSDSSpy ).toHaveBeenCalled();
 			expect( generateSearchReplaceMapSpy ).toHaveBeenCalled();
 			expect( searchReplaceSpy ).toHaveBeenCalled();
 			expect( importSpy ).toHaveBeenCalled();

--- a/src/bin/vip-dev-env-sync-sql.js
+++ b/src/bin/vip-dev-env-sync-sql.js
@@ -105,8 +105,6 @@ command( {
 	.examples( examples )
 	.argv( process.argv, async ( arg, opt ) => {
 		const { app, env, configFile, table, siteId, wpcliCommand, ...optRest } = opt;
-		console.log( app, env );
-		process.exit( 0 );
 
 		const liveBackupCopyCLIOptions = parseLiveBackupCopyCLIOptions(
 			configFile,

--- a/src/bin/vip-dev-env-sync-sql.js
+++ b/src/bin/vip-dev-env-sync-sql.js
@@ -2,6 +2,7 @@
 
 import { DevEnvSyncSQLCommand } from '../commands/dev-env-sync-sql';
 import command from '../lib/cli/command';
+import { NUMBER_OF_SITE_FROM_SDS } from '../lib/constants/dev-environment';
 import {
 	getEnvironmentName,
 	processBooleanOption,
@@ -59,7 +60,7 @@ const appQuery = `
 		primaryDomain { name }
 		uniqueLabel
 		isMultisite
-		wpSitesSDS(first:500) {
+		wpSitesSDS(first:${ NUMBER_OF_SITE_FROM_SDS }) {
 			nodes {
 				id
 				blogId
@@ -104,6 +105,8 @@ command( {
 	.examples( examples )
 	.argv( process.argv, async ( arg, opt ) => {
 		const { app, env, configFile, table, siteId, wpcliCommand, ...optRest } = opt;
+		console.log( app, env );
+		process.exit( 0 );
 
 		const liveBackupCopyCLIOptions = parseLiveBackupCopyCLIOptions(
 			configFile,

--- a/src/bin/vip-dev-env-sync-sql.js
+++ b/src/bin/vip-dev-env-sync-sql.js
@@ -2,7 +2,6 @@
 
 import { DevEnvSyncSQLCommand } from '../commands/dev-env-sync-sql';
 import command from '../lib/cli/command';
-import { NUMBER_OF_SITE_FROM_SDS } from '../lib/constants/dev-environment';
 import {
 	getEnvironmentName,
 	processBooleanOption,
@@ -60,7 +59,8 @@ const appQuery = `
 		primaryDomain { name }
 		uniqueLabel
 		isMultisite
-		wpSitesSDS(first:${ NUMBER_OF_SITE_FROM_SDS }) {
+		wpSitesSDS(first:500) {
+			total
 			nodes {
 				id
 				blogId

--- a/src/commands/dev-env-sync-sql.generated.d.ts
+++ b/src/commands/dev-env-sync-sql.generated.d.ts
@@ -1,0 +1,30 @@
+import * as Types from '../graphqlTypes';
+
+export type SiteUrlsQueryQueryVariables = Types.Exact< {
+	appId: Types.Scalars[ 'Int' ][ 'input' ];
+	environmentId: Types.Scalars[ 'Int' ][ 'input' ];
+	after?: Types.InputMaybe< Types.Scalars[ 'String' ][ 'input' ] >;
+	first: Types.Scalars[ 'Int' ][ 'input' ];
+} >;
+
+export type SiteUrlsQueryQuery = {
+	__typename?: 'Query';
+	app?: {
+		__typename?: 'App';
+		environments?: Array< {
+			__typename?: 'AppEnvironment';
+			wpSitesSDS?: {
+				__typename?: 'WPSiteList';
+				total?: number | null;
+				nextCursor?: string | null;
+				nodes?: Array< {
+					__typename?: 'WPSite';
+					id?: number | null;
+					blogId?: number | null;
+					homeUrl?: string | null;
+					siteUrl?: string | null;
+				} | null > | null;
+			} | null;
+		} | null > | null;
+	} | null;
+};

--- a/src/commands/dev-env-sync-sql.ts
+++ b/src/commands/dev-env-sync-sql.ts
@@ -18,7 +18,6 @@ import API from '../lib/api';
 import { BackupStorageAvailability } from '../lib/backup-storage-availability/backup-storage-availability';
 import * as exit from '../lib/cli/exit';
 import { unzipFile } from '../lib/client-file-uploader';
-import { NUMBER_OF_SITE_FROM_SDS } from '../lib/constants/dev-environment';
 import { fixMyDumperTransform, getSqlDumpDetails, SqlDumpType } from '../lib/database';
 import { LiveBackupCopyCLIOptions } from '../lib/live-backup-copy';
 import { makeTempDir } from '../lib/utils';
@@ -226,7 +225,8 @@ export class DevEnvSyncSQLCommand {
 		if (
 			this.env.isMultisite &&
 			( ! this.env.wpSitesSDS?.nodes ||
-				this.env.wpSitesSDS.nodes.length === NUMBER_OF_SITE_FROM_SDS )
+				! this.env.wpSitesSDS?.total ||
+				this.env.wpSitesSDS.nodes.length < this.env.wpSitesSDS.total )
 		) {
 			return this.fetchAllSites( Number( this.app.id ), Number( this.env.id ) );
 		}

--- a/src/commands/dev-env-sync-sql.ts
+++ b/src/commands/dev-env-sync-sql.ts
@@ -12,7 +12,7 @@ import { pipeline } from 'node:stream/promises';
 import { DevEnvImportSQLCommand, DevEnvImportSQLOptions } from './dev-env-import-sql';
 import { SiteUrlsQueryQuery, SiteUrlsQueryQueryVariables } from './dev-env-sync-sql.generated';
 import { ExportSQLCommand } from './export-sql';
-import { App, AppEnvironment, Maybe, WpSite } from '../graphqlTypes';
+import { App, AppEnvironment, WpSite } from '../graphqlTypes';
 import { TrackFunction } from '../lib/analytics/clients/tracks';
 import API from '../lib/api';
 import { BackupStorageAvailability } from '../lib/backup-storage-availability/backup-storage-availability';
@@ -118,7 +118,7 @@ export class DevEnvSyncSQLCommand {
 	public liveBackupCopyCLIOptions?: LiveBackupCopyCLIOptions;
 	public _track: TrackFunction;
 	private _sqlDumpType?: SqlDumpType;
-	public sdsSiteUrls: Maybe< WpSite >[] | null | undefined = null;
+	public sdsSiteUrls: WpSite[] = [];
 
 	/**
 	 * Creates a new instance of the command
@@ -221,7 +221,7 @@ export class DevEnvSyncSQLCommand {
 		fs.renameSync( outputFile, this.sqlFile );
 	}
 
-	public async getSiteUrlsFromSDS(): Promise< Maybe< WpSite >[] > {
+	public async getSiteUrlsFromSDS(): Promise< WpSite[] > {
 		if (
 			this.env.isMultisite &&
 			( ! this.env.wpSitesSDS?.nodes ||
@@ -231,7 +231,7 @@ export class DevEnvSyncSQLCommand {
 			return this.fetchAllSites( Number( this.app.id ), Number( this.env.id ) );
 		}
 
-		return this.env.wpSitesSDS?.nodes ?? [];
+		return this.env.wpSitesSDS?.nodes?.filter( ( node ): node is WpSite => Boolean( node ) ) ?? [];
 	}
 
 	private fetchSitesPage(
@@ -263,7 +263,11 @@ export class DevEnvSyncSQLCommand {
 			const res = await this.fetchSitesPage( api, appId, environmentId, after );
 			if ( res.data.app?.environments?.[ 0 ]?.wpSitesSDS?.nodes ) {
 				const wpSitesSDS = res.data.app.environments[ 0 ].wpSitesSDS;
-				allSites.push( ...( res.data.app.environments[ 0 ].wpSitesSDS.nodes as WpSite[] ) );
+				allSites.push(
+					...res.data.app.environments[ 0 ].wpSitesSDS.nodes.filter( ( node ): node is WpSite =>
+						Boolean( node )
+					)
+				);
 				after = wpSitesSDS.nextCursor;
 				total = Number( wpSitesSDS.total );
 				console.log( `Fetched ${ allSites.length } of ${ total } sites...` );
@@ -285,7 +289,7 @@ export class DevEnvSyncSQLCommand {
 		}
 
 		const networkSites = this.sdsSiteUrls;
-		if ( ! networkSites ) return;
+		if ( ! networkSites.length ) return;
 
 		const primaryUrl = networkSites.find( site => site?.blogId === 1 )?.homeUrl;
 		const primaryDomain = primaryUrl ? new URL( primaryUrl ).hostname : '';
@@ -347,7 +351,7 @@ export class DevEnvSyncSQLCommand {
 
 	private fixBlogsTableQuery() {
 		const networkSites = this.sdsSiteUrls;
-		if ( ! networkSites ) {
+		if ( ! networkSites.length ) {
 			return '';
 		}
 
@@ -446,7 +450,17 @@ DROP PROCEDURE vip_sync_update_blog_domains;
 			exit.withError( `Error extracting site URLs: ${ error.message }` );
 		}
 
-		this.sdsSiteUrls = await this.getSiteUrlsFromSDS();
+		try {
+			this.sdsSiteUrls = await this.getSiteUrlsFromSDS();
+		} catch ( err ) {
+			const error = err as Error;
+			await this.track( 'error', {
+				error_type: 'get_site_urls_from_sds',
+				error_message: error.message,
+				stack: error.stack,
+			} );
+			exit.withError( `Error getting site URLs from SDS: ${ error.message }` );
+		}
 
 		console.log( 'Generating search-replace configuration...' );
 		this.generateSearchReplaceMap();

--- a/src/commands/dev-env-sync-sql.ts
+++ b/src/commands/dev-env-sync-sql.ts
@@ -1,16 +1,20 @@
 #!/usr/bin/env node
 
+import { ApolloQueryResult } from '@apollo/client';
 import { replace } from '@automattic/vip-search-replace';
 import chalk from 'chalk';
 import debugLib from 'debug';
 import fs from 'fs';
+import gql from 'graphql-tag';
 import Lando from 'lando';
 import { pipeline } from 'node:stream/promises';
 
 import { DevEnvImportSQLCommand, DevEnvImportSQLOptions } from './dev-env-import-sql';
+import { SiteUrlsQueryQuery, SiteUrlsQueryQueryVariables } from './dev-env-sync-sql.generated';
 import { ExportSQLCommand } from './export-sql';
-import { App, AppEnvironment } from '../graphqlTypes';
+import { App, AppEnvironment, Maybe, WpSite } from '../graphqlTypes';
 import { TrackFunction } from '../lib/analytics/clients/tracks';
+import API from '../lib/api';
 import { BackupStorageAvailability } from '../lib/backup-storage-availability/backup-storage-availability';
 import * as exit from '../lib/cli/exit';
 import { unzipFile } from '../lib/client-file-uploader';
@@ -88,6 +92,25 @@ async function extractSiteUrls( sqlFile: string ): Promise< string[] > {
 	} );
 }
 
+const SITE_URLS_QUERY = gql`
+	query SiteUrlsQuery($appId: Int!, $environmentId: Int!, $after: String, $first: Int!) {
+		app(id: $appId) {
+			environments(id: $environmentId) {
+				wpSitesSDS(after: $after, first: $first) {
+					total
+					nextCursor
+					nodes {
+						id
+						blogId
+						homeUrl
+						siteUrl
+					}
+				}
+			}
+		}
+	}
+`;
+
 export class DevEnvSyncSQLCommand {
 	public tmpDir: string;
 	public siteUrls: string[] = [];
@@ -95,6 +118,7 @@ export class DevEnvSyncSQLCommand {
 	public liveBackupCopyCLIOptions?: LiveBackupCopyCLIOptions;
 	public _track: TrackFunction;
 	private _sqlDumpType?: SqlDumpType;
+	private sdsSiteUrls: Maybe< WpSite >[] | null | undefined = null;
 
 	/**
 	 * Creates a new instance of the command
@@ -197,6 +221,55 @@ export class DevEnvSyncSQLCommand {
 		fs.renameSync( outputFile, this.sqlFile );
 	}
 
+	public async getSiteUrlsFromSDS(): Promise< Maybe< WpSite >[] > {
+		if ( ! this.env.wpSitesSDS?.nodes || this.env.wpSitesSDS.nodes.length === 500 ) {
+			return this.fetchAllSites( Number( this.app.id ), Number( this.env.id as number ) );
+		}
+
+		return this.env.wpSitesSDS.nodes;
+	}
+
+	private fetchSitesPage(
+		api: ReturnType< typeof API >,
+		appId: number,
+		environmentId: number,
+		after: string | null
+	): Promise< ApolloQueryResult< SiteUrlsQueryQuery > > {
+		return api.query< SiteUrlsQueryQuery, SiteUrlsQueryQueryVariables >( {
+			query: SITE_URLS_QUERY,
+			variables: {
+				first: 100,
+				after,
+				appId,
+				environmentId,
+			},
+		} );
+	}
+
+	private async fetchAllSites( appId: number, environmentId: number ): Promise< WpSite[] > {
+		const api = API();
+		let after: string | null | undefined = null;
+		const allSites: WpSite[] = [];
+		let total = 0;
+
+		console.log( 'Fetching list of sites for database sync...' );
+		do {
+			// eslint-disable-next-line no-await-in-loop
+			const res = await this.fetchSitesPage( api, appId, environmentId, after );
+			if ( res.data.app?.environments?.[ 0 ]?.wpSitesSDS?.nodes ) {
+				const wpSitesSDS = res.data.app.environments[ 0 ].wpSitesSDS;
+				allSites.push( ...( res.data.app.environments[ 0 ].wpSitesSDS.nodes as WpSite[] ) );
+				after = wpSitesSDS.nextCursor;
+				total = Number( wpSitesSDS.total );
+				console.log( `Fetched ${ allSites.length } of ${ total } sites...` );
+			} else {
+				after = null;
+			}
+		} while ( after );
+
+		return allSites;
+	}
+
 	public generateSearchReplaceMap(): void {
 		this.searchReplaceMap = {};
 
@@ -206,7 +279,7 @@ export class DevEnvSyncSQLCommand {
 			);
 		}
 
-		const networkSites = this.env.wpSitesSDS?.nodes;
+		const networkSites = this.sdsSiteUrls;
 		if ( ! networkSites ) return;
 
 		const primaryUrl = networkSites.find( site => site?.blogId === 1 )?.homeUrl;
@@ -268,7 +341,7 @@ export class DevEnvSyncSQLCommand {
 	}
 
 	private fixBlogsTableQuery() {
-		const networkSites = this.env.wpSitesSDS?.nodes;
+		const networkSites = this.sdsSiteUrls;
 		if ( ! networkSites ) {
 			return '';
 		}
@@ -367,6 +440,8 @@ DROP PROCEDURE vip_sync_update_blog_domains;
 			} );
 			exit.withError( `Error extracting site URLs: ${ error.message }` );
 		}
+
+		this.sdsSiteUrls = await this.getSiteUrlsFromSDS();
 
 		console.log( 'Generating search-replace configuration...' );
 		this.generateSearchReplaceMap();

--- a/src/commands/dev-env-sync-sql.ts
+++ b/src/commands/dev-env-sync-sql.ts
@@ -18,6 +18,7 @@ import API from '../lib/api';
 import { BackupStorageAvailability } from '../lib/backup-storage-availability/backup-storage-availability';
 import * as exit from '../lib/cli/exit';
 import { unzipFile } from '../lib/client-file-uploader';
+import { NUMBER_OF_SITE_FROM_SDS } from '../lib/constants/dev-environment';
 import { fixMyDumperTransform, getSqlDumpDetails, SqlDumpType } from '../lib/database';
 import { LiveBackupCopyCLIOptions } from '../lib/live-backup-copy';
 import { makeTempDir } from '../lib/utils';
@@ -118,7 +119,7 @@ export class DevEnvSyncSQLCommand {
 	public liveBackupCopyCLIOptions?: LiveBackupCopyCLIOptions;
 	public _track: TrackFunction;
 	private _sqlDumpType?: SqlDumpType;
-	private sdsSiteUrls: Maybe< WpSite >[] | null | undefined = null;
+	public sdsSiteUrls: Maybe< WpSite >[] | null | undefined = null;
 
 	/**
 	 * Creates a new instance of the command
@@ -222,11 +223,15 @@ export class DevEnvSyncSQLCommand {
 	}
 
 	public async getSiteUrlsFromSDS(): Promise< Maybe< WpSite >[] > {
-		if ( ! this.env.wpSitesSDS?.nodes || this.env.wpSitesSDS.nodes.length === 500 ) {
+		if (
+			this.env.isMultisite &&
+			( ! this.env.wpSitesSDS?.nodes ||
+				this.env.wpSitesSDS.nodes.length === NUMBER_OF_SITE_FROM_SDS )
+		) {
 			return this.fetchAllSites( Number( this.app.id ), Number( this.env.id as number ) );
 		}
 
-		return this.env.wpSitesSDS.nodes;
+		return this.env.wpSitesSDS?.nodes ?? [];
 	}
 
 	private fetchSitesPage(

--- a/src/commands/dev-env-sync-sql.ts
+++ b/src/commands/dev-env-sync-sql.ts
@@ -228,7 +228,7 @@ export class DevEnvSyncSQLCommand {
 			( ! this.env.wpSitesSDS?.nodes ||
 				this.env.wpSitesSDS.nodes.length === NUMBER_OF_SITE_FROM_SDS )
 		) {
-			return this.fetchAllSites( Number( this.app.id ), Number( this.env.id as number ) );
+			return this.fetchAllSites( Number( this.app.id ), Number( this.env.id ) );
 		}
 
 		return this.env.wpSitesSDS?.nodes ?? [];

--- a/src/commands/dev-env-sync-sql.ts
+++ b/src/commands/dev-env-sync-sql.ts
@@ -255,7 +255,7 @@ export class DevEnvSyncSQLCommand {
 		const api = API();
 		let after: string | null | undefined = null;
 		const allSites: WpSite[] = [];
-		let total = 0;
+		let total: number;
 
 		console.log( 'Fetching list of sites for database sync...' );
 		do {

--- a/src/lib/constants/dev-environment.ts
+++ b/src/lib/constants/dev-environment.ts
@@ -22,6 +22,8 @@ export const DEV_ENVIRONMENT_WORDPRESS_CACHE_KEY = 'wordpress-versions.json';
 
 export const DEV_ENVIRONMENT_WORDPRESS_VERSION_TTL = 86400; // once per day
 
+export const NUMBER_OF_SITE_FROM_SDS = 500;
+
 interface PhpImage {
 	image: string;
 	label: string;

--- a/src/lib/constants/dev-environment.ts
+++ b/src/lib/constants/dev-environment.ts
@@ -22,8 +22,6 @@ export const DEV_ENVIRONMENT_WORDPRESS_CACHE_KEY = 'wordpress-versions.json';
 
 export const DEV_ENVIRONMENT_WORDPRESS_VERSION_TTL = 86400; // once per day
 
-export const NUMBER_OF_SITE_FROM_SDS = 500;
-
 interface PhpImage {
 	image: string;
 	label: string;


### PR DESCRIPTION
## Description

This pull request introduces improvements to the multisite SQL sync process, specifically enhancing how site URLs are fetched and used during search-and-replace operations. The main change is adding logic to fetch all site URLs from SDS via paginated GraphQL queries, ensuring that all multisite URLs are available for accurate database syncs.

#### Multisite site URL fetching and usage

* Added a paginated GraphQL query (`SITE_URLS_QUERY`) and related logic to fetch all site URLs from SDS, addressing cases where the default environment data may be incomplete. This ensures the sync operation works with the full set of multisite URLs. [[1]](diffhunk://#diff-2d14f3c6a0add05c867268d61ebd6ee91441615c585977292eeab241785fe96aR96-R122) [[2]](diffhunk://#diff-2d14f3c6a0add05c867268d61ebd6ee91441615c585977292eeab241785fe96aR225-R277) [[3]](diffhunk://#diff-b4be5d52558b1c8e11df527bb8e26ea540e55f42ca24da3f8315956dd8f38491R25-R26)
* Updated the `DevEnvSyncSQLCommand` class to store fetched site URLs in the new `sdsSiteUrls` property, replacing previous usage of `env.wpSitesSDS.nodes` in search-replace and blogs table logic. [[1]](diffhunk://#diff-2d14f3c6a0add05c867268d61ebd6ee91441615c585977292eeab241785fe96aL209-R287) [[2]](diffhunk://#diff-2d14f3c6a0add05c867268d61ebd6ee91441615c585977292eeab241785fe96aL271-R349) [[3]](diffhunk://#diff-2d14f3c6a0add05c867268d61ebd6ee91441615c585977292eeab241785fe96aR449-R450)

#### Test enhancements

* Modified tests in `__tests__/commands/dev-env-sync-sql.ts` to set up and verify the new site URL fetching logic, including mocking the `getSiteUrlsFromSDS` method and checking its invocation. [[1]](diffhunk://#diff-e66accd6ab778605597a19c013106d7c066d738c51e47620bf339edc1e4b3d73R80) [[2]](diffhunk://#diff-e66accd6ab778605597a19c013106d7c066d738c51e47620bf339edc1e4b3d73R160) [[3]](diffhunk://#diff-e66accd6ab778605597a19c013106d7c066d738c51e47620bf339edc1e4b3d73R175) [[4]](diffhunk://#diff-e66accd6ab778605597a19c013106d7c066d738c51e47620bf339edc1e4b3d73R191)

## Changelog Description

### Fixed

- `vip dev-env sync sql` now supports networks with more than 500 sites.

## Pull request checklist

- [ ] Update [SETUP.md](https://github.com/Automattic/vip-cli/blob/trunk/docs/SETUP.md#list-of-environmental-variables) with any new environmental variables.
- [ ] Update [the documentation](https://github.com/Automattic/vip-cli/blob/trunk/docs).
- [x] [Manually test](https://github.com/Automattic/vip-cli/blob/trunk/docs/TESTING.md#manual-testing) the relevant changes.
- [x] Follow the [pull request checklist](https://github.com/Automattic/vip-cli/blob/trunk/docs/RELEASING.md#new-pull-requests)
- [x] Add/update [automated tests](https://github.com/Automattic/vip-cli/blob/trunk/docs/TESTING.md#automated-testing) as needed.

## New release checklist

- [ ] [Automated tests](https://github.com/Automattic/vip-cli/blob/trunk/docs/TESTING.md#automated-testing) pass.
- [ ] The [Preparing for release checklist](https://github.com/Automattic/vip-cli/blob/trunk/docs/RELEASING.md#preparing-for-release) is completed.

## Steps to Test

See PLTFRM-1654