### PR TITLE
[PLTFRM-1814] [PLTFRM-1822] feat: add --skip-download option to export sql command

### DIFF
--- a/__tests__/commands/export-sql.ts
+++ b/__tests__/commands/export-sql.ts
@@ -254,7 +254,7 @@ describe( 'commands/ExportSQLCommand', () => {
 			const downloadMock = jest.spyOn( downloadFileModule, 'downloadFile' ).mockResolvedValue();
 
 			await exportCommand.run();
-			expect( stepSuccessSpy ).toHaveBeenCalledWith( 'prepare' );
+			expect( stepSuccessSpy ).toHaveBeenCalledWith( 'prepare', expect.any( Array ) );
 			expect( stepSuccessSpy ).toHaveBeenCalledWith( 'create' );
 			expect( stepSuccessSpy ).toHaveBeenCalledWith( 'confirmEnoughStorage' );
 			expect( stepSuccessSpy ).toHaveBeenCalledWith( 'downloadLink' );
@@ -264,6 +264,35 @@ describe( 'commands/ExportSQLCommand', () => {
 				'exported.sql.gz',
 				expect.any( Function )
 			);
+		} );
+
+		it( 'should return download URL instead of downloading when skipDownload is true', async () => {
+			const exportCommandWithUrl = new ExportSQLCommand( app, env, { skipDownload: true } );
+			const stepSuccessSpyUrl = jest.spyOn( exportCommandWithUrl.progressTracker, 'stepSuccess' );
+			const stepSkippedSpy = jest.spyOn( exportCommandWithUrl.progressTracker, 'stepSkipped' );
+			const confirmEnoughStorageSpyUrl = jest.spyOn( exportCommandWithUrl, 'confirmEnoughStorage' );
+			const downloadMock = jest.spyOn( downloadFileModule, 'downloadFile' ).mockResolvedValue();
+			const consoleLogSpy = jest.spyOn( console, 'log' ).mockImplementation();
+
+			confirmEnoughStorageSpyUrl.mockResolvedValue( { continue: true, isPromptShown: false } );
+
+			await exportCommandWithUrl.run();
+
+			// Should skip confirmEnoughStorage and download steps
+			expect( stepSkippedSpy ).toHaveBeenCalledWith( 'confirmEnoughStorage' );
+			expect( stepSkippedSpy ).toHaveBeenCalledWith( 'download' );
+
+			// Should not call confirmEnoughStorage or download
+			expect( confirmEnoughStorageSpyUrl ).not.toHaveBeenCalled();
+			expect( downloadMock ).not.toHaveBeenCalled();
+
+			// Should output the download URL
+			expect( consoleLogSpy ).toHaveBeenCalledWith( 'Download URL: https://test-backup.sql.gz' );
+
+			stepSuccessSpyUrl.mockRestore();
+			stepSkippedSpy.mockRestore();
+			confirmEnoughStorageSpyUrl.mockRestore();
+			consoleLogSpy.mockRestore();
 		} );
 	} );
 

