### PR TITLE
fix(wp): correctly parse multiline values

### DIFF
--- a/__tests__/lib/wp/helpers.ts
+++ b/__tests__/lib/wp/helpers.ts
@@ -6,7 +6,6 @@ describe( 'vip-wp helpers', () => {
 		expect( actual ).toEqual( {
 			state: 'S0',
 			command: '',
-			error: false,
 			done: false,
 		} );
 	} );
@@ -15,7 +14,6 @@ describe( 'vip-wp helpers', () => {
 		const state: CmdState = {
 			state: 'S3',
 			command: 'wp some command',
-			error: true,
 			done: true,
 		};
 
@@ -24,7 +22,6 @@ describe( 'vip-wp helpers', () => {
 		expect( state ).toEqual( {
 			state: 'S0',
 			command: '',
-			error: false,
 			done: false,
 		} );
 	} );
@@ -37,7 +34,6 @@ describe( 'vip-wp helpers', () => {
 			expect( state ).toEqual(
 				expect.objectContaining( {
 					command: 'wp plugin list',
-					error: false,
 					done: true,
 				} )
 			);
@@ -47,13 +43,12 @@ describe( 'vip-wp helpers', () => {
 			const state = initState();
 			stateMachine(
 				state,
-				`wp post create --post_title="John's \\"Great\\" Post" --post_content="This is a test\nNew line here"`
+				`wp post create --post_title="John's \\"Great\\" Post" --post_content='This is a test\nNew line here'`
 			);
 
 			expect( state ).toEqual(
 				expect.objectContaining( {
-					command: `wp post create --post_title="John's \\"Great\\" Post" --post_content="This is a test\nNew line here"`,
-					error: false,
+					command: `wp post create --post_title="John's \\"Great\\" Post" --post_content='This is a test\nNew line here'`,
 					done: true,
 				} )
 			);
@@ -65,13 +60,30 @@ describe( 'vip-wp helpers', () => {
 			const state = initState();
 			for ( const part of parts ) {
 				stateMachine( state, part );
-				expect( state.error ).toBe( false );
 			}
 
 			expect( state ).toEqual(
 				expect.objectContaining( {
 					command: `wp option set test216596 "\naaa\nbb\\"\ncc"`,
-					error: false,
+					done: true,
+				} )
+			);
+		} );
+
+		test.each( [
+			[ `wp option set xxx "inner single quote'"`, `wp option set xxx "inner single quote'"` ],
+			[ `wp option set xxx 'inner double quote"'`, `wp option set xxx 'inner double quote"'` ],
+			[
+				`wp option set xxx "escaped double quote\\""`,
+				`wp option set xxx "escaped double quote\\""`,
+			],
+		] )( 'handles nested quotes (%s)', ( input, expected ) => {
+			const state = initState();
+			stateMachine( state, input );
+
+			expect( state ).toEqual(
+				expect.objectContaining( {
+					command: expected,
 					done: true,
 				} )
 			);

--- a/__tests__/lib/wp/helpers.ts
+++ b/__tests__/lib/wp/helpers.ts
@@ -4,7 +4,7 @@ describe( 'vip-wp helpers', () => {
 	test( 'initState', () => {
 		const actual = initState();
 		expect( actual ).toEqual( {
-			state: 0,
+			state: 'S0',
 			command: '',
 			error: false,
 			done: false,
@@ -13,7 +13,7 @@ describe( 'vip-wp helpers', () => {
 
 	test( 'resetState', () => {
 		const state: CmdState = {
-			state: 3,
+			state: 'S3',
 			command: 'wp some command',
 			error: true,
 			done: true,
@@ -22,7 +22,7 @@ describe( 'vip-wp helpers', () => {
 		resetState( state );
 
 		expect( state ).toEqual( {
-			state: 0,
+			state: 'S0',
 			command: '',
 			error: false,
 			done: false,
@@ -36,7 +36,7 @@ describe( 'vip-wp helpers', () => {
 
 			expect( state ).toEqual(
 				expect.objectContaining( {
-					command: 'wp plugin list\n',
+					command: 'wp plugin list',
 					error: false,
 					done: true,
 				} )
@@ -52,7 +52,7 @@ describe( 'vip-wp helpers', () => {
 
 			expect( state ).toEqual(
 				expect.objectContaining( {
-					command: `wp post create --post_title="John's \\"Great\\" Post" --post_content="This is a test\nNew line here"\n`,
+					command: `wp post create --post_title="John's \\"Great\\" Post" --post_content="This is a test\nNew line here"`,
 					error: false,
 					done: true,
 				} )
@@ -70,7 +70,7 @@ describe( 'vip-wp helpers', () => {
 
 			expect( state ).toEqual(
 				expect.objectContaining( {
-					command: `wp option set test216596 "\naaa\nbb\\"\ncc"\n`,
+					command: `wp option set test216596 "\naaa\nbb\\"\ncc"`,
 					error: false,
 					done: true,
 				} )

--- a/__tests__/lib/wp/helpers.ts
+++ b/__tests__/lib/wp/helpers.ts
@@ -1,0 +1,80 @@
+import { type CmdState, initState, resetState, stateMachine } from '../../../src/lib/wp/helpers';
+
+describe( 'vip-wp helpers', () => {
+	test( 'initState', () => {
+		const actual = initState();
+		expect( actual ).toEqual( {
+			state: 0,
+			command: '',
+			error: false,
+			done: false,
+		} );
+	} );
+
+	test( 'resetState', () => {
+		const state: CmdState = {
+			state: 3,
+			command: 'wp some command',
+			error: true,
+			done: true,
+		};
+
+		resetState( state );
+
+		expect( state ).toEqual( {
+			state: 0,
+			command: '',
+			error: false,
+			done: false,
+		} );
+	} );
+
+	describe( 'stateMachine', () => {
+		test( 'handles simple command', () => {
+			const state = initState();
+			stateMachine( state, 'wp plugin list' );
+
+			expect( state ).toEqual(
+				expect.objectContaining( {
+					command: 'wp plugin list\n',
+					error: false,
+					done: true,
+				} )
+			);
+		} );
+
+		test( 'handles command with quotes and escapes', () => {
+			const state = initState();
+			stateMachine(
+				state,
+				`wp post create --post_title="John's \\"Great\\" Post" --post_content="This is a test\nNew line here"`
+			);
+
+			expect( state ).toEqual(
+				expect.objectContaining( {
+					command: `wp post create --post_title="John's \\"Great\\" Post" --post_content="This is a test\nNew line here"\n`,
+					error: false,
+					done: true,
+				} )
+			);
+		} );
+
+		test( 'handles multiline input', () => {
+			const parts = [ `wp option set test216596 "`, 'aaa', 'bb\\"', 'cc"' ];
+
+			const state = initState();
+			for ( const part of parts ) {
+				stateMachine( state, part );
+				expect( state.error ).toBe( false );
+			}
+
+			expect( state ).toEqual(
+				expect.objectContaining( {
+					command: `wp option set test216596 "\naaa\nbb\\"\ncc"\n`,
+					error: false,
+					done: true,
+				} )
+			);
+		} );
+	} );
+} );

--- a/docs/vip-wp-line-parse-dfa.dot
+++ b/docs/vip-wp-line-parse-dfa.dot
@@ -1,0 +1,31 @@
+digraph state_diagram {
+    rankdir=LR;
+
+    start [shape=doublecircle, label="S"];
+    S0 [shape=circle, label="S0"];
+    S1 [shape=circle, label="S1"];
+    S2 [shape=circle, label="S2"];
+    S3 [shape=circle, label="S3"];
+    S4 [shape=circle, label="S4"];
+    end [shape=doublecircle, label="F"];
+
+    start -> S0 [label="wp "];
+
+    S0 -> S1 [label="backslash"];
+    S0 -> S2 [label="double-quote"];
+    S0 -> end [label="newline"];
+    S0 -> S4 [label="single-quote"];
+    S0 -> S0 [label="[other]"];
+
+    S1 -> end [label="newline"];
+    S1 -> S0 [label="[other]"];
+
+    S2 -> S3 [label="backslash"];
+    S2 -> S0 [label="double-quote"];
+    S2 -> S2 [label="[other]"];
+
+    S3 -> S2 [label="[any]"];
+
+    S4 -> S0 [label="single-quote"];
+    S4 -> S4 [label="[other]"];
+}

--- a/src/bin/vip-wp.js
+++ b/src/bin/vip-wp.js
@@ -494,7 +494,7 @@ commandWrapper( {
 			subShellRl.pause();
 
 			let result;
-			const wpCliCmd = commandState.command.replace( /^wp\s+/, '' ).trimEnd();
+			const wpCliCmd = commandState.command.replace( /^wp\s+/, '' );
 			seenWP = false;
 			resetState( commandState );
 

--- a/src/bin/vip-wp.js
+++ b/src/bin/vip-wp.js
@@ -478,10 +478,7 @@ commandWrapper( {
 				if ( ! commandState.done ) {
 					return;
 				}
-			}
-
-			if ( ! commandState.done ) {
-				seenWP = false;
+			} else {
 				resetState( commandState );
 				console.log(
 					chalk.red( 'Error:' ),

--- a/src/bin/vip-wp.js
+++ b/src/bin/vip-wp.js
@@ -475,7 +475,7 @@ commandWrapper( {
 
 			if ( seenWP ) {
 				stateMachine( commandState, line );
-				if ( ! commandState.done && ! commandState.error ) {
+				if ( ! commandState.done ) {
 					return;
 				}
 			}

--- a/src/bin/vip-wp.js
+++ b/src/bin/vip-wp.js
@@ -18,6 +18,7 @@ import { confirm } from '../lib/cli/prompt';
 import { createProxyAgent } from '../lib/http/proxy-agent';
 import Token from '../lib/token';
 import { trackEvent } from '../lib/tracker';
+import { initState, resetState, stateMachine } from '../lib/wp/helpers';
 
 const debug = debugLib( '@automattic/vip:wp' );
 
@@ -438,6 +439,9 @@ commandWrapper( {
 			subShellSettings.historySize = 200;
 		}
 
+		const commandState = initState();
+		let seenWP = false;
+
 		const subShellRl = readline.createInterface( subShellSettings );
 		subShellRl.on( 'line', async line => {
 			if ( commandRunning ) {
@@ -451,16 +455,34 @@ commandWrapper( {
 			}
 
 			// Check for exit, like SSH (handles both `exit` and `exit;`)
-			if ( line.startsWith( 'exit' ) ) {
+			if ( ! seenWP && line.startsWith( 'exit' ) ) {
 				subShellRl.close();
 				process.exit();
 			}
 
-			const startsWithWp = line.trim().startsWith( 'wp ' );
-			const empty = 0 === line.length;
 			const userCmdCancelled = line === cancelCommandChar;
+			if ( userCmdCancelled ) {
+				seenWP = false;
+				resetState( commandState );
+				subShellRl.prompt();
+				return;
+			}
 
-			if ( ( empty || ! startsWithWp ) && ! userCmdCancelled ) {
+			if ( ! seenWP && line.trimStart().startsWith( 'wp ' ) ) {
+				seenWP = true;
+				resetState( commandState );
+			}
+
+			if ( seenWP ) {
+				stateMachine( commandState, line );
+				if ( ! commandState.done && ! commandState.error ) {
+					return;
+				}
+			}
+
+			if ( ! commandState.done ) {
+				seenWP = false;
+				resetState( commandState );
 				console.log(
 					chalk.red( 'Error:' ),
 					'invalid command, please pass a valid WP-CLI command.'
@@ -472,8 +494,12 @@ commandWrapper( {
 			subShellRl.pause();
 
 			let result;
+			const wpCliCmd = commandState.command.replace( /^wp\s+/, '' ).trimEnd();
+			seenWP = false;
+			resetState( commandState );
+
 			try {
-				result = await getTokenForCommand( appId, envId, line.replace( 'wp ', '' ) );
+				result = await getTokenForCommand( appId, envId, wpCliCmd );
 			} catch ( error ) {
 				// If this was a GraphQL error, print that to the message to the line
 				if ( error.graphQLErrors ) {

--- a/src/lib/wp/helpers.ts
+++ b/src/lib/wp/helpers.ts
@@ -1,5 +1,5 @@
-type Action = 'continue' | 'done' | 'error';
-export type State = 0 | 1 | 2 | 3 | 4 | 5;
+type Action = 'continue' | 'done';
+export type State = 'S0' | 'S1' | 'S2' | 'S3' | 'FF';
 
 export interface CmdState {
 	state: State;
@@ -9,7 +9,7 @@ export interface CmdState {
 }
 
 export function resetState( state: CmdState ): void {
-	state.state = 0;
+	state.state = 'S0';
 	state.command = '';
 	state.error = false;
 	state.done = false;
@@ -21,47 +21,78 @@ export function initState(): CmdState {
 	return state;
 }
 
+/**
+ * State machine table for parsing WP-CLI commands.
+ *
+ * States:
+ *   - S0 - Normal
+ *   - S1 - After backslash
+ *   - S2 - Inside quotes
+ *   - S3 - After backslash inside quotes
+ *   - FF - Final state (done)
+ *
+ * ```mermaid
+ * stateDiagram
+ *     direction LR
+ *     [*] --> S0: "wp "
+ *     S0 --> S1: \\
+ *     S0 --> S2: "
+ *     S0 --> [*]: \n
+ *     S0 --> S0: [other]
+ *     S1 --> [*]: \n
+ *     S1 --> S0: [other]
+ *     S2 --> S3: \\
+ *     S2 --> S0: "
+ *     S2 --> S2: [other]
+ *     S3 --> S2: [any]
+ * ```
+ */
 const stateTable: State[][] = [
-	/*         \  "  \n other */
-	/* S0 */ [ 1, 2, 4, 0 ],
-	/* S1 */ [ 0, 0, 4, 0 ],
-	/* S2 */ [ 3, 0, 2, 2 ],
-	/* S3 */ [ 2, 2, 2, 2 ],
+	/*         \     "     \n    other */
+	/* S0 */ [ 'S1', 'S2', 'FF', 'S0' ],
+	/* S1 */ [ 'S0', 'S0', 'FF', 'S0' ],
+	/* S2 */ [ 'S3', 'S0', 'S2', 'S2' ],
+	/* S3 */ [ 'S2', 'S2', 'S2', 'S2' ],
+	/* FF  */ [ 'FF', 'FF', 'FF', 'FF' ],
 ] as const;
 
 const charMap: Record< string, number > = {
 	'\\': 0,
 	'"': 1,
 	'\n': 2,
+	other: 3,
+} as const;
+
+const stateToRow: Record< State, number > = {
+	S0: 0,
+	S1: 1,
+	S2: 2,
+	S3: 3,
+	FF: 4,
 } as const;
 
 const stateToAction: Record< State, Action > = {
-	0: 'continue',
-	1: 'continue',
-	2: 'continue',
-	3: 'continue',
-	4: 'done',
-	5: 'error',
+	S0: 'continue',
+	S1: 'continue',
+	S2: 'continue',
+	S3: 'continue',
+	FF: 'done',
 } as const;
 
 export function stateMachine( state: CmdState, line: string ): void {
 	line += '\n';
 
 	for ( const char of line ) {
-		const charType = charMap[ char ] ?? 3;
-		state.state = stateTable[ state.state ][ charType ];
-		state.command += char;
+		const charType = charMap[ char ] ?? charMap.other;
+		state.state = stateTable[ stateToRow[ state.state ] ][ charType ];
 
 		switch ( stateToAction[ state.state ] ) {
 			case 'done':
 				state.done = true;
 				return;
 
-			case 'error': // Unreachable in current implementation
-				state.error = true;
-				return;
-
-			default:
+			case 'continue':
+				state.command += char;
 				continue;
 		}
 	}

--- a/src/lib/wp/helpers.ts
+++ b/src/lib/wp/helpers.ts
@@ -1,3 +1,31 @@
+/**
+ * DFA parser for WP-CLI commands.
+ *
+ * This file implements a small deterministic finite automaton (DFA) that
+ * accumulates a full WP-CLI command across one or more physical input lines.
+ * It preserves quoted multiline values and does not perform shell-like
+ * unescaping. Call `stateMachine(state, line)` repeatedly with the same
+ * `CmdState` until `state.done === true`; the reconstructed command will be
+ * available in `state.command`.
+ *
+ * Quick example:
+ *
+ * ```ts
+ * const state = initState();
+ * stateMachine(state, 'wp option set mykey "first line');
+ * // still inside double quotes -> state.done === false
+ * stateMachine(state, 'second line"');
+ * // quotes closed and trailing newline finalizes -> state.done === true
+ * console.log(state.command);
+ * // => wp option set mykey "first line\nsecond line"
+ * ```
+ *
+ * Key points:
+ * - Newline outside quotes ends the command; newlines inside quotes are kept.
+ * - Backslashes are preserved literally; they are NOT shell escapes.
+ * - A backslash followed by a newline is NOT treated as a continuation.
+ */
+
 type Action = 'continue' | 'done';
 export type State =
 	| 'S0' /* Normal */
@@ -26,7 +54,7 @@ export function initState(): CmdState {
 }
 
 /**
- * State machine table for parsing WP-CLI commands.
+ * State machine table for parsing WP-CLI commands. This is a matrix of next-states keyed by current state (row) and character class (column).
  *
  * ```mermaid
  * stateDiagram

--- a/src/lib/wp/helpers.ts
+++ b/src/lib/wp/helpers.ts
@@ -53,9 +53,6 @@ export function stateMachine( state: CmdState, line: string ): void {
 		state.command += char;
 
 		switch ( stateToAction[ state.state ] ) {
-			default:
-				continue;
-
 			case 'done':
 				state.done = true;
 				return;
@@ -63,6 +60,9 @@ export function stateMachine( state: CmdState, line: string ): void {
 			case 'error': // Unreachable in current implementation
 				state.error = true;
 				return;
+
+			default:
+				continue;
 		}
 	}
 }

--- a/src/lib/wp/helpers.ts
+++ b/src/lib/wp/helpers.ts
@@ -1,17 +1,21 @@
 type Action = 'continue' | 'done';
-export type State = 'S0' | 'S1' | 'S2' | 'S3' | 'FF';
+export type State =
+	| 'S0' /* Normal */
+	| 'S1' /* After backslash */
+	| 'S2' /* Inside double quotes */
+	| 'S3' /* After backslash inside double quotes */
+	| 'S4' /* Inside single quotes */
+	| 'FF' /* Final */;
 
 export interface CmdState {
 	state: State;
 	command: string;
-	error: boolean;
 	done: boolean;
 }
 
 export function resetState( state: CmdState ): void {
 	state.state = 'S0';
 	state.command = '';
-	state.error = false;
 	state.done = false;
 }
 
@@ -24,51 +28,41 @@ export function initState(): CmdState {
 /**
  * State machine table for parsing WP-CLI commands.
  *
- * States:
- *   - S0 - Normal
- *   - S1 - After backslash
- *   - S2 - Inside quotes
- *   - S3 - After backslash inside quotes
- *   - FF - Final state (done)
- *
  * ```mermaid
  * stateDiagram
  *     direction LR
  *     [*] --> S0: "wp "
- *     S0 --> S1: \\
- *     S0 --> S2: "
- *     S0 --> [*]: \n
+ *     S0 --> S1: backslash
+ *     S0 --> S2: double-quote
+ *     S0 --> S4: single-quote
+ *     S0 --> [*]: newline
  *     S0 --> S0: [other]
- *     S1 --> [*]: \n
+ *     S1 --> [*]: newline
  *     S1 --> S0: [other]
- *     S2 --> S3: \\
- *     S2 --> S0: "
+ *     S2 --> S3: backslash
+ *     S2 --> S0: double-quote
  *     S2 --> S2: [other]
  *     S3 --> S2: [any]
+ *     S4 --> S0: '
+ *     S4 --> S4: [other]
  * ```
  */
-const stateTable: State[][] = [
-	/*         \     "     \n    other */
-	/* S0 */ [ 'S1', 'S2', 'FF', 'S0' ],
-	/* S1 */ [ 'S0', 'S0', 'FF', 'S0' ],
-	/* S2 */ [ 'S3', 'S0', 'S2', 'S2' ],
-	/* S3 */ [ 'S2', 'S2', 'S2', 'S2' ],
-	/* FF  */ [ 'FF', 'FF', 'FF', 'FF' ],
-] as const;
+const stateTable: Record< State, State[] > = {
+	/*    \     "     '     \n    other */
+	S0: [ 'S1', 'S2', 'S4', 'FF', 'S0' ],
+	S1: [ 'S0', 'S0', 'S0', 'FF', 'S0' ],
+	S2: [ 'S3', 'S0', 'S2', 'S2', 'S2' ],
+	S3: [ 'S2', 'S2', 'S2', 'S2', 'S2' ],
+	S4: [ 'S4', 'S4', 'S0', 'S4', 'S4' ],
+	FF: [ 'FF', 'FF', 'FF', 'FF', 'FF' ],
+} as const;
 
 const charMap: Record< string, number > = {
 	'\\': 0,
 	'"': 1,
-	'\n': 2,
-	other: 3,
-} as const;
-
-const stateToRow: Record< State, number > = {
-	S0: 0,
-	S1: 1,
-	S2: 2,
-	S3: 3,
-	FF: 4,
+	"'": 2,
+	'\n': 3,
+	other: 4,
 } as const;
 
 const stateToAction: Record< State, Action > = {
@@ -76,15 +70,31 @@ const stateToAction: Record< State, Action > = {
 	S1: 'continue',
 	S2: 'continue',
 	S3: 'continue',
+	S4: 'continue',
 	FF: 'done',
 } as const;
 
+/**
+ * Parses a line of WP-CLI command input using a state machine.
+ *
+ * Supports quoted strings, allowing for multiline commands.
+ * The state machine transitions are defined by the `stateTable` above.
+ * Multiline input is handled by appending a newline to the input.
+ *
+ * Due to the limitations of the internal command runner infrastructure,
+ * the syntax is NOT shell-like:
+ *   - escape sequences are not interpreted (e.g., `\n` is treated as two characters, not a newline)
+ *   - backslash preceding a newline is not treated as a line continuation
+ *
+ * @param state The mutable command state object tracking parsing progress.
+ * @param line The input line to parse (will be treated as a single line, with a newline appended).
+ */
 export function stateMachine( state: CmdState, line: string ): void {
 	line += '\n';
 
 	for ( const char of line ) {
 		const charType = charMap[ char ] ?? charMap.other;
-		state.state = stateTable[ stateToRow[ state.state ] ][ charType ];
+		state.state = stateTable[ state.state ][ charType ];
 
 		switch ( stateToAction[ state.state ] ) {
 			case 'done':

--- a/src/lib/wp/helpers.ts
+++ b/src/lib/wp/helpers.ts
@@ -1,0 +1,68 @@
+type Action = 'continue' | 'done' | 'error';
+export type State = 0 | 1 | 2 | 3 | 4 | 5;
+
+export interface CmdState {
+	state: State;
+	command: string;
+	error: boolean;
+	done: boolean;
+}
+
+export function resetState( state: CmdState ): void {
+	state.state = 0;
+	state.command = '';
+	state.error = false;
+	state.done = false;
+}
+
+export function initState(): CmdState {
+	const state: CmdState = {} as CmdState;
+	resetState( state );
+	return state;
+}
+
+const stateTable: State[][] = [
+	/*         \  "  \n other */
+	/* S0 */ [ 1, 2, 4, 0 ],
+	/* S1 */ [ 0, 0, 4, 0 ],
+	/* S2 */ [ 3, 0, 2, 2 ],
+	/* S3 */ [ 2, 2, 2, 2 ],
+] as const;
+
+const charMap: Record< string, number > = {
+	'\\': 0,
+	'"': 1,
+	'\n': 2,
+} as const;
+
+const stateToAction: Record< State, Action > = {
+	0: 'continue',
+	1: 'continue',
+	2: 'continue',
+	3: 'continue',
+	4: 'done',
+	5: 'error',
+} as const;
+
+export function stateMachine( state: CmdState, line: string ): void {
+	line += '\n';
+
+	for ( const char of line ) {
+		const charType = charMap[ char ] ?? 3;
+		state.state = stateTable[ state.state ][ charType ];
+		state.command += char;
+
+		switch ( stateToAction[ state.state ] ) {
+			default:
+				continue;
+
+			case 'done':
+				state.done = true;
+				return;
+
+			case 'error': // Unreachable in current implementation
+				state.error = true;
+				return;
+		}
+	}
+}

--- a/src/lib/wp/helpers.ts
+++ b/src/lib/wp/helpers.ts
@@ -71,7 +71,7 @@ export function initState(): CmdState {
  *     S2 --> S0: double-quote
  *     S2 --> S2: [other]
  *     S3 --> S2: [any]
- *     S4 --> S0: '
+ *     S4 --> S0: single-quote
  *     S4 --> S4: [other]
  * ```
  */


### PR DESCRIPTION
## Description

This PR implements parsing for multiline values in WP-CLI commands. This ensures that commands with multiline arguments are handled correctly.

The implementation uses a state machine to track the current parsing state and process input accordingly.

```mermaid
stateDiagram
    direction LR
    [*] --> S0: "wp "
    S0 --> S1: backslash
    S0 --> S2: double-quote
    S0 --> S4: single-quote
    S0 --> [*]: newline
    S0 --> S0: [other]
    S1 --> [*]: newline
    S1 --> S0: [other]
    S2 --> S3: backslash
    S2 --> S0: double-quote
    S2 --> S2: [other]
    S3 --> S2: [any]
    S4 --> S0: single-quote
    S4 --> S4: [other]
```

Ref: PLTFRM-1847

## Changelog Description

### Added

- Parsing of multiline values for the `vip wp` command

## Pull request checklist

- [ ] Update [SETUP.md](https://github.com/Automattic/vip-cli/blob/trunk/docs/SETUP.md#list-of-environmental-variables) with any new environmental variables.
- [ ] Update [the documentation](https://github.com/Automattic/vip-cli/blob/trunk/docs).
- [x] [Manually test](https://github.com/Automattic/vip-cli/blob/trunk/docs/TESTING.md#manual-testing) the relevant changes.
- [x] Follow the [pull request checklist](https://github.com/Automattic/vip-cli/blob/trunk/docs/RELEASING.md#new-pull-requests)
- [x] Add/update [automated tests](https://github.com/Automattic/vip-cli/blob/trunk/docs/TESTING.md#automated-testing) as needed.

## New release checklist

- [x] [Automated tests](https://github.com/Automattic/vip-cli/blob/trunk/docs/TESTING.md#automated-testing) pass.
- [ ] The [Preparing for release checklist](https://github.com/Automattic/vip-cli/blob/trunk/docs/RELEASING.md#preparing-for-release) is completed.

## Steps to Test

Try hard to break `vip @app.env wp` in different scenarios.
