### PR TITLE
fix: pass `LANDO_HOST_xID` vars to `initOnly` services

### DIFF
--- a/assets/dev-env.lando.template.yml.ejs
+++ b/assets/dev-env.lando.template.yml.ejs
@@ -218,6 +218,8 @@ services:
       environment:
         LANDO_NO_SCRIPTS: 1
         LANDO_NEEDS_EXEC: 1
+        LANDO_HOST_UID: ${LANDO_HOST_USER_ID}
+        LANDO_HOST_GID: ${LANDO_HOST_GROUP_ID}
     volumes:
       mu-plugins: {}
     initOnly: true
@@ -237,6 +239,9 @@ services:
         - clientcode_private:/clientcode/private
         - clientcode_themes:/clientcode/themes
         - clientcode_vipconfig:/clientcode/vip-config
+      environment:
+        LANDO_HOST_UID: ${LANDO_HOST_USER_ID}
+        LANDO_HOST_GID: ${LANDO_HOST_GROUP_ID}
     volumes:
       clientcode_clientmuPlugins: {}
       clientcode_images: {}

--- a/src/lib/constants/dev-environment.ts
+++ b/src/lib/constants/dev-environment.ts
@@ -52,4 +52,4 @@ export const DEV_ENVIRONMENT_DEFAULTS = {
 	phpVersion: Object.keys( DEV_ENVIRONMENT_PHP_VERSIONS )[ 0 ],
 } as const;
 
-export const DEV_ENVIRONMENT_VERSION = '2.3.2';
+export const DEV_ENVIRONMENT_VERSION = '2.3.3';


### PR DESCRIPTION
## Description

This PR solves the issue with permissions like this:

```
demo-app-code-1   | 2026-03-09T04:55:00.570754117Z userperms 04:55:00.DEBUG ==> Lando ENVVARS set at
demo-app-code-1   | 2026-03-09T04:55:00.571069728Z userperms 04:55:00.DEBUG ==> 
demo-app-code-1   | 2026-03-09T04:55:00.571370967Z userperms 04:55:00.DEBUG ==> ========================================
demo-app-code-1   | 2026-03-09T04:55:00.571669105Z userperms 04:55:00.DEBUG ==> LANDO_WEBROOT_USER      : www-data
demo-app-code-1   | 2026-03-09T04:55:00.571979118Z userperms 04:55:00.DEBUG ==> LANDO_WEBROOT_GROUP     : www-data
demo-app-code-1   | 2026-03-09T04:55:00.572291281Z userperms 04:55:00.DEBUG ==> LANDO_WEBROOT_UID       : 33
demo-app-code-1   | 2026-03-09T04:55:00.572573118Z userperms 04:55:00.DEBUG ==> LANDO_WEBROOT_GID       : 33
demo-app-code-1   | 2026-03-09T04:55:00.572830574Z userperms 04:55:00.DEBUG ==> LANDO_HOST_UID          : 
demo-app-code-1   | 2026-03-09T04:55:00.573062930Z userperms 04:55:00.DEBUG ==> LANDO_HOST_GID          : 
demo-app-code-1   | 2026-03-09T04:55:00.573321436Z userperms 04:55:00.DEBUG ==> ========================================
demo-app-code-1   | 2026-03-09T04:55:00.573571590Z userperms 04:55:00.DEBUG ==> 
demo-app-code-1   | 2026-03-09T04:55:00.573830754Z userperms 04:55:00.INFO  ==> Making sure correct user:group (www-data:www-data) exists...
demo-app-code-1   | 2026-03-09T04:55:00.575058175Z /helpers/user-perms.sh: line 37: chsh: not found
demo-app-code-1   | 2026-03-09T04:55:00.575260206Z userperms 04:55:00.INFO  ==> Remapping ownership to handle docker volume sharing...
demo-app-code-1   | 2026-03-09T04:55:00.575511096Z userperms 04:55:00.INFO  ==> Resetting www-data:www-data from 33:33 to :
demo-app-code-1   | 2026-03-09T04:55:00.645239061Z id: unknown user www-data
demo-app-code-1   | 2026-03-09T04:55:00.645824548Z userperms 04:55:00.WARN  ==> Looks like host/container user mapping was not possible! aborting...
```

