### PR TITLE
feat: add print option to phpMyAdmin command to output URL to stdout

### DIFF
--- a/__tests__/commands/phpmyadmin.ts
+++ b/__tests__/commands/phpmyadmin.ts
@@ -91,5 +91,16 @@ describe( 'commands/PhpMyAdminCommand', () => {
 			} );
 			expect( openUrl ).toHaveBeenCalledWith( 'http://test-url.com' );
 		} );
+
+		it( 'should print the URL to stdout instead of opening browser when print option is set', async () => {
+			const printCmd = new PhpMyAdminCommand( app, env, tracker );
+			const printOpenUrl = jest.spyOn( printCmd, 'openUrl' );
+			printOpenUrl.mockReset();
+			const consoleSpy = jest.spyOn( console, 'log' );
+			await printCmd.run( { print: true } );
+			expect( printOpenUrl ).not.toHaveBeenCalled();
+			expect( consoleSpy ).toHaveBeenCalledWith( 'http://test-url.com' );
+			consoleSpy.mockRestore();
+		} );
 	} );
 } );

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -11691,7 +11691,6 @@
       "version": "10.2.4",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.4.tgz",
       "integrity": "sha512-oRjTw/97aTBN0RHbYCdtF1MQfvusSIBQM0IZEgzl6426+8jSC0nF1a/GmnVLpfB9yyr6g6FTqWqiZVbxrtaCIg==",
-      "dev": true,
       "license": "BlueOak-1.0.0",
       "dependencies": {
         "brace-expansion": "^5.0.2"
@@ -11707,7 +11706,6 @@
       "version": "4.0.4",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
       "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": "18 || 20 || >=22"
@@ -11717,7 +11715,6 @@
       "version": "5.0.3",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.3.tgz",
       "integrity": "sha512-fy6KJm2RawA5RcHkLa1z/ScpBeA762UF9KmZQxwIbDtRJrgLzM10depAiEQ+CXYcoiqW1/m96OAAoke2nE9EeA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^4.0.2"

--- a/src/bin/vip-db-phpmyadmin.ts
+++ b/src/bin/vip-db-phpmyadmin.ts
@@ -18,6 +18,10 @@ const examples = [
 		description:
 			"Generate access to a read-only phpMyAdmin web interface for the environment's database.",
 	},
+	{
+		usage: 'vip @example-app.develop db phpmyadmin --print',
+		description: 'Print the phpMyAdmin URL to stdout instead of opening it in a browser.',
+	},
 ];
 
 const appQuery = `
@@ -40,16 +44,23 @@ void command( {
 	requiredArgs: 0,
 	usage: 'vip db phpmyadmin',
 } )
+	.option( 'print', 'Print the phpMyAdmin URL to stdout instead of opening it in a browser.' )
 	.examples( examples )
-	.argv( process.argv, async ( arg: string[], { app, env }: { app: App; env: AppEnvironment } ) => {
-		const trackerFn = makeCommandTracker( 'phpmyadmin', {
-			app: app.id,
-			env: env.uniqueLabel,
-		} );
-		await trackerFn( 'execute' );
+	.argv(
+		process.argv,
+		async (
+			arg: string[],
+			{ app, env, print: printUrl }: { app: App; env: AppEnvironment; print: boolean }
+		) => {
+			const trackerFn = makeCommandTracker( 'phpmyadmin', {
+				app: app.id,
+				env: env.uniqueLabel,
+			} );
+			await trackerFn( 'execute' );
 
-		const cmd = new PhpMyAdminCommand( app, env, trackerFn );
-		await cmd.run();
+			const cmd = new PhpMyAdminCommand( app, env, trackerFn );
+			await cmd.run( { print: printUrl } );
 
-		await trackerFn( 'success' );
-	} );
+			await trackerFn( 'success' );
+		}
+	);

--- a/src/commands/phpmyadmin.ts
+++ b/src/commands/phpmyadmin.ts
@@ -167,7 +167,7 @@ export class PhpMyAdminCommand {
 		}
 	}
 
-	public async run( silent = false ): Promise< void > {
+	public async run( { silent = false, print = false } = {} ): Promise< void > {
 		this.silent = silent;
 
 		if ( ! this.app.id ) {
@@ -229,8 +229,14 @@ export class PhpMyAdminCommand {
 			exit.withError( `Failed to generate PhpMyAdmin URL: ${ error.message }` );
 		}
 
-		void this.openUrl( url );
 		this.stopProgressTracker();
-		this.log( 'PhpMyAdmin is opened in your default browser.' );
+
+		if ( print ) {
+			// Output only the URL to stdout for scripting/automation use
+			console.log( url );
+		} else {
+			void this.openUrl( url );
+			this.log( 'PhpMyAdmin is opened in your default browser.' );
+		}
 	}
 }


### PR DESCRIPTION
## Description

Adds a `--print` option to `vip db phpmyadmin` that outputs the phpMyAdmin URL to stdout instead of automatically opening it in the default browser. This is useful for opening in a non-default, i.e. ie specific browser. In my use case, there were networking issues, and I could not easily debug Chrome network logs in the browser when the auto-opened link was used. Additional use cases are scripting, automation, and piping to clipboard utilities.

## Changelog Description

### Added
- `vip db phpmyadmin`: Added `--print` option to output the phpMyAdmin URL to stdout instead of opening it in a browser.

## Pull request checklist

- [x] [Manually test](https://github.com/Automattic/vip-cli/blob/trunk/docs/TESTING.md#manual-testing) the relevant changes.
- [x] Follow the [pull request checklist](https://github.com/Automattic/vip-cli/blob/trunk/docs/RELEASING.md#new-pull-requests)
- [x] Add/update [automated tests](https://github.com/Automattic/vip-cli/blob/trunk/docs/TESTING.md#automated-testing) as needed.

## Pull request checklist (skipped, no changes)
- [ ] Update [SETUP.md](https://github.com/Automattic/vip-cli/blob/trunk/docs/SETUP.md#list-of-environmental-variables) with any new environmental variables.
- [ ] Update [the documentation](https://github.com/Automattic/vip-cli/blob/trunk/docs).

## New release checklist
- [x] [Automated tests](https://github.com/Automattic/vip-cli/blob/trunk/docs/TESTING.md#automated-testing) pass.
- [ ] The [Preparing for release checklist](https://github.com/Automattic/vip-cli/blob/trunk/docs/RELEASING.md#preparing-for-release) is completed.

## Steps to Test

1. Check out PR.
1. Run `npm install && npm run build`.
1. Run `./dist/bin/vip-db-phpmyadmin.js @<app>.<env> --help` and verify `--print` appears in the options list.
1. Run `./dist/bin/vip-db-phpmyadmin.js @<app>.<env>` (without `--print`) and verify it opens phpMyAdmin in the default browser as before.
1. Run `./dist/bin/vip-db-phpmyadmin.js @<app>.<env> --print` and verify the URL is printed to stdout and no browser is opened.
1. Verify the printed URL is valid by pasting it into a browser manually.
1. Run `npx jest --forceExit __tests__/commands/phpmyadmin.ts` and verify all tests pass.
