### PR TITLE
npm-publish-prerelease: use latest version

### DIFF
--- a/.github/workflows/npm-publish-prerelease.yml
+++ b/.github/workflows/npm-publish-prerelease.yml
@@ -17,7 +17,7 @@ jobs:
       id-token: write
       pull-requests: write
     steps:
-      - uses: Automattic/vip-actions/npm-publish@v0.7.3
+      - uses: Automattic/vip-actions/npm-publish-prerelease@v0.7.4
         with:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           USE_TRUSTED_PUBLISHING: 'true'


### PR DESCRIPTION
## Description

Pulls in changes to use the latest version which accepts trusted publishing