## Changelog Description

### Fixed

- Directory permissions issues for `initOnly` containers

## Pull request checklist

- [ ] Update [SETUP.md](https://github.com/Automattic/vip-cli/blob/trunk/docs/SETUP.md#list-of-environmental-variables) with any new environmental variables.
- [ ] Update [the documentation](https://github.com/Automattic/vip-cli/blob/trunk/docs).
- [x] [Manually test](https://github.com/Automattic/vip-cli/blob/trunk/docs/TESTING.md#manual-testing) the relevant changes.
- [ ] Follow the [pull request checklist](https://github.com/Automattic/vip-cli/blob/trunk/docs/RELEASING.md#new-pull-requests)
- [ ] Add/update [automated tests](https://github.com/Automattic/vip-cli/blob/trunk/docs/TESTING.md#automated-testing) as needed.

## New release checklist

- [x] [Automated tests](https://github.com/Automattic/vip-cli/blob/trunk/docs/TESTING.md#automated-testing) pass.
- [ ] The [Preparing for release checklist](https://github.com/Automattic/vip-cli/blob/trunk/docs/RELEASING.md#preparing-for-release) is completed.

## Steps to Test

Wuth this PR applied, the permission sweep must succeed:
```
demo-app-code-1   | 2026-03-09T05:04:18.995652607Z userperms 05:04:18.DEBUG ==> 
demo-app-code-1   | 2026-03-09T05:04:18.996315084Z userperms 05:04:18.DEBUG ==> ========================================
demo-app-code-1   | 2026-03-09T05:04:18.996922112Z userperms 05:04:18.DEBUG ==> LANDO_WEBROOT_USER      : www-data
demo-app-code-1   | 2026-03-09T05:04:18.997428898Z userperms 05:04:18.DEBUG ==> LANDO_WEBROOT_GROUP     : www-data
demo-app-code-1   | 2026-03-09T05:04:18.997966425Z userperms 05:04:18.DEBUG ==> LANDO_WEBROOT_UID       : 33
demo-app-code-1   | 2026-03-09T05:04:18.998504933Z userperms 05:04:18.DEBUG ==> LANDO_WEBROOT_GID       : 33
demo-app-code-1   | 2026-03-09T05:04:18.998984127Z userperms 05:04:18.DEBUG ==> LANDO_HOST_UID          : 1000
demo-app-code-1   | 2026-03-09T05:04:18.999415869Z userperms 05:04:18.DEBUG ==> LANDO_HOST_GID          : 1000
demo-app-code-1   | 2026-03-09T05:04:18.999862878Z userperms 05:04:18.DEBUG ==> ========================================
demo-app-code-1   | 2026-03-09T05:04:19.000291236Z userperms 05:04:19.DEBUG ==> 
demo-app-code-1   | 2026-03-09T05:04:19.000711925Z userperms 05:04:19.INFO  ==> Making sure correct user:group (www-data:www-data) exists...
demo-app-code-1   | 2026-03-09T05:04:19.002180411Z /helpers/user-perms.sh: line 37: chsh: not found
demo-app-code-1   | 2026-03-09T05:04:19.002478686Z userperms 05:04:19.INFO  ==> Remapping ownership to handle docker volume sharing...
demo-app-code-1   | 2026-03-09T05:04:19.002834302Z userperms 05:04:19.INFO  ==> Resetting www-data:www-data from 33:33 to 1000:1000
demo-app-code-1   | 2026-03-09T05:04:19.203239598Z userperms 05:04:19.INFO  ==> www-data:www-data is now running as uid=1000(www-data) gid=1000(www-data) groups=1000(www-data)!
```

The issues with missing `chsh` or `getent` will be addressed in Automattic/lando-cli