### PR TITLE
fix(dev-env): defer querying site details

### DIFF
--- a/src/bin/vip-dev-env-sync-sql.js
+++ b/src/bin/vip-dev-env-sync-sql.js
@@ -59,14 +59,6 @@ const appQuery = `
 		primaryDomain { name }
 		uniqueLabel
 		isMultisite
-		wpSitesSDS(first:500) {
-			total
-			nodes {
-				id
-				blogId
-				homeUrl
-			}
-		}
 	}
 `;
 

--- a/src/commands/dev-env-sync-sql.ts
+++ b/src/commands/dev-env-sync-sql.ts
@@ -222,7 +222,18 @@ export class DevEnvSyncSQLCommand {
 	}
 
 	public getSiteUrlsFromSDS(): Promise< WpSite[] > {
-		return this.fetchAllSites( Number( this.app.id ), Number( this.env.id ) );
+		if ( this.env.isMultisite ) {
+			return this.fetchAllSites( Number( this.app.id ), Number( this.env.id ) );
+		}
+
+		return Promise.resolve( [
+			{
+				blogId: 1,
+				homeUrl: this.env.primaryDomain ? `https://${ this.env.primaryDomain.name }` : undefined,
+				siteUrl: this.env.primaryDomain ? `https://${ this.env.primaryDomain.name }` : undefined,
+				id: 1,
+			},
+		] );
 	}
 
 	private fetchSitesPage(

--- a/src/commands/dev-env-sync-sql.ts
+++ b/src/commands/dev-env-sync-sql.ts
@@ -221,17 +221,8 @@ export class DevEnvSyncSQLCommand {
 		fs.renameSync( outputFile, this.sqlFile );
 	}
 
-	public async getSiteUrlsFromSDS(): Promise< WpSite[] > {
-		if (
-			this.env.isMultisite &&
-			( ! this.env.wpSitesSDS?.nodes ||
-				! this.env.wpSitesSDS?.total ||
-				this.env.wpSitesSDS.nodes.length < this.env.wpSitesSDS.total )
-		) {
-			return this.fetchAllSites( Number( this.app.id ), Number( this.env.id ) );
-		}
-
-		return this.env.wpSitesSDS?.nodes?.filter( ( node ): node is WpSite => Boolean( node ) ) ?? [];
+	public getSiteUrlsFromSDS(): Promise< WpSite[] > {
+		return this.fetchAllSites( Number( this.app.id ), Number( this.env.id ) );
 	}
 
 	private fetchSitesPage(

--- a/src/commands/dev-env-sync-sql.ts
+++ b/src/commands/dev-env-sync-sql.ts
@@ -226,14 +226,7 @@ export class DevEnvSyncSQLCommand {
 			return this.fetchAllSites( Number( this.app.id ), Number( this.env.id ) );
 		}
 
-		return Promise.resolve( [
-			{
-				blogId: 1,
-				homeUrl: this.env.primaryDomain ? `https://${ this.env.primaryDomain.name }` : undefined,
-				siteUrl: this.env.primaryDomain ? `https://${ this.env.primaryDomain.name }` : undefined,
-				id: 1,
-			},
-		] );
+		return Promise.resolve( [] );
 	}
 
 	private fetchSitesPage(


### PR DESCRIPTION
## Description

Move querying of site details out of the application query to fix permission issues.

## Changelog Description

### Fixed

- `vip dev-env sync sql`: query site details only when they are needed. This fixes the issue with permissions when `@app.env` is not specified.

## Pull request checklist

- [ ] Update [SETUP.md](https://github.com/Automattic/vip-cli/blob/trunk/docs/SETUP.md#list-of-environmental-variables) with any new environmental variables.
- [ ] Update [the documentation](https://github.com/Automattic/vip-cli/blob/trunk/docs).
- [x] [Manually test](https://github.com/Automattic/vip-cli/blob/trunk/docs/TESTING.md#manual-testing) the relevant changes.
- [x] Follow the [pull request checklist](https://github.com/Automattic/vip-cli/blob/trunk/docs/RELEASING.md#new-pull-requests)
- [ ] Add/update [automated tests](https://github.com/Automattic/vip-cli/blob/trunk/docs/TESTING.md#automated-testing) as needed.

## New release checklist

- [x] [Automated tests](https://github.com/Automattic/vip-cli/blob/trunk/docs/TESTING.md#automated-testing) pass.
- [ ] The [Preparing for release checklist](https://github.com/Automattic/vip-cli/blob/trunk/docs/RELEASING.md#preparing-for-release) is completed.

## Steps to Test

1. Log in as "Platform Test User - App Read"
2. `vip dev-env @vip-permissions-test-wp.production sync sql` must not fail until the "Preparing for backup download" phase
3. `vip dev-env sync sql` must ask for app/env instead of failing with "Unauthorized" error.
