### PR TITLE
chore(deps): update `lando` and `protobufjs`

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -29,7 +29,7 @@
         "https-proxy-agent": "^9.0.0",
         "js-yaml": "^4.1.0",
         "jwt-decode": "4.0.0",
-        "lando": "github:automattic/lando-cli#c7dd51e8fb341e59e0e51a1aac453aa81dc2faf6",
+        "lando": "github:automattic/lando-cli#78d382fcf40357c4a4cebe4a3cfaef032eab743a",
         "node-fetch": "^3.3.2",
         "node-stream-zip": "1.15.0",
         "open": "^11.0.0",
@@ -3809,9 +3809,9 @@
       "license": "BSD-3-Clause"
     },
     "node_modules/@protobufjs/codegen": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/@protobufjs/codegen/-/codegen-2.0.4.tgz",
-      "integrity": "sha512-YyFaikqM5sH0ziFZCN3xDC7zeGaB/d0IUb9CATugHWbd1FRFwWwt4ld4OYMPWu5a3Xe01mGAULCdqhMlPl29Jg==",
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/@protobufjs/codegen/-/codegen-2.0.5.tgz",
+      "integrity": "sha512-zgXFLzW3Ap33e6d0Wlj4MGIm6Ce8O89n/apUaGNB/jx+hw+ruWEp7EwGUshdLKVRCxZW12fp9r40E1mQrf/34g==",
       "license": "BSD-3-Clause"
     },
     "node_modules/@protobufjs/eventemitter": {
@@ -3837,9 +3837,9 @@
       "license": "BSD-3-Clause"
     },
     "node_modules/@protobufjs/inquire": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@protobufjs/inquire/-/inquire-1.1.0.tgz",
-      "integrity": "sha512-kdSefcPdruJiFMVSbn801t4vFK7KB/5gd2fYvrxhuJYg8ILrmn9SKSX2tZdV6V+ksulWqS7aXjBcRXl3wHoD9Q==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@protobufjs/inquire/-/inquire-1.1.1.tgz",
+      "integrity": "sha512-mnzgDV26ueAvk7rsbt9L7bE0SuAoqyuys/sMMrmVcN5x9VsxpcG3rqAUSgDyLp0UZlmNfIbQ4fHfCtreVBk8Ew==",
       "license": "BSD-3-Clause"
     },
     "node_modules/@protobufjs/path": {
@@ -3855,9 +3855,9 @@
       "license": "BSD-3-Clause"
     },
     "node_modules/@protobufjs/utf8": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@protobufjs/utf8/-/utf8-1.1.0.tgz",
