### PR TITLE
fix(dev-env): `key=value` parsing

### DIFF
--- a/__tests__/lib/utils.js
+++ b/__tests__/lib/utils.js
@@ -1,0 +1,15 @@
+import { splitKeyValueString } from '../../src/lib/utils';
+
+describe( 'splitKeyValueString', () => {
+	it.each( [
+		[ 'KEY=VALUE', [ 'KEY', 'VALUE' ] ],
+		[ ' KEY = VALUE ', [ 'KEY', 'VALUE' ] ],
+		[ 'KEY=VALUE=WITH=EQUALS', [ 'KEY', 'VALUE=WITH=EQUALS' ] ],
+		[ 'KEY=', [ 'KEY', '' ] ],
+		[ 'KEY', [ 'KEY', '' ] ],
+		[ '=VALUE', [ '', 'VALUE' ] ],
+		[ '', [ '', '' ] ],
+	] )( 'splits "%s" into %o', ( input, expected ) => {
+		expect( splitKeyValueString( input ) ).toEqual( expected );
+	} );
+} );

--- a/src/bin/vip-dev-env-envvar-delete.js
+++ b/src/bin/vip-dev-env-envvar-delete.js
@@ -12,6 +12,7 @@ import {
 import { readEnvFile, updateEnvFile } from '../lib/dev-environment/env-vars';
 import { debug } from '../lib/envvar/logging';
 import { trackEvent } from '../lib/tracker';
+import { splitKeyValueString } from '../lib/utils';
 
 const exampleUsage = 'vip dev-env envvar delete --slug=example-site';
 const usage = 'vip dev-env envvar delete';
@@ -39,7 +40,7 @@ async function deleteEnvVarCommand( args, opt ) {
 		const data = await readEnvFile( slug );
 		const envVars = [];
 		data.forEach( line => {
-			const [ key ] = line.split( '=', 2 ).map( part => part.trim() );
+			const [ key ] = splitKeyValueString( line );
 			if ( key !== name ) {
 				envVars.push( line );
 			} else {

--- a/src/bin/vip-dev-env-envvar-get-all.js
+++ b/src/bin/vip-dev-env-envvar-get-all.js
@@ -13,6 +13,7 @@ import {
 import { parseEnvValue, readEnvFile } from '../lib/dev-environment/env-vars';
 import { debug } from '../lib/envvar/logging';
 import { trackEvent } from '../lib/tracker';
+import { splitKeyValueString } from '../lib/utils';
 
 const exampleUsage = 'vip dev-env envvar get-all --slug=example-site';
 const usage = 'vip dev-env envvar get-all';
@@ -43,7 +44,7 @@ async function getAllEnvVarsCommand( args, opt ) {
 	try {
 		const data = await readEnvFile( slug );
 		const envVars = data.map( line => {
-			const [ key, value ] = line.split( '=', 2 ).map( part => part.trim() );
+			const [ key, value ] = splitKeyValueString( line );
 			return { name: key, value: parseEnvValue( value ) };
 		} );
 

--- a/src/bin/vip-dev-env-envvar-get.js
+++ b/src/bin/vip-dev-env-envvar-get.js
@@ -12,6 +12,7 @@ import {
 import { parseEnvValue, readEnvFile } from '../lib/dev-environment/env-vars';
 import { debug } from '../lib/envvar/logging';
 import { trackEvent } from '../lib/tracker';
+import { splitKeyValueString } from '../lib/utils';
 
 const exampleUsage = 'vip dev-env envvar get --slug=example-site';
 const usage = 'vip dev-env envvar get';
@@ -38,7 +39,7 @@ async function getEnvVarsCommand( args, opt ) {
 	try {
 		const data = await readEnvFile( slug );
 		const envVar = data
-			.map( line => line.split( '=', 2 ) )
+			.map( line => splitKeyValueString( line ) )
 			.find( ( [ key ] ) => name === key.trim() );
 
 		if ( undefined === envVar ) {

--- a/src/bin/vip-dev-env-envvar-list.js
+++ b/src/bin/vip-dev-env-envvar-list.js
@@ -13,6 +13,7 @@ import {
 import { readEnvFile } from '../lib/dev-environment/env-vars';
 import { debug } from '../lib/envvar/logging';
 import { trackEvent } from '../lib/tracker';
+import { splitKeyValueString } from '../lib/utils';
 
 const usage = 'vip dev-env envvar list';
 
@@ -39,7 +40,7 @@ async function listEnvVarsCommand( args, opt ) {
 	try {
 		const data = await readEnvFile( slug );
 		const envVars = data.map( line => {
-			const [ key ] = line.split( '=', 2 );
+			const [ key ] = splitKeyValueString( line );
 			return { name: key.trim() };
 		} );
 

--- a/src/bin/vip-dev-env-envvar-set.js
+++ b/src/bin/vip-dev-env-envvar-set.js
@@ -15,6 +15,7 @@ import { cancel, promptForValue } from '../lib/envvar/input';
 import { debug } from '../lib/envvar/logging';
 import { readVariableFromFile } from '../lib/envvar/read-file';
 import { trackEvent } from '../lib/tracker';
+import { splitKeyValueString } from '../lib/utils';
 
 const exampleUsage = 'vip dev-env envvar set --slug=example-site';
 const usage = 'vip dev-env envvar set';
@@ -74,7 +75,7 @@ async function deleteEnvVarCommand( args, opt ) {
 		let replaced = false;
 
 		const envVars = data.map( line => {
-			const [ key ] = line.split( '=', 2 ).map( part => part.trim() );
+			const [ key ] = splitKeyValueString( line );
 			if ( key === name ) {
 				replaced = true;
 				return `${ key }=${ newValue }`;

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -104,3 +104,17 @@ export function parseApiError( err: {
 
 	return null;
 }
+
+export function splitKeyValueString(
+	str: string,
+	delimiter = '='
+): [ key: string, value: string ] {
+	const delimiterIndex = str.indexOf( delimiter );
+	if ( delimiterIndex === -1 ) {
+		return [ str.trim(), '' ];
+	}
+
+	const key = str.slice( 0, delimiterIndex ).trim();
+	const value = str.slice( delimiterIndex + delimiter.length ).trim();
+	return [ key, value ];
+}


### PR DESCRIPTION
## Description

`vip dev-env envvar` commands incorrectly display values containing the equal sign. This happens because the equal sign splits the key-value line, and `split()` in JavaScript behaves differently than in PHP (`'x=a=b'.split( '=', 2 )` will split the entire line by `=`, but will return only the first two items; while PHP in this case will split the line by the first `=`).

This PR fixes that.

## Changelog Description

### Fixed

- `vip dev-env envvar` commands now correctly display values with embedded equal signs.

## Pull request checklist

- [ ] Update [SETUP.md](https://github.com/Automattic/vip-cli/blob/trunk/docs/SETUP.md#list-of-environmental-variables) with any new environmental variables.
- [ ] Update [the documentation](https://github.com/Automattic/vip-cli/blob/trunk/docs).
- [x] [Manually test](https://github.com/Automattic/vip-cli/blob/trunk/docs/TESTING.md#manual-testing) the relevant changes.
- [x] Follow the [pull request checklist](https://github.com/Automattic/vip-cli/blob/trunk/docs/RELEASING.md#new-pull-requests)
- [x] Add/update [automated tests](https://github.com/Automattic/vip-cli/blob/trunk/docs/TESTING.md#automated-testing) as needed.

## New release checklist

- [ ] [Automated tests](https://github.com/Automattic/vip-cli/blob/trunk/docs/TESTING.md#automated-testing) pass.
- [ ] The [Preparing for release checklist](https://github.com/Automattic/vip-cli/blob/trunk/docs/RELEASING.md#preparing-for-release) is completed.

## Steps to Test

1. `vip dev-env envvar set X 123==`
2. `vip dev-env envvar get-all`

Without this patch, the result will be
```
┌──────┬───────┐
│ name │ value │
├──────┼───────┤
│ X    │ "123  │
└──────┴───────┘
```

With this patch,
```
┌──────┬───────┐
│ name │ value │
├──────┼───────┤
│ X    │ 123== │
└──────┴───────┘
```
