### PR TITLE
fix: support `docker-compose` >= 2.x

### DIFF
--- a/src/lib/dev-environment/dev-environment-lando.ts
+++ b/src/lib/dev-environment/dev-environment-lando.ts
@@ -777,7 +777,7 @@ export function validateDockerInstalled( lando: Lando ): void {
 			);
 		}
 
-		if ( ! satisfies( compose, '^2.0.0' ) ) {
+		if ( ! satisfies( compose, '>=2.0.0' ) ) {
 			throw new Error(
 				`docker-compose version ${ compose } is not supported. Please upgrade to version 2.0.0 or higher - https://docs.docker.com/compose/install/`
 			);


### PR DESCRIPTION
## Description

This pull request updates the Docker Compose version check in the `validateDockerInstalled` function to be more inclusive of valid versions. Current version of `docker-compose` standalone binary is 5.x; our code checks for `^2.0.0` and, therefore, fails on 5.x.

Dependency validation update:

* Relaxed the version constraint for Docker Compose in `validateDockerInstalled` to allow any version `2.0.0` or higher, instead of only versions matching the `^2.0.0` range. (`src/lib/dev-environment/dev-environment-lando.ts`)

## Changelog Description

### Fixed

- Dev Environment: allow `docker-compose` newer than 2.x

## Pull request checklist

- [ ] Update [SETUP.md](https://github.com/Automattic/vip-cli/blob/trunk/docs/SETUP.md#list-of-environmental-variables) with any new environmental variables.
- [ ] Update [the documentation](https://github.com/Automattic/vip-cli/blob/trunk/docs).
- [x] [Manually test](https://github.com/Automattic/vip-cli/blob/trunk/docs/TESTING.md#manual-testing) the relevant changes.
- [x] Follow the [pull request checklist](https://github.com/Automattic/vip-cli/blob/trunk/docs/RELEASING.md#new-pull-requests)
- [ ] Add/update [automated tests](https://github.com/Automattic/vip-cli/blob/trunk/docs/TESTING.md#automated-testing) as needed.

## New release checklist

- [ ] [Automated tests](https://github.com/Automattic/vip-cli/blob/trunk/docs/TESTING.md#automated-testing) pass.
- [ ] The [Preparing for release checklist](https://github.com/Automattic/vip-cli/blob/trunk/docs/RELEASING.md#preparing-for-release) is completed.

## Steps to Test

Install the `docker-compose` binary from https://github.com/docker/compose/releases and ensure that dev env works.
