### PR TITLE
fix: honor quiet mode

### DIFF
--- a/src/bin/vip-dev-env-exec.js
+++ b/src/bin/vip-dev-env-exec.js
@@ -56,7 +56,7 @@ command( {
 	.option( 'quiet', 'Suppress informational messages.', undefined, processBooleanOption )
 	.examples( examples )
 	.argv( process.argv, async ( unmatchedArgs, opt ) => {
-		const slug = await getEnvironmentName( opt );
+		const slug = await getEnvironmentName( opt, opt.quiet );
 		const lando = await bootstrapLando( { logFile: getDevEnvLogFile( slug ) } );
 		validateDependencies( lando );
 

--- a/src/bin/vip-dev-env-exec.js
+++ b/src/bin/vip-dev-env-exec.js
@@ -57,7 +57,7 @@ command( {
 	.examples( examples )
 	.argv( process.argv, async ( unmatchedArgs, opt ) => {
 		const slug = await getEnvironmentName( opt, opt.quiet );
-		const lando = await bootstrapLando( { logFile: getDevEnvLogFile( slug ) } );
+		const lando = await bootstrapLando( { logFile: getDevEnvLogFile( slug ), quiet: opt.quiet } );
 		validateDependencies( lando );
 
 		const trackingInfo = getEnvTrackingInfo( slug );

--- a/src/bin/vip-dev-env-import-sql.js
+++ b/src/bin/vip-dev-env-import-sql.js
@@ -66,7 +66,7 @@ command( {
 	.examples( examples )
 	.argv( process.argv, async ( unmatchedArgs, opt ) => {
 		const [ fileName ] = unmatchedArgs;
-		const slug = await getEnvironmentName( opt );
+		const slug = await getEnvironmentName( opt, opt.quiet );
 		if ( opt.searchReplace && ! Array.isArray( opt.searchReplace ) ) {
 			opt.searchReplace = [ opt.searchReplace ];
 		}

--- a/src/lib/dev-environment/dev-environment-cli.ts
+++ b/src/lib/dev-environment/dev-environment-cli.ts
@@ -125,7 +125,10 @@ export const validateDependencies = ( lando: Lando ) => {
 	debug( 'Validation checks completed in %d ms', duration );
 };
 
-export async function getEnvironmentName( options: EnvironmentNameOptions ): Promise< string > {
+export async function getEnvironmentName(
+	options: EnvironmentNameOptions,
+	quiet = false
+): Promise< string > {
 	if ( options.slug ) {
 		return options.slug;
 	}
@@ -146,11 +149,13 @@ export async function getEnvironmentName( options: EnvironmentNameOptions ): Pro
 
 	if ( configurationFileOptions.slug && configurationFileOptions.meta ) {
 		const slug = configurationFileOptions.slug;
-		console.log(
-			`Using environment ${ chalk.blue.bold( slug ) } from ${ chalk.gray(
-				configurationFileOptions.meta[ 'configuration-path' ]
-			) }\n`
-		);
+		if ( ! quiet ) {
+			console.log(
+				`Using environment ${ chalk.blue.bold( slug ) } from ${ chalk.gray(
+					configurationFileOptions.meta[ 'configuration-path' ]
+				) }\n`
+			);
+		}
 
 		return slug;
 	}

--- a/src/lib/dev-environment/dev-environment-lando.ts
+++ b/src/lib/dev-environment/dev-environment-lando.ts
@@ -44,6 +44,7 @@ const debug = debugLib( DEBUG_KEY );
 interface LandoBootstrapOptions {
 	logFile?: string;
 	logName?: string;
+	quiet?: boolean;
 }
 
 interface LandoConfigWithLogging extends Omit< LandoConfig, 'composeBin' | 'dockerBin' > {
@@ -73,7 +74,7 @@ const getLogFilePath = ( config: LandoConfigWithLogging ): string | null => {
 	return null;
 };
 
-const registerLogPathOutput = ( config: LandoConfigWithLogging ): void => {
+const registerLogPathOutput = ( config: LandoConfigWithLogging, quiet: boolean ): void => {
 	if ( logPathRegistered ) {
 		return;
 	}
@@ -84,6 +85,10 @@ const registerLogPathOutput = ( config: LandoConfigWithLogging ): void => {
 	}
 
 	logPathRegistered = true;
+	if ( quiet ) {
+		return;
+	}
+
 	process.once( 'exit', () => {
 		if ( resolvedLogPath && process.stdout.isTTY ) {
 			console.log(
@@ -380,7 +385,7 @@ export async function bootstrapLando( options: LandoBootstrapOptions = {} ): Pro
 			debug( 'Engine config: %j', config.engineConfig );
 		}
 
-		registerLogPathOutput( config as LandoConfigWithLogging );
+		registerLogPathOutput( config as LandoConfigWithLogging, Boolean( options.quiet ) );
 		await writeLogBanner( config as LandoConfigWithLogging );
 
 		const lando = new Lando( config );


### PR DESCRIPTION
## Description

This pull request introduces an optional "quiet" mode to suppress console output in the development environment CLI and Lando integration. The main focus is to allow users or calling code to opt out of informational logs and messages during environment setup and bootstrapping.

The most important changes are:

**Quiet mode support in CLI and Lando integration:**
* Added an optional `quiet` parameter to the `getEnvironmentName` function in `dev-environment-cli.ts`, which suppresses console output when set to `true`. [[1]](diffhunk://#diff-ec426ae812f0e370584b75a318437ca199a457c2ca9a8f66ec3f7447aad6a279L128-R131) [[2]](diffhunk://#diff-ec426ae812f0e370584b75a318437ca199a457c2ca9a8f66ec3f7447aad6a279R152-R158)
* Extended the `LandoBootstrapOptions` interface in `dev-environment-lando.ts` to include a `quiet` property, allowing quiet mode to be passed through the bootstrapping process.
* Updated the `registerLogPathOutput` function in `dev-environment-lando.ts` to accept a `quiet` argument and skip log path output when `quiet` is enabled. [[1]](diffhunk://#diff-15dbc43165de0e5b07bbd1cc20ebe7a756e8f08ac7cdb252729414a57bb04e22L76-R77) [[2]](diffhunk://#diff-15dbc43165de0e5b07bbd1cc20ebe7a756e8f08ac7cdb252729414a57bb04e22R88-R91)
* Modified the `bootstrapLando` function to pass the `quiet` option to `registerLogPathOutput`, ensuring that log output respects the quiet mode setting.

Before:
<img width="980" height="415" alt="Screenshot_20260226_171427" src="https://github.com/user-attachments/assets/050666be-7140-4b45-8c24-afa67e1ae49e" />

After:
<img width="980" height="144" alt="Screenshot_20260226_171541" src="https://github.com/user-attachments/assets/a0d9959b-08bc-4537-880e-cbafd4112a42" />

## Changelog Description

### Fixed

- Do not display extra output when `vip dev-env exec` is run with `--quiet`

## Pull request checklist

- [ ] Update [SETUP.md](https://github.com/Automattic/vip-cli/blob/trunk/docs/SETUP.md#list-of-environmental-variables) with any new environmental variables.
- [ ] Update [the documentation](https://github.com/Automattic/vip-cli/blob/trunk/docs).
- [x] [Manually test](https://github.com/Automattic/vip-cli/blob/trunk/docs/TESTING.md#manual-testing) the relevant changes.
- [x] Follow the [pull request checklist](https://github.com/Automattic/vip-cli/blob/trunk/docs/RELEASING.md#new-pull-requests)
- [ ] Add/update [automated tests](https://github.com/Automattic/vip-cli/blob/trunk/docs/TESTING.md#automated-testing) as needed.

## New release checklist

- [x] [Automated tests](https://github.com/Automattic/vip-cli/blob/trunk/docs/TESTING.md#automated-testing) pass.
- [ ] The [Preparing for release checklist](https://github.com/Automattic/vip-cli/blob/trunk/docs/RELEASING.md#preparing-for-release) is completed.

## Steps to Test

```sh
vip dev-env exec -- wp user list
```

must not display the "COMMAND LOG FILE" message.

When running with a config file, there should be no "Using environment ..." message as well.
