### PR TITLE
[PLTFRM-1821]: Add --skip-backup to vip import sql

### DIFF
--- a/src/bin/vip-import-sql.js
+++ b/src/bin/vip-import-sql.js
@@ -357,7 +357,7 @@ export const promptToContinue = async ( {
  * @returns {Promise<boolean>} True if user confirmed both times, false otherwise
  */
 export const confirmSkipBackup = async track => {
-	console.log( chalk.red( chalk.bold.red( '⚠️ WARNING ⚠️' ) ) );
+	console.log( chalk.bold.red( '⚠️ WARNING ⚠️' ) );
 	console.log(
 		chalk.red( chalk.bold.red( 'YOU ARE ABOUT TO SKIP CREATING A BACKUP BEFORE IMPORTING SQL!\n' ) )
 	);

--- a/src/bin/vip-import-sql.js
+++ b/src/bin/vip-import-sql.js
@@ -351,6 +351,70 @@ export const promptToContinue = async ( {
 };
 
 /**
+ * Show a huge warning and prompt the user to confirm twice when skipping backup
+ *
+ * @param {Function} track - Tracking function
+ * @returns {Promise<boolean>} True if user confirmed both times, false otherwise
+ */
+export const confirmSkipBackup = async track => {
+	console.log( chalk.red( chalk.bold.red( '⚠️ WARNING ⚠️' ) ) );
+	console.log(
+		chalk.red( chalk.bold.red( 'YOU ARE ABOUT TO SKIP CREATING A BACKUP BEFORE IMPORTING SQL!\n' ) )
+	);
+	console.log( chalk.bold.yellow( 'This action is EXTREMELY DANGEROUS and can result in:' ) );
+	console.log( chalk.bold.yellow( '• Permanent data loss' ) );
+	console.log( chalk.bold.yellow( '• Inability to automatically restore your database' ) );
+	console.log( chalk.bold.yellow( '• Complete site failure' ) );
+	console.log( chalk.bold.red( 'There is NO way to undo this action once the import begins!\n' ) );
+
+	const importAbortedMsg = chalk.red( '✗ Import aborted.' );
+
+	try {
+		// First confirmation: y/n prompt
+		const firstConfirm = await prompt( {
+			type: 'confirm',
+			name: 'firstConfirm',
+			message: 'Are you absolutely certain you want to skip the backup?',
+		} ).catch( () => {
+			return { firstConfirm: false };
+		} );
+
+		if ( ! firstConfirm.firstConfirm ) {
+			await track( 'import_sql_skip_backup_cancelled' );
+			console.log( importAbortedMsg );
+			return false;
+		}
+
+		// Second confirmation: requires typing "yes"
+		const secondConfirm = await prompt( {
+			type: 'input',
+			name: 'secondConfirm',
+			message: `Type '${ chalk.yellow(
+				'yes'
+			) }' (without quotes) to proceed WITHOUT creating a backup (this cannot be undone):\n`,
+		} ).catch( () => {
+			return { secondConfirm: '' };
+		} );
+
+		if ( secondConfirm.secondConfirm?.toLowerCase() !== 'yes' ) {
+			await track( 'import_sql_skip_backup_cancelled' );
+			console.error( 'Failed to confirm!' );
+			console.log( importAbortedMsg );
+			return false;
+		}
+	} catch ( error ) {
+		await track( 'import_sql_skip_backup_cancelled' );
+		console.log( importAbortedMsg );
+		console.error( error );
+		return false;
+	}
+
+	await track( 'import_sql_skip_backup_confirmed' );
+	console.log( chalk.red( '⚠️ Backup will be skipped. Proceeding with import...' ) );
+	return true;
+};
+
+/**
  * @returns {Promise<string[]>}
  */
 export async function validateAndGetTableNames( {
@@ -505,11 +569,15 @@ command( {
 		'header',
 		'Pass a header name and value (Formatted as "Name: Value") in a request for a remote SQL database file. Can be passed more than once for multiple headers and values.'
 	)
+	.option(
+		[ 'B', 'skip-backup' ],
+		'Skip creating a backup before importing the SQL file. WARNING: This is extremely dangerous and can result in permanent data loss.'
+	)
 	.examples( examples )
 	// eslint-disable-next-line complexity
 	.argv( process.argv, async ( arg, opts ) => {
 		const { app, env } = opts;
-		const { skipValidate, searchReplace, skipMaintenanceMode, md5, header } = opts;
+		const { skipValidate, searchReplace, skipMaintenanceMode, md5, header, skipBackup } = opts;
 		const { id: envId, appId } = env;
 		const [ fileNameOrURL ] = arg;
 		const isMultiSite = await isMultiSiteInSiteMeta( appId, envId );
@@ -596,6 +664,13 @@ command( {
 			tableNames,
 		} );
 
+		if ( skipBackup ) {
+			const confirmed = await confirmSkipBackup( track );
+			if ( ! confirmed ) {
+				process.exit( 0 );
+			}
+		}
+
 		if ( ! isUrl && opts.inPlace ) {
 			const approved = await confirm(
 				[],
@@ -677,6 +752,7 @@ Processing the SQL import for your environment...
 				id: app.id,
 				environmentId: env.id,
 				skipMaintenanceMode,
+				...( skipBackup && { skipBackup: true } ),
 			},
 		};
 


### PR DESCRIPTION
## Description

Adds the `--skip-backup` flag to `vip import sql` command with double confirmation prompts:
<img width="686" height="199" alt="Screenshot 2025-12-16 at 1 01 58 PM" src="https://github.com/user-attachments/assets/2f569a2b-77ca-4015-8845-b40019b40fa6" />

3 confirmations in total b/c when you first do `vip import sql` you must confirm the domain name.

## Changelog Description

### Added

- Added dangerous `--skip-backup` flag to `vip import sql` 

## Pull request checklist

- [ ] Update [SETUP.md](https://github.com/Automattic/vip-cli/blob/trunk/docs/SETUP.md#list-of-environmental-variables) with any new environmental variables.
- [ ] Update [the documentation](https://github.com/Automattic/vip-cli/blob/trunk/docs).
- [ ] [Manually test](https://github.com/Automattic/vip-cli/blob/trunk/docs/TESTING.md#manual-testing) the relevant changes.
- [ ] Follow the [pull request checklist](https://github.com/Automattic/vip-cli/blob/trunk/docs/RELEASING.md#new-pull-requests)
- [ ] Add/update [automated tests](https://github.com/Automattic/vip-cli/blob/trunk/docs/TESTING.md#automated-testing) as needed.

## New release checklist

- [ ] [Automated tests](https://github.com/Automattic/vip-cli/blob/trunk/docs/TESTING.md#automated-testing) pass.
- [ ] The [Preparing for release checklist](https://github.com/Automattic/vip-cli/blob/trunk/docs/RELEASING.md#preparing-for-release) is completed.

## Steps to Test

Outline the steps to test and verify the PR here.

Example:

1. Check out PR.
1. Run `npm run build && npm link`
1. Make non-empty dummy sql file called `test.sql`
2. `vip @<id>.<env> import sql test.sql --skip-backup --skip-validate`
