### PR TITLE
Improve command description for `import media`

### DIFF
--- a/src/bin/vip-import.js
+++ b/src/bin/vip-import.js
@@ -8,7 +8,7 @@ command()
 	.command( 'validate-sql', 'Validate a local SQL database file prior to import.' )
 	.command(
 		'validate-files',
-		'Validate that the directory structure and contents of a local media file directory can be successfully importedß.'
+		'Validate that the directory structure and contents of a local media file directory can be successfully imported.'
 	)
 	.command(
 		'media',

--- a/src/bin/vip-import.js
+++ b/src/bin/vip-import.js
@@ -8,11 +8,11 @@ command()
 	.command( 'validate-sql', 'Validate a local SQL database file prior to import.' )
 	.command(
 		'validate-files',
-		'Validate the directory structure and contents of a local media file directory prior to archiving and uploading it to a publicly accessible URL.'
+		'Validate that the directory structure and contents of a local media file directory can be successfully importedß.'
 	)
 	.command(
 		'media',
-		'Import media files to an environment from an archived file located at a publicly accessible URL.'
+		'Import media files to a production environment from an archived file at a local path or a publicly accessible remote URL.'
 	)
 	.example(
 		'vip @example-app.develop import sql example-file.sql',


### PR DESCRIPTION
## Description

The VIP-CLI command `vip import media` can only be run against the production environment of an application. This PR restores that clarification which was unintentionally lost about a year ago. 

## Changelog Description

### Changed

- Edited the command description for `import media` to clarify that it can only be run against a production environment.

## Steps to Test

1. Check out PR.
2.  Observe the results of the `--help` display for impacted command `vip import media`.

