### PR TITLE
fix: service detection in `vip dev-env logs`

### DIFF
--- a/__tests__/devenv-e2e/011-logs.spec.js
+++ b/__tests__/devenv-e2e/011-logs.spec.js
@@ -93,7 +93,7 @@ describe( 'vip dev-env logs', () => {
 			);
 			expect( result.rc ).toBeGreaterThan( 0 );
 			expect( result.stderr ).toContain(
-				"Error:  Service 'foobar' not found. Please choose from one:"
+				"Error:  Service 'foobar' not found. Please choose from:"
 			);
 		} );
 

--- a/src/lib/dev-environment/dev-environment-core.ts
+++ b/src/lib/dev-environment/dev-environment-core.ts
@@ -29,6 +29,7 @@ import {
 	LandoExecOptions,
 	getProxyContainer,
 	removeProxyCache,
+	getLandoApplication,
 } from './dev-environment-lando';
 import { AppEnvironment } from '../../graphqlTypes';
 import app from '../api/app';
@@ -344,15 +345,14 @@ export async function showLogs(
 
 	const instancePath = getEnvironmentPath( slug );
 
-	debug( 'Instance path for', slug, 'is:', instancePath );
+	debug( 'Instance path for %s is %s', slug, instancePath );
 
 	if ( options.service ) {
-		const appInfo = await landoInfo( lando, instancePath );
-		if ( ! appInfo.services.includes( options.service ) ) {
+		const application = await getLandoApplication( lando, instancePath );
+		const services = application.info.map( service => service.service );
+		if ( ! services.includes( options.service ) ) {
 			throw new UserError(
-				`Service '${
-					options.service
-				}' not found. Please choose from one: ${ appInfo.services.toString() }`
+				`Service '${ options.service }' not found. Please choose from: ${ services.join( ', ' ) }`
 			);
 		}
 	}

--- a/src/lib/dev-environment/dev-environment-lando.ts
+++ b/src/lib/dev-environment/dev-environment-lando.ts
@@ -341,7 +341,7 @@ async function landoRecovery( lando: Lando, instancePath: string, error: unknown
 	}
 }
 
-async function getLandoApplication( lando: Lando, instancePath: string ): Promise< App > {
+export async function getLandoApplication( lando: Lando, instancePath: string ): Promise< App > {
 	const started = new Date();
 	try {
 		if ( appMap.has( instancePath ) ) {

--- a/types/lando/plugins/lando-core/lib/utils.d.ts
+++ b/types/lando/plugins/lando-core/lib/utils.d.ts
@@ -1,10 +1,9 @@
 import App from 'lando/lib/app';
 
-export interface AppInfo {
+export interface AppInfo extends Record< string, unknown > {
 	name: string;
 	location: string;
-	services: string[];
-	[ key: string ]: unknown;
+	services: string;
 }
 
 export function getHostPath( mount: any ): any;


### PR DESCRIPTION
## Description

This PR fixes service detection for the `vip dev-env logs` command.

The previous implementation:
- did that incorrectly because it assumed the wrong data type;
- unnecessarily run the full environment health check to get the list of available services.

This implementation fixes that and is more stable for faulty dev environments.

## Changelog Description

### Fixed

- `vip dev-env logs` implementation. It is now faster and more stable.

## Pull request checklist

- [ ] Update [SETUP.md](https://github.com/Automattic/vip-cli/blob/trunk/docs/SETUP.md#list-of-environmental-variables) with any new environmental variables.
- [ ] Update [the documentation](https://github.com/Automattic/vip-cli/blob/trunk/docs).
- [x] [Manually test](https://github.com/Automattic/vip-cli/blob/trunk/docs/TESTING.md#manual-testing) the relevant changes.
- [x] Follow the [pull request checklist](https://github.com/Automattic/vip-cli/blob/trunk/docs/RELEASING.md#new-pull-requests)
- [ ] Add/update [automated tests](https://github.com/Automattic/vip-cli/blob/trunk/docs/TESTING.md#automated-testing) as needed.

## New release checklist

- [ ] [Automated tests](https://github.com/Automattic/vip-cli/blob/trunk/docs/TESTING.md#automated-testing) pass.
- [ ] The [Preparing for release checklist](https://github.com/Automattic/vip-cli/blob/trunk/docs/RELEASING.md#preparing-for-release) is completed.

## Steps to Test

`vip dev-env logs -S inx` before and after this PR.
