### PR TITLE
chore: remove PHP 8.1

### DIFF
--- a/__tests__/lib/dev-environment/dev-environment-cli.js
+++ b/__tests__/lib/dev-environment/dev-environment-cli.js
@@ -585,9 +585,10 @@ describe( 'lib/dev-environment/dev-environment-cli', () => {
 
 	describe( 'resolvePhpVersion', () => {
 		it.each( [
-			[ '8.1', DEV_ENVIRONMENT_PHP_VERSIONS[ '8.1' ].image ],
 			[ '8.2', DEV_ENVIRONMENT_PHP_VERSIONS[ '8.2' ].image ],
 			[ '8.3', DEV_ENVIRONMENT_PHP_VERSIONS[ '8.3' ].image ],
+			[ '8.4', DEV_ENVIRONMENT_PHP_VERSIONS[ '8.4' ].image ],
+			[ '8.5', DEV_ENVIRONMENT_PHP_VERSIONS[ '8.5' ].image ],
 		] )( 'should process versions correctly', async ( input, expected ) => {
 			const actual = resolvePhpVersion( input );
 			expect( actual ).toStrictEqual( expected );

--- a/src/lib/constants/dev-environment.ts
+++ b/src/lib/constants/dev-environment.ts
@@ -32,7 +32,6 @@ export const DEV_ENVIRONMENT_PHP_VERSIONS: Record< string, PhpImage > = {
 		image: 'ghcr.io/automattic/vip-container-images/php-fpm:8.2',
 		label: '8.2 (recommended)',
 	},
-	8.1: { image: 'ghcr.io/automattic/vip-container-images/php-fpm:8.1', label: '8.1' },
 	8.3: {
 		image: 'ghcr.io/automattic/vip-container-images/php-fpm:8.3',
 		label: '8.3',


### PR DESCRIPTION
## Description

PHP 8.1 reached its EoL on December 31, 2025, and it is time to say goodbye.

## Changelog Description

### Removed

- Dev Env: removed PHP 8.1.

## Pull request checklist

- [ ] Update [SETUP.md](https://github.com/Automattic/vip-cli/blob/trunk/docs/SETUP.md#list-of-environmental-variables) with any new environmental variables.
- [ ] Update [the documentation](https://github.com/Automattic/vip-cli/blob/trunk/docs).
- [x] [Manually test](https://github.com/Automattic/vip-cli/blob/trunk/docs/TESTING.md#manual-testing) the relevant changes.
- [x] Follow the [pull request checklist](https://github.com/Automattic/vip-cli/blob/trunk/docs/RELEASING.md#new-pull-requests)
- [ ] Add/update [automated tests](https://github.com/Automattic/vip-cli/blob/trunk/docs/TESTING.md#automated-testing) as needed.

## New release checklist

- [ ] [Automated tests](https://github.com/Automattic/vip-cli/blob/trunk/docs/TESTING.md#automated-testing) pass.
- [ ] The [Preparing for release checklist](https://github.com/Automattic/vip-cli/blob/trunk/docs/RELEASING.md#preparing-for-release) is completed.

## Steps to Test

CI must pass.
