### PR TITLE
chore: update `lando` to fix PLTFRM-1878

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -29,7 +29,7 @@
         "https-proxy-agent": "^7.0.6",
         "js-yaml": "^4.1.0",
         "jwt-decode": "4.0.0",
-        "lando": "github:automattic/lando-cli#603e9dc490d402a07816560f07b6bfecfc902c5a",
+        "lando": "github:automattic/lando-cli#9b67fe1aeea119ce4be75b693ca512237e07d964",
         "node-fetch": "^3.3.2",
         "node-stream-zip": "1.15.0",
         "open": "^11.0.0",
@@ -11061,8 +11061,8 @@
     "node_modules/lando": {
       "name": "@lando/cli",
       "version": "3.6.5",
-      "resolved": "git+ssh://git@github.com/automattic/lando-cli.git#603e9dc490d402a07816560f07b6bfecfc902c5a",
-      "integrity": "sha512-ql/EFlUe8y8tfgMmeYL2rECgbfDFQ3FiU1JpKmTklhJyast/h0MVYW3oq5tn/pLJjs+r1MQDiDD1I0iCC+3lwA==",
+      "resolved": "git+ssh://git@github.com/automattic/lando-cli.git#9b67fe1aeea119ce4be75b693ca512237e07d964",
+      "integrity": "sha512-FVaztiZ7iZj+UcRc05J0i3jhEdX56BKAUIULBRuHiBqrE+odthHQZUyRpjt/4OFGF/sy7i4NTZE5YdyaeaZBug==",
       "license": "GPL-3.0",
       "dependencies": {
         "axios": "^1.12.1",
@@ -21977,9 +21977,9 @@
       "integrity": "sha512-tPhhoGUiEiU/WXR4rt8klIoLdnTtyu+9jVKHd/wauEjYud32jyn63mzKWQweaQrHWxBQtYoVtdcEnYX1LosnFQ=="
     },
     "lando": {
-      "version": "git+ssh://git@github.com/automattic/lando-cli.git#603e9dc490d402a07816560f07b6bfecfc902c5a",
-      "integrity": "sha512-ql/EFlUe8y8tfgMmeYL2rECgbfDFQ3FiU1JpKmTklhJyast/h0MVYW3oq5tn/pLJjs+r1MQDiDD1I0iCC+3lwA==",
-      "from": "lando@github:automattic/lando-cli#603e9dc490d402a07816560f07b6bfecfc902c5a",
+      "version": "git+ssh://git@github.com/automattic/lando-cli.git#9b67fe1aeea119ce4be75b693ca512237e07d964",
+      "integrity": "sha512-FVaztiZ7iZj+UcRc05J0i3jhEdX56BKAUIULBRuHiBqrE+odthHQZUyRpjt/4OFGF/sy7i4NTZE5YdyaeaZBug==",
+      "from": "lando@github:automattic/lando-cli#9b67fe1aeea119ce4be75b693ca512237e07d964",
       "requires": {
         "axios": "^1.12.1",
         "bluebird": "^3.4.1",

--- a/package.json
+++ b/package.json
@@ -158,7 +158,7 @@
     "https-proxy-agent": "^7.0.6",
     "js-yaml": "^4.1.0",
     "jwt-decode": "4.0.0",
-    "lando": "github:automattic/lando-cli#603e9dc490d402a07816560f07b6bfecfc902c5a",
+    "lando": "github:automattic/lando-cli#9b67fe1aeea119ce4be75b693ca512237e07d964",
     "node-fetch": "^3.3.2",
     "node-stream-zip": "1.15.0",
     "open": "^11.0.0",


### PR DESCRIPTION
## Description

This PR updates `lando` to the latest version to fix PLTFRM-1878/GH-2651.

The fix deals with containers that lost their name mappings.

Fixes: #2651
Related: Automattic/lando-cli#129

## Changelog Description

### Fixed

- Dev Env: Correctly handle containers without name mappings.

## Pull request checklist

- [ ] Update [SETUP.md](https://github.com/Automattic/vip-cli/blob/trunk/docs/SETUP.md#list-of-environmental-variables) with any new environmental variables.
- [ ] Update [the documentation](https://github.com/Automattic/vip-cli/blob/trunk/docs).
- [x] [Manually test](https://github.com/Automattic/vip-cli/blob/trunk/docs/TESTING.md#manual-testing) the relevant changes.
- [x] Follow the [pull request checklist](https://github.com/Automattic/vip-cli/blob/trunk/docs/RELEASING.md#new-pull-requests)
- [ ] Add/update [automated tests](https://github.com/Automattic/vip-cli/blob/trunk/docs/TESTING.md#automated-testing) as needed.

## New release checklist

- [x] [Automated tests](https://github.com/Automattic/vip-cli/blob/trunk/docs/TESTING.md#automated-testing) pass.
- [ ] The [Preparing for release checklist](https://github.com/Automattic/vip-cli/blob/trunk/docs/RELEASING.md#preparing-for-release) is completed.

## Steps to Test

See #2651 for details. It might be tricky to reproduce the issue.