### PR TITLE
feat(dev-env): add SSL for auxilliary services

### DIFF
--- a/assets/dev-env.lando.template.yml.ejs
+++ b/assets/dev-env.lando.template.yml.ejs
@@ -138,6 +138,8 @@ services:
 <% if ( phpmyadmin ) { %>
   phpmyadmin:
     type: compose
+    ssl: true
+    sslExpose: false
     services:
       image: phpmyadmin:5
       command: /docker-entrypoint.sh apache2-foreground
@@ -248,6 +250,8 @@ services:
 
 <% if ( mailpit ) { %>
   mailpit:
+    ssl: true
+    sslExpose: false
     type: compose
     services:
       image: axllent/mailpit:latest


### PR DESCRIPTION
## Description

This PR adds SSL to phpMyAdmin and Mailpit endpoints.

## Changelog Description

### Added

- Dev Environment: phpMyAdmin and Mailpit are now exposed over TLS/SSL.

## Pull request checklist

- [ ] Update [SETUP.md](https://github.com/Automattic/vip-cli/blob/trunk/docs/SETUP.md#list-of-environmental-variables) with any new environmental variables.
- [ ] Update [the documentation](https://github.com/Automattic/vip-cli/blob/trunk/docs).
- [x] [Manually test](https://github.com/Automattic/vip-cli/blob/trunk/docs/TESTING.md#manual-testing) the relevant changes.
- [x] Follow the [pull request checklist](https://github.com/Automattic/vip-cli/blob/trunk/docs/RELEASING.md#new-pull-requests)
- [ ] Add/update [automated tests](https://github.com/Automattic/vip-cli/blob/trunk/docs/TESTING.md#automated-testing) as needed.

## New release checklist

- [x] [Automated tests](https://github.com/Automattic/vip-cli/blob/trunk/docs/TESTING.md#automated-testing) pass.
- [ ] The [Preparing for release checklist](https://github.com/Automattic/vip-cli/blob/trunk/docs/RELEASING.md#preparing-for-release) is completed.

## Steps to Test

```sh
vip dev-env create --phpmyadmin --mailpit < /dev/null
vip dev-env start
```

Ensure that there are HTTPS URLs for MailPit and phpMyAdmin, like this:
```
 PHPMYADMIN URLS   http://localhost:33061
                   http://vip-local-pma.vipdev.lndo.site/
                   https://vip-local-pma.vipdev.lndo.site/
 MAILPIT URLS      http://vip-local-mailpit.vipdev.lndo.site/
                   https://vip-local-mailpit.vipdev.lndo.site/
```

Ensure that HTTPS URLs work.
