### PR TITLE
fix: `Proxying to unknown service` warning

### DIFF
--- a/assets/dev-env.lando.template.yml.ejs
+++ b/assets/dev-env.lando.template.yml.ejs
@@ -7,10 +7,14 @@ proxy:
 <% if ( multisite ) { %>
     - '*.<%= siteSlug %>.<%= domain %>'
 <% } %>
+<% if ( phpmyadmin ) { %>
   phpmyadmin:
     - <%= siteSlug %>-pma.<%= domain %>
+<% } %>
+<% if ( mailpit ) { %>
   mailpit:
     - <%= siteSlug %>-mailpit.<%= domain %>:8025
+<% } %>
 
 keys: false
 

--- a/src/lib/constants/dev-environment.ts
+++ b/src/lib/constants/dev-environment.ts
@@ -53,4 +53,4 @@ export const DEV_ENVIRONMENT_DEFAULTS = {
 	phpVersion: Object.keys( DEV_ENVIRONMENT_PHP_VERSIONS )[ 0 ],
 } as const;
 
-export const DEV_ENVIRONMENT_VERSION = '2.3.1';
+export const DEV_ENVIRONMENT_VERSION = '2.3.2';


### PR DESCRIPTION
## Description

This pull request introduces minor enhancements to the development environment configuration, focusing on proxy setup flexibility and versioning.

Configuration improvements:
* Added conditional proxy entries for `phpmyadmin` and `mailpit` in `assets/dev-env.lando.template.yml.ejs`, allowing these services to be exposed only when enabled.

Version update:
* Bumped the default development environment version from `2.3.1` to `2.3.2` in `src/lib/constants/dev-environment.ts`.

## Changelog Description

### Fixed

- "Proxying to unknown service" warning when Mailpit or phpMyAdmin is not enabled.

## Pull request checklist

- [ ] Update [SETUP.md](https://github.com/Automattic/vip-cli/blob/trunk/docs/SETUP.md#list-of-environmental-variables) with any new environmental variables.
- [ ] Update [the documentation](https://github.com/Automattic/vip-cli/blob/trunk/docs).
- [x] [Manually test](https://github.com/Automattic/vip-cli/blob/trunk/docs/TESTING.md#manual-testing) the relevant changes.
- [x] Follow the [pull request checklist](https://github.com/Automattic/vip-cli/blob/trunk/docs/RELEASING.md#new-pull-requests)
- [ ] Add/update [automated tests](https://github.com/Automattic/vip-cli/blob/trunk/docs/TESTING.md#automated-testing) as needed.

## New release checklist

- [x] [Automated tests](https://github.com/Automattic/vip-cli/blob/trunk/docs/TESTING.md#automated-testing) pass.
- [ ] The [Preparing for release checklist](https://github.com/Automattic/vip-cli/blob/trunk/docs/RELEASING.md#preparing-for-release) is completed.

## Steps to Test

CI must pass.