--- a/__tests__/commands/export-sql.ts
+++ b/__tests__/commands/export-sql.ts
@@ -257,7 +257,9 @@ describe( 'commands/ExportSQLCommand', () => {
 			expect( stepSuccessSpy ).toHaveBeenCalledWith( 'prepare', expect.any( Array ) );
 			expect( stepSuccessSpy ).toHaveBeenCalledWith( 'create' );
 			expect( stepSuccessSpy ).toHaveBeenCalledWith( 'confirmEnoughStorage' );
-			expect( stepSuccessSpy ).toHaveBeenCalledWith( 'downloadLink' );
+			expect( stepSuccessSpy ).toHaveBeenCalledWith( 'downloadLink', [
+				'https://test-backup.sql.gz',
+			] );
 			expect( stepSuccessSpy ).toHaveBeenCalledWith( 'download' );
 			expect( downloadMock ).toHaveBeenCalledWith(
 				'https://test-backup.sql.gz',
@@ -287,7 +289,9 @@ describe( 'commands/ExportSQLCommand', () => {
 			expect( downloadMock ).not.toHaveBeenCalled();
 
 			// Should output the download URL
-			expect( consoleLogSpy ).toHaveBeenCalledWith( 'Download URL: https://test-backup.sql.gz' );
+			expect( consoleLogSpy ).toHaveBeenCalledWith(
+				expect.stringContaining( 'https://test-backup.sql.gz' )
+			);
 
 			stepSuccessSpyUrl.mockRestore();
 			stepSkippedSpy.mockRestore();

--- a/src/bin/vip-export-sql.js
+++ b/src/bin/vip-export-sql.js
@@ -22,6 +22,11 @@ const examples = [
 			'Generate a fresh database backup for an environment and download an archived copy of that backup.',
 	},
 	{
+		usage: 'vip @example-app.develop export sql --skip-download',
+		description:
+			'Get the download URL for the most recent database backup without downloading the file.',
+	},
+	{
 		usage: 'vip @example-app.develop export sql --table=wp_posts --table=wp_comments',
 		description:
 			'Generate and download an archived partial database export file that includes only the wp_posts and wp_comments tables.',
@@ -96,12 +101,13 @@ command( {
 		'generate-backup',
 		'Generate a fresh database backup and export an archived copy of that backup.'
 	)
+	.option( 'skip-download', 'Skip downloading the file and output the download URL instead.' )
 	.examples( examples )
 	.argv(
 		process.argv,
 		async (
 			arg,
-			{ app, env, output, configFile, table, siteId, wpcliCommand, generateBackup }
+			{ app, env, output, configFile, table, siteId, wpcliCommand, generateBackup, skipDownload }
 		) => {
 			const liveBackupCopyCLIOptions = parseLiveBackupCopyCLIOptions(
 				configFile,
@@ -121,7 +127,7 @@ command( {
 			const exportCommand = new ExportSQLCommand(
 				app,
 				env,
-				{ outputFile: output, generateBackup, liveBackupCopyCLIOptions },
+				{ outputFile: output, generateBackup, liveBackupCopyCLIOptions, skipDownload },
 				trackerFn
 			);
 			await exportCommand.run();

--- a/src/bin/vip-export-sql.js
+++ b/src/bin/vip-export-sql.js
@@ -23,8 +23,7 @@ const examples = [
 	},
 	{
 		usage: 'vip @example-app.develop export sql --skip-download',
-		description:
-			'Get the download URL for the most recent database backup without downloading the file.',
+		description: 'Skip downloading the database backup file.',
 	},
 	{
 		usage: 'vip @example-app.develop export sql --table=wp_posts --table=wp_comments',
@@ -101,7 +100,7 @@ command( {
 		'generate-backup',
 		'Generate a fresh database backup and export an archived copy of that backup.'
 	)
-	.option( 'skip-download', 'Skip downloading the file and output the download URL instead.' )
+	.option( 'skip-download', 'Skip downloading the file.' )
 	.examples( examples )
 	.argv(
 		process.argv,

--- a/src/commands/export-sql.ts
+++ b/src/commands/export-sql.ts
@@ -19,7 +19,7 @@ import {
 	PromptStatus,
 } from '../lib/backup-storage-availability/backup-storage-availability';
 import * as exit from '../lib/cli/exit';
-import { formatBytes, getGlyphForStatus } from '../lib/cli/format';
+import { formatBytes } from '../lib/cli/format';
 import { ProgressTracker } from '../lib/cli/progress';
 import { downloadFile, OnProgressCallback } from '../lib/http/download-file';
 import * as liveBackupCopy from '../lib/live-backup-copy';
@@ -221,6 +221,7 @@ export interface ExportSQLOptions {
 	generateBackup?: boolean;
 	liveBackupCopyCLIOptions?: LiveBackupCopyCLIOptions;
 	showMyDumperWarning?: boolean;
+	skipDownload?: boolean;
 }
 
 /**
@@ -243,6 +244,8 @@ export class ExportSQLCommand {
 	private readonly liveBackupCopyCLIOptions?: LiveBackupCopyCLIOptions;
 
 	private readonly showMyDumperWarning: boolean;
+
+	private readonly skipDownload: boolean;
 
 	/**
 	 * Creates an instance of SQLExportCommand
@@ -273,6 +276,7 @@ export class ExportSQLCommand {
 		this.liveBackupCopyCLIOptions = options.liveBackupCopyCLIOptions;
 		this.showMyDumperWarning =
 			options.showMyDumperWarning === undefined ? true : options.showMyDumperWarning;
+		this.skipDownload = options.skipDownload || false;
 	}
 
 	/**
@@ -412,6 +416,17 @@ export class ExportSQLCommand {
 			size = Number( bytesWrittenMeta.value );
 		}
 
+		if ( this.skipDownload ) {
+			this.progressTracker.stepSkipped( this.steps.CONFIRM_ENOUGH_STORAGE );
+			this.progressTracker.stepSkipped( this.steps.DOWNLOAD );
+			this.progressTracker.print();
+			this.progressTracker.stopPrinting();
+
+			console.log( `Download URL: ${ url }` );
+
+			return;
+		}
+
 		const storageConfirmed = await this.progressTracker.handleContinuePrompt(
 			async setPromptShown => {
 				const status = await this.confirmEnoughStorage( Number( size ) );
@@ -478,39 +493,26 @@ export class ExportSQLCommand {
 			exit.withError( `No backup found for site ${ this.app.name }` );
 		}
 
-		if ( ! this.generateBackup ) {
-			console.log(
-				`${ getGlyphForStatus( 'success' ) } Latest backup found with timestamp ${
-					latestBackup.createdAt
-				}`
-			);
-		} else {
-			console.log(
-				`${ getGlyphForStatus( 'success' ) } Backup created with timestamp ${
-					latestBackup.createdAt
-				}`
-			);
-		}
+		const prepareAdditionalInfo = [];
 
 		const showMyDumperWarning =
 			this.showMyDumperWarning && ( latestBackup.sqlDumpTool ?? envSqlDumpTool ) === 'mydumper';
 		if ( showMyDumperWarning ) {
-			console.warn(
-				chalk.yellow.bold( 'WARNING:' ),
-				chalk.yellow(
-					'This is a large or complex database. The backup file for this database is generated with MyDumper. ' +
-						'The file can only be loaded with MyLoader. ' +
-						'For more information: https://github.com/mydumper/mydumper'
-				)
+			prepareAdditionalInfo.push(
+				`${ chalk.yellow.bold(
+					'WARNING:'
+				) } This is a large or complex database. The backup file for this database is generated with MyDumper. The file can only be loaded with MyLoader. For more information: https://github.com/mydumper/mydumper`
 			);
 		}
 
 		if ( await this.getExportJob() ) {
-			console.log(
+			prepareAdditionalInfo.push(
 				`Attaching to an existing export for the backup with timestamp ${ latestBackup.createdAt }`
 			);
 		} else {
-			console.log( `Exporting database backup with timestamp ${ latestBackup.createdAt }` );
+			prepareAdditionalInfo.push(
+				`Exporting database backup with timestamp ${ latestBackup.createdAt }`
+			);
 
 			try {
 				await createExportJob( this.app.id, this.env.id, latestBackup.id );
@@ -545,7 +547,7 @@ export class ExportSQLCommand {
 			this.isPrepared.bind( this )
 		);
 
-		this.progressTracker.stepSuccess( this.steps.PREPARE );
+		this.progressTracker.stepSuccess( this.steps.PREPARE, prepareAdditionalInfo );
 
 		await pollUntil(
 			this.getExportJob.bind( this ),

--- a/src/commands/export-sql.ts
+++ b/src/commands/export-sql.ts
@@ -268,8 +268,8 @@ export class ExportSQLCommand {
 		this.progressTracker = new ProgressTracker( [
 			{ id: this.steps.PREPARE, name: 'Preparing for backup download' },
 			{ id: this.steps.CREATE, name: 'Creating backup copy' },
-			{ id: this.steps.CONFIRM_ENOUGH_STORAGE, name: "Checking if there's enough storage" },
 			{ id: this.steps.DOWNLOAD_LINK, name: 'Requesting download link' },
+			{ id: this.steps.CONFIRM_ENOUGH_STORAGE, name: "Checking if there's enough storage" },
 			{ id: this.steps.DOWNLOAD, name: 'Downloading file' },
 		] );
 		this.track = trackerFn;
@@ -416,14 +416,14 @@ export class ExportSQLCommand {
 			size = Number( bytesWrittenMeta.value );
 		}
 
+		const downloadURLString = `\n${ chalk.green( 'Download URL' ) }:\n${ url }\n\n`;
+
 		if ( this.skipDownload ) {
 			this.progressTracker.stepSkipped( this.steps.CONFIRM_ENOUGH_STORAGE );
 			this.progressTracker.stepSkipped( this.steps.DOWNLOAD );
 			this.progressTracker.print();
 			this.progressTracker.stopPrinting();
-
-			console.log( `Download URL: ${ url }` );
-
+			console.log( downloadURLString );
 			return;
 		}
 
@@ -557,7 +557,7 @@ export class ExportSQLCommand {
 		this.progressTracker.stepSuccess( this.steps.CREATE );
 
 		const url = await generateDownloadLink( this.app.id, this.env.id, latestBackup.id );
-		this.progressTracker.stepSuccess( this.steps.DOWNLOAD_LINK );
+		this.progressTracker.stepSuccess( this.steps.DOWNLOAD_LINK, [ url ] );
 
 		return url;
 	}
@@ -590,7 +590,7 @@ export class ExportSQLCommand {
 			} );
 			this.progressTracker.stepSuccess( this.steps.CREATE );
 
-			this.progressTracker.stepSuccess( this.steps.DOWNLOAD_LINK );
+			this.progressTracker.stepSuccess( this.steps.DOWNLOAD_LINK, [ result.url ] );
 
 			return result;
 		} catch ( err ) {

--- a/src/lib/cli/progress.ts
+++ b/src/lib/cli/progress.ts
@@ -20,7 +20,9 @@ export interface Step {
 	id: string;
 	name: string;
 	status: StepStatus;
-	[ key: string ]: string;
+	percentage?: string;
+	progress?: string;
+	additionalInfo?: string[];
 }
 
 export type StepConstructorParam = Omit< Step, 'status' > & { status?: StepStatus };
@@ -133,20 +135,20 @@ export class ProgressTracker {
 		return steps.find( ( { status } ) => status === StepStatus.RUNNING );
 	}
 
-	public stepRunning( stepId: string ): void {
-		this.setStatusForStepId( stepId, StepStatus.RUNNING );
+	public stepRunning( stepId: string, additionalInfo: string | string[] = [] ): void {
+		this.setStatusForStepId( stepId, StepStatus.RUNNING, additionalInfo );
 	}
 
-	public stepFailed( stepId: string ): void {
-		this.setStatusForStepId( stepId, StepStatus.FAILED );
+	public stepFailed( stepId: string, additionalInfo: string | string[] = [] ): void {
+		this.setStatusForStepId( stepId, StepStatus.FAILED, additionalInfo );
 	}
 
-	public stepSkipped( stepId: string ): void {
-		this.setStatusForStepId( stepId, StepStatus.SKIPPED );
+	public stepSkipped( stepId: string, additionalInfo: string | string[] = [] ): void {
+		this.setStatusForStepId( stepId, StepStatus.SKIPPED, additionalInfo );
 	}
 
-	public stepSuccess( stepId: string ) {
-		this.setStatusForStepId( stepId, StepStatus.SUCCESS );
+	public stepSuccess( stepId: string, additionalInfo: string | string[] = [] ) {
+		this.setStatusForStepId( stepId, StepStatus.SUCCESS, additionalInfo );
 		// The stepSuccess helper automatically sets the next step to "running"
 		const nextStep = this.getNextStep();
 		if ( nextStep ) {
@@ -158,7 +160,11 @@ export class ProgressTracker {
 		return [ ...this.getSteps().values() ].every( ( { status } ) => status === StepStatus.SUCCESS );
 	}
 
-	public setStatusForStepId( stepId: string, status: StepStatus ) {
+	public setStatusForStepId(
+		stepId: string,
+		status: StepStatus,
+		additionalInfo: string | string[] = []
+	) {
 		const step = this.stepsFromCaller.get( stepId );
 		if ( ! step ) {
 			// Only allowed to update existing steps with this method
@@ -176,6 +182,7 @@ export class ProgressTracker {
 		this.stepsFromCaller.set( stepId, {
 			...step,
 			status,
+			additionalInfo: Array.isArray( additionalInfo ) ? additionalInfo : [ additionalInfo ],
 		} );
 	}
 
@@ -249,7 +256,7 @@ export class ProgressTracker {
 		}
 		const stepValues = [ ...this.getSteps().values() ];
 		const logs = stepValues.reduce(
-			( accumulator, { name, id, percentage, status, progress }, stepNumber ) => {
+			( accumulator, { name, id, percentage, status, progress, additionalInfo }, stepNumber ) => {
 				if ( stepNumber < this.displayFromStep ) {
 					return accumulator;
 				}
@@ -263,6 +270,12 @@ export class ProgressTracker {
 				} else if ( progress ) {
 					suffix = progress;
 				}
+
+				if ( additionalInfo && additionalInfo.length > 0 ) {
+					suffix += EOL;
+					suffix += additionalInfo.map( stepInfo => `  - ${ stepInfo }` ).join( EOL );
+				}
+
 				return `${ accumulator }${ statusIcon } ${ name } ${ suffix }\n`;
 			},
 			''


### PR DESCRIPTION
## Description

Adds a new `--skip-download` flag to the `vip export sql` command that allows users to retrieve the download URL for database backups without actually downloading the file. This is particularly useful for automation scenarios where the download needs to be handled separately or when users just need the URL for later use.

This PR also refactors the ProgressTracker to support additional info messages for each step. This prevents direct `console.log` calls from interfering with the progress tracker's single-line printing mode, ensuring consistent and clean output formatting throughout command execution.

Output example:
```
$ vip @0000.production export sql
✓ Preparing for backup download 
  • Attaching to an existing export for the backup with timestamp 2025-11-14T13:21:07.000Z
✓ Creating backup copy 
✓ Requesting download link 
  • Download URL: https://example.org/sql.gz
```


## Changes
- Added `--skip-download` CLI option to the export sql command
- When enabled, the command skips storage confirmation and download steps
- Outputs the download URL to console instead of downloading the file
- Enhanced ProgressTracker to support additional info messages for steps
- Refactored console output in prepare step to use ProgressTracker's additional info feature
- Added comprehensive test coverage for the new functionality

## Testing
To test this feature locally:

1. Run the command with the new flag:
```bash
npm run build && ./dist/bin/vip-export-sql.js @<id>.production --skip-download
```


## Changelog Description

<!-- Changelogs are published for our customers. Well-written entries help them stay informed on platform changes and all of the great work that we do! -->

<!-- Write a concise description of changes in the relevant section.
- Add new line items as needed.
- Entries should follow the [Common Changelog Style Guide](https://github.com/vweevers/common-changelog).
- Remove all unused sections before merging.
- Proof-read.
-->

### Added

- Added `--skip-download` flag to export sql command for URL-only retrieval

## Pull request checklist

- [ ] Update [SETUP.md](https://github.com/Automattic/vip-cli/blob/trunk/docs/SETUP.md#list-of-environmental-variables) with any new environmental variables.
- [ ] Update [the documentation](https://github.com/Automattic/vip-cli/blob/trunk/docs).
- [ ] [Manually test](https://github.com/Automattic/vip-cli/blob/trunk/docs/TESTING.md#manual-testing) the relevant changes.
- [ ] Follow the [pull request checklist](https://github.com/Automattic/vip-cli/blob/trunk/docs/RELEASING.md#new-pull-requests)
- [ ] Add/update [automated tests](https://github.com/Automattic/vip-cli/blob/trunk/docs/TESTING.md#automated-testing) as needed.

## New release checklist

- [ ] [Automated tests](https://github.com/Automattic/vip-cli/blob/trunk/docs/TESTING.md#automated-testing) pass.
- [ ] The [Preparing for release checklist](https://github.com/Automattic/vip-cli/blob/trunk/docs/RELEASING.md#preparing-for-release) is completed.

## Steps to Test

Outline the steps to test and verify the PR here.

Example:

1. Check out PR.
1. Run `npm run build`
1. Run `./dist/bin/vip-cookies.js nom`
1. Verify cookies are delicious.
