### PR TITLE
fix: make Jest work with Node 25

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -82,6 +82,8 @@ jobs:
           - 'lts/*'
           - 'lts/-1'
           - current
+    env:
+      NODE_OPTIONS: "--localstorage-file=/tmp/localstorage"
     steps:
       - name: Check out the source code
         uses: actions/checkout@v5

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -83,7 +83,7 @@ jobs:
           - 'lts/-1'
           - current
     env:
-      NODE_OPTIONS: "--localstorage-file=/tmp/localstorage"
+      NODE_OPTIONS: '--localstorage-file=/tmp/localstorage'
     steps:
       - name: Check out the source code
         uses: actions/checkout@v5

--- a/.github/workflows/devenv-e2e.yml
+++ b/.github/workflows/devenv-e2e.yml
@@ -21,6 +21,8 @@ jobs:
           - 2
           - 3
     runs-on: ubuntu-latest
+    env:
+      NODE_OPTIONS: "--localstorage-file=/tmp/localstorage"
     steps:
       - name: Checkout
         uses: actions/checkout@v5

--- a/.github/workflows/devenv-e2e.yml
+++ b/.github/workflows/devenv-e2e.yml
@@ -22,7 +22,7 @@ jobs:
           - 3
     runs-on: ubuntu-latest
     env:
-      NODE_OPTIONS: "--localstorage-file=/tmp/localstorage"
+      NODE_OPTIONS: '--localstorage-file=/tmp/localstorage'
     steps:
       - name: Checkout
         uses: actions/checkout@v5


### PR DESCRIPTION
## Description

Jest does not work with Node.js 25.x:

```
SecurityError: Cannot initialize local storage without a `--localstorage-file` path
```

This is due to a [breaking change](nodejs/node#60351) in Node.js, and Jest is not yet ready for it.

This PR provides a workaround for this bug. It will need to be reverted when Jest fixes the issue.

Ref: jestjs/jest#15888

## Pull request checklist

- [ ] Update [SETUP.md](https://github.com/Automattic/vip-cli/blob/trunk/docs/SETUP.md#list-of-environmental-variables) with any new environmental variables.
- [ ] Update [the documentation](https://github.com/Automattic/vip-cli/blob/trunk/docs).
- [x] [Manually test](https://github.com/Automattic/vip-cli/blob/trunk/docs/TESTING.md#manual-testing) the relevant changes.
- [ ] Follow the [pull request checklist](https://github.com/Automattic/vip-cli/blob/trunk/docs/RELEASING.md#new-pull-requests)
- [ ] Add/update [automated tests](https://github.com/Automattic/vip-cli/blob/trunk/docs/TESTING.md#automated-testing) as needed.

## New release checklist

- [ ] [Automated tests](https://github.com/Automattic/vip-cli/blob/trunk/docs/TESTING.md#automated-testing) pass.
- [ ] The [Preparing for release checklist](https://github.com/Automattic/vip-cli/blob/trunk/docs/RELEASING.md#preparing-for-release) is completed.

## Steps to Test

CI must pass.