-      "integrity": "sha512-Vvn3zZrhQZkkBE8LSuW3em98c0FwgO4nxzv6OdSxPKJIEKY2bGbHn+mhGIPerzI4twdxaP8/0+06HBpwf345Lw==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@protobufjs/utf8/-/utf8-1.1.1.tgz",
+      "integrity": "sha512-oOAWABowe8EAbMyWKM0tYDKi8Yaox52D+HWZhAIJqQXbqe0xI/GV7FhLWqlEKreMkfDjshR5FKgi3mnle0h6Eg==",
       "license": "BSD-3-Clause"
     },
     "node_modules/@rtsao/scc": {
@@ -5277,9 +5277,9 @@
       }
     },
     "node_modules/axios": {
-      "version": "1.14.0",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.14.0.tgz",
-      "integrity": "sha512-3Y8yrqLSwjuzpXuZ0oIYZ/XGgLwUIBU3uLvbcpb0pidD9ctpShJd43KSlEEkVQg6DS0G9NKyzOvBfUtDKEyHvQ==",
+      "version": "1.15.2",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.15.2.tgz",
+      "integrity": "sha512-wLrXxPtcrPTsNlJmKjkPnNPK2Ihe0hn0wGSaTEiHRPxwjvJwT3hKmXF4dpqxmPO9SoNb2FsYXj/xEo0gHN+D5A==",
       "license": "MIT",
       "dependencies": {
         "follow-redirects": "^1.15.11",
@@ -6559,7 +6559,6 @@
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/dockerode/-/dockerode-5.0.0.tgz",
       "integrity": "sha512-C52mvJ+7lcyhWNfrzVfFsbTrBfy/ezE9FGEYLpu17FUeBcCkxERk9nN7uDl/478ynDiQ4U+5DbQC2vENHkVEtQ==",
-      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@balena/dockerignore": "^1.0.2",
@@ -8096,9 +8095,9 @@
       "license": "MIT"
     },
     "node_modules/follow-redirects": {
-      "version": "1.15.11",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.11.tgz",
-      "integrity": "sha512-deG2P0JfjrTxl50XGCDyfI97ZGVCxIpfKYmfyrQ54n5FO/0gfIES8C/Psl6kWVDolizcaaxZJnTS0QSMxvnsBQ==",
+      "version": "1.16.0",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.16.0.tgz",
+      "integrity": "sha512-y5rN/uOsadFT/JfYwhxRS5R7Qce+g3zG97+JrtFZlC9klX/W5hD7iiLzScI4nZqUS7DNUdhPgw4xI8W2LuXlUw==",
       "funding": [
         {
           "type": "individual",
@@ -11186,9 +11185,9 @@
       "license": "MIT"
     },
     "node_modules/jsonfile": {
-      "version": "6.2.0",
-      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.2.0.tgz",
-      "integrity": "sha512-FGuPw30AdOIUTRMC2OMRtQV+jkVj2cfPqSeWXv1NEAJ1qZ5zb1X6z1mFhbfOB/iy3ssJCD+3KuZ8r8C3uVFlAg==",
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.2.1.tgz",
+      "integrity": "sha512-zwOTdL3rFQ/lRdBnntKVOX6k5cKJwEc1HdilT71BWEu7J41gXIB2MRp+vxduPSwZJPWBxEzv4yH1wYLJGUHX4Q==",
       "license": "MIT",
       "dependencies": {
         "universalify": "^2.0.0"
@@ -11254,20 +11253,20 @@
     "node_modules/lando": {
       "name": "@lando/cli",
       "version": "3.6.5",
-      "resolved": "git+ssh://git@github.com/automattic/lando-cli.git#c7dd51e8fb341e59e0e51a1aac453aa81dc2faf6",
-      "integrity": "sha512-nowflXlhDTXXKPwCi2iH0pb7/HGJUmkthG6lqszymLzwR+XIok72F5e8bbaZHKYCftDLoar9BWR3H0JYdDwxLQ==",
+      "resolved": "git+ssh://git@github.com/automattic/lando-cli.git#78d382fcf40357c4a4cebe4a3cfaef032eab743a",
+      "integrity": "sha512-2FOCUCo9kKatRQsvYDUKtR9j8Ev2t+zSAOC2o64arGd8qdIqDtCcMOJaSTmWrWVUgAJNjs3ezXrUjPSd2Keu2w==",
       "license": "GPL-3.0",
       "dependencies": {
-        "axios": "^1.13.6",
+        "axios": "^1.15.2",
         "bluebird": "^3.4.1",
         "chalk": "^4.1.2",
         "cli-table3": "^0.6.5",
         "copy-dir": "^1.3.0",
-        "dockerode": "^4.0.9",
+        "dockerode": "^5.0.0",
         "glob": "^13.0.0",
         "js-yaml": "^4.1.1",
-        "jsonfile": "^6.1.0",
-        "lodash": "^4.17.23",
+        "jsonfile": "^6.2.1",
+        "lodash": "^4.18.1",
         "node-cache": "^5.1.2",
         "object-hash": "^3.0.0",
         "semver": "^7.7.3",
@@ -11281,7 +11280,7 @@
         "lando": "bin/lando.js"
       },
       "engines": {
-        "node": ">=14.0.0"
+        "node": ">=18.0.0"
       },
       "peerDependencies": {
         "debug": "^4.4.3"
@@ -11346,24 +11345,6 @@
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
       "license": "MIT"
-    },
-    "node_modules/lando/node_modules/dockerode": {
-      "version": "4.0.12",
-      "resolved": "https://registry.npmjs.org/dockerode/-/dockerode-4.0.12.tgz",
-      "integrity": "sha512-/bCZd6KlGcjZO8Buqmi/vXuqEGVEZ0PNjx/biBNqJD3MhK9DmdiAuKxqfNhflgDESDIiBz3qF+0e55+CpnrUcw==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@balena/dockerignore": "^1.0.2",
-        "@grpc/grpc-js": "^1.11.1",
-        "@grpc/proto-loader": "^0.7.13",
-        "docker-modem": "^5.0.7",
-        "protobufjs": "^7.3.2",
-        "tar-fs": "^2.1.4",
-        "uuid": "^10.0.0"
-      },
-      "engines": {
-        "node": ">= 8.0"
-      }
     },
     "node_modules/lando/node_modules/glob": {
       "version": "13.0.6",
@@ -12665,22 +12646,22 @@
       "license": "ISC"
     },
     "node_modules/protobufjs": {
-      "version": "7.5.4",
-      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.5.4.tgz",
-      "integrity": "sha512-CvexbZtbov6jW2eXAvLukXjXUW1TzFaivC46BpWc/3BpcCysb5Vffu+B3XHMm8lVEuy2Mm4XGex8hBSg1yapPg==",
+      "version": "7.5.6",
+      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.5.6.tgz",
+      "integrity": "sha512-M71sTMB146U3u0di3yup8iM+zv8yPRNQVr1KK4tyBitl3qFvEGucq/rGDRShD2rsJhtN02RJaJ7j5X5hmy8SJg==",
       "hasInstallScript": true,
       "license": "BSD-3-Clause",
       "dependencies": {
         "@protobufjs/aspromise": "^1.1.2",
         "@protobufjs/base64": "^1.1.2",
-        "@protobufjs/codegen": "^2.0.4",
+        "@protobufjs/codegen": "^2.0.5",
         "@protobufjs/eventemitter": "^1.1.0",
         "@protobufjs/fetch": "^1.1.0",
         "@protobufjs/float": "^1.0.2",
-        "@protobufjs/inquire": "^1.1.0",
+        "@protobufjs/inquire": "^1.1.1",
         "@protobufjs/path": "^1.1.2",
         "@protobufjs/pool": "^1.1.0",
-        "@protobufjs/utf8": "^1.1.0",
+        "@protobufjs/utf8": "^1.1.1",
         "@types/node": ">=13.7.0",
         "long": "^5.0.0"
       },
@@ -14649,19 +14630,6 @@
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
       "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
       "license": "MIT"
-    },
-    "node_modules/uuid": {
-      "version": "10.0.0",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-10.0.0.tgz",
-      "integrity": "sha512-8XkAphELsDnEGrDxUOHB3RGvXz6TeuYSGEZBOjtTtPm2lwhGBjLgOzLHB63IUWfBpNucQjND6d3AOudO+H3RWQ==",
-      "funding": [
-        "https://github.com/sponsors/broofa",
-        "https://github.com/sponsors/ctavan"
-      ],
-      "license": "MIT",
-      "bin": {
-        "uuid": "dist/bin/uuid"
-      }
     },
     "node_modules/v8-to-istanbul": {
       "version": "9.3.0",

--- a/package.json
+++ b/package.json
@@ -157,7 +157,7 @@
     "https-proxy-agent": "^9.0.0",
     "js-yaml": "^4.1.0",
     "jwt-decode": "4.0.0",
-    "lando": "github:automattic/lando-cli#c7dd51e8fb341e59e0e51a1aac453aa81dc2faf6",
+    "lando": "github:automattic/lando-cli#78d382fcf40357c4a4cebe4a3cfaef032eab743a",
     "node-fetch": "^3.3.2",
     "node-stream-zip": "1.15.0",
     "open": "^11.0.0",


### PR DESCRIPTION
This pull request updates several dependencies in the project, primarily focusing on the `lando` package and its related dependencies. The main goal is to upgrade `lando` to a newer commit, which in turn brings in newer versions of several key libraries, updates the minimum required Node.js version, removes some transitive dependencies, and fixes many security issues (including a critical severity vulnerability in `protobufjs`).

Dependency updates:

* Upgraded `lando` from commit `c7dd51e8` to `78d382fc`, which updates its dependencies, including bumping `axios` to `^1.15.2`, `dockerode` to `^5.0.0`, `jsonfile` to `^6.2.1`, and `lodash` to `^4.18.1`. The minimum required Node.js version for `lando` is also increased from `>=14.0.0` to `>=18.0.0`. [[1]](diffhunk://#diff-44a7c69871c5958e657226d5552c9451606a778233fb824f68530d0cfd3f8994L32-R32) [[2]](diffhunk://#diff-44a7c69871c5958e657226d5552c9451606a778233fb824f68530d0cfd3f8994L11257-R11269) [[3]](diffhunk://#diff-44a7c69871c5958e657226d5552c9451606a778233fb824f68530d0cfd3f8994L11284-R11283) [[4]](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L160-R160)

* Updated direct and transitive dependencies:  
    - `axios` from `1.14.0` to `1.15.2`  
    - `dockerode` from `4.0.12` to `5.0.0` [[1]](diffhunk://#diff-44a7c69871c5958e657226d5552c9451606a778233fb824f68530d0cfd3f8994L6562) [[2]](diffhunk://#diff-44a7c69871c5958e657226d5552c9451606a778233fb824f68530d0cfd3f8994L11350-L11367)  
    - `follow-redirects` from `1.15.11` to `1.16.0`  
    - `jsonfile` from `6.2.0` to `6.2.1`  
    - `protobufjs` from `7.5.4` to `7.5.6`, along with its dependencies: `@protobufjs/codegen`, `@protobufjs/inquire`, and `@protobufjs/utf8` [[1]](diffhunk://#diff-44a7c69871c5958e657226d5552c9451606a778233fb824f68530d0cfd3f8994L12668-R12664) [[2]](diffhunk://#diff-44a7c69871c5958e657226d5552c9451606a778233fb824f68530d0cfd3f8994L3812-R3814) [[3]](diffhunk://#diff-44a7c69871c5958e657226d5552c9451606a778233fb824f68530d0cfd3f8994L3840-R3842) [[4]](diffhunk://#diff-44a7c69871c5958e657226d5552c9451606a778233fb824f68530d0cfd3f8994L3858-R3860)

Maintenance and cleanup:

* Removed the transitive dependency on `uuid` (was previously included via `lando`'s old `dockerode` dependency).

These changes ensure the project uses the latest compatible versions of its dependencies, improves security and compatibility, and aligns with newer Node.js requirements.
