### PR TITLE
fix(cli): preserve parent args for nested subcommands

### DIFF
--- a/__tests__/lib/cli/command.js
+++ b/__tests__/lib/cli/command.js
@@ -1,6 +1,33 @@
-import { containsAppEnvArgument } from '../../../src/lib/cli/command';
+import { describe, expect, it, jest, beforeEach, afterEach } from '@jest/globals';
+import { spawnSync } from 'node:child_process';
+import path from 'node:path';
+
+import command, { containsAppEnvArgument } from '../../../src/lib/cli/command';
+
+jest.mock( 'node:child_process', () => ( {
+	spawnSync: jest.fn( () => ( { status: 0 } ) ),
+} ) );
+
+jest.mock( '../../../src/lib/tracker', () => ( {
+	trackEvent: jest.fn(),
+} ) );
 
 describe( 'utils/cli/command', () => {
+	beforeEach( () => {
+		jest.clearAllMocks();
+		jest.spyOn( process, 'exit' ).mockImplementation( code => {
+			if ( code ) {
+				throw new Error( `process.exit: ${ code }` );
+			}
+		} );
+		jest.spyOn( console, 'error' ).mockImplementation( () => {} );
+		jest.spyOn( console, 'log' ).mockImplementation( () => {} );
+	} );
+
+	afterEach( () => {
+		jest.restoreAllMocks();
+	} );
+
 	describe( 'containsAppEnvArgument', () => {
 		it.each( [
 			[ [ 'test', 'one' ], false ],
@@ -10,6 +37,47 @@ describe( 'utils/cli/command', () => {
 		] )( 'should identify app/env arguments - %p', ( argv, expected ) => {
 			const result = containsAppEnvArgument( argv );
 			expect( result ).toBe( expected );
+		} );
+	} );
+
+	describe( 'subcommand dispatch', () => {
+		it( 'forwards parent-level options and command payload to nested subcommands', async () => {
+			const parentScript = path.join( process.cwd(), 'src/bin/vip-dev-env.js' );
+			const childScript = path.join( process.cwd(), 'src/bin/vip-dev-env-shell.js' );
+			const commandPayload = [
+				'curl',
+				'-X',
+				'PUT',
+				'http://elasticsearch:9200/_snapshot/gtf',
+				'-H',
+				'Content-Type: application/json',
+				'-d',
+				'{ "type": "fs", "settings":{ "location": "/usr/share/elasticsearch/data/gtf",  "compress": true } }',
+			];
+
+			const cmd = command( { requiredArgs: 0 } ).command(
+				'shell',
+				'Create a shell and run commands against a local environment.'
+			);
+
+			await cmd.argv( [
+				process.execPath,
+				parentScript,
+				'--slug=what-mu',
+				'shell',
+				'--',
+				...commandPayload,
+			] );
+
+			expect( spawnSync ).toHaveBeenCalledWith(
+				process.execPath,
+				[ childScript, '--slug=what-mu', '--', ...commandPayload ],
+				{
+					stdio: 'inherit',
+					env: process.env,
+				}
+			);
+			expect( process.exit ).toHaveBeenCalledWith( 0 );
 		} );
 	} );
 } );

--- a/src/lib/cli/command.js
+++ b/src/lib/cli/command.js
@@ -125,6 +125,10 @@ function createOptionDefinition( name, description, defaultValue, parseFn, usedS
 	};
 }
 
+function isOptionToken( arg ) {
+	return arg !== '-' && arg.startsWith( '-' );
+}
+
 class CommanderArgsCompat {
 	constructor( opts ) {
 		this.details = {
@@ -234,19 +238,46 @@ class CommanderArgsCompat {
 		return this.program.opts();
 	}
 
+	findSubcommand( argv ) {
+		const dashDashIndex = argv.indexOf( '--', 2 );
+		const searchEnd = dashDashIndex === -1 ? argv.length : dashDashIndex;
+
+		for ( let index = 2; index < searchEnd; index++ ) {
+			const arg = argv[ index ];
+			if ( this.isDefined( arg, 'commands' ) ) {
+				return { index, name: arg };
+			}
+
+			if ( ! isOptionToken( arg ) ) {
+				return null;
+			}
+
+			const nextArg = argv[ index + 1 ];
+			const optionHasInlineValue = arg.includes( '=' );
+			const nextArgCouldBeOptionValue =
+				nextArg && ! isOptionToken( nextArg ) && ! this.isDefined( nextArg, 'commands' );
+
+			if ( ! optionHasInlineValue && nextArgCouldBeOptionValue ) {
+				index++;
+			}
+		}
+
+		return null;
+	}
+
 	async executeSubcommand( argv, parsedAlias, subcommand ) {
 		const currentScript = argv[ 1 ];
+		const subcommandName = subcommand.name;
 		const extension = path.extname( currentScript );
 		const baseScriptPath = extension ? currentScript.slice( 0, -extension.length ) : currentScript;
 		const childScriptPath = extension
-			? `${ baseScriptPath }-${ subcommand }${ extension }`
-			: `${ baseScriptPath }-${ subcommand }`;
+			? `${ baseScriptPath }-${ subcommandName }${ extension }`
+			: `${ baseScriptPath }-${ subcommandName }`;
 		const aliasFromRawArgv = argv.slice( 2 ).find( arg => isAlias( arg ) );
-		const subcommandIndex = parsedAlias.argv.findIndex( ( arg, index ) => {
-			return index > 1 && arg === subcommand;
-		} );
-
-		let childArgs = subcommandIndex > -1 ? parsedAlias.argv.slice( subcommandIndex + 1 ) : [];
+		let childArgs = [
+			...parsedAlias.argv.slice( 2, subcommand.index ),
+			...parsedAlias.argv.slice( subcommand.index + 1 ),
+		];
 
 		if ( aliasFromRawArgv ) {
 			childArgs = [ aliasFromRawArgv, ...childArgs ];
@@ -259,7 +290,7 @@ class CommanderArgsCompat {
 				env: process.env,
 			} );
 		} else {
-			const fallbackCommand = `${ path.basename( baseScriptPath ) }-${ subcommand }`;
+			const fallbackCommand = `${ path.basename( baseScriptPath ) }-${ subcommandName }`;
 
 			if ( process.env.VIP_CLI_SEA_MODE === '1' && hasInternalBin( fallbackCommand ) ) {
 				process.argv = [ process.argv[ 0 ], process.argv[ 1 ], ...childArgs ];
@@ -304,8 +335,9 @@ CommanderArgsCompat.prototype.argv = async function ( argv, cb ) {
 	const options = this.parse( parsedAlias.argv );
 
 	// If there's a sub-command, run that instead
-	if ( this.isDefined( this.sub[ 0 ], 'commands' ) ) {
-		await this.executeSubcommand( argv, parsedAlias, this.sub[ 0 ] );
+	const dispatchSubcommand = this.findSubcommand( parsedAlias.argv );
+	if ( dispatchSubcommand ) {
+		await this.executeSubcommand( argv, parsedAlias, dispatchSubcommand );
 		return {};
 	}
 


### PR DESCRIPTION
[PLTFRM-2278]

Commander left unknown parent options in the positional list, so vip dev-env --slug=$slug shell -- ... was rejected before dispatching to vip-dev-env-shell. Find declared subcommands after leading option tokens and forward those parent-level args to the child command with the post--- payload intact.

Add a regression test for the dev-env shell curl payload shape.

## Description

## Changelog Description

- Fixed regression when passing custom commands to  `vip dev-env exec`

## Pull request checklist

- [ ] Update [SETUP.md](https://github.com/Automattic/vip-cli/blob/trunk/docs/SETUP.md#list-of-environmental-variables) with any new environmental variables.
- [ ] Update [the documentation](https://github.com/Automattic/vip-cli/blob/trunk/docs).
- [ ] [Manually test](https://github.com/Automattic/vip-cli/blob/trunk/docs/TESTING.md#manual-testing) the relevant changes.
- [ ] Follow the [pull request checklist](https://github.com/Automattic/vip-cli/blob/trunk/docs/RELEASING.md#new-pull-requests)
- [ ] Add/update [automated tests](https://github.com/Automattic/vip-cli/blob/trunk/docs/TESTING.md#automated-testing) as needed.

## New release checklist

- [ ] [Automated tests](https://github.com/Automattic/vip-cli/blob/trunk/docs/TESTING.md#automated-testing) pass.
- [ ] The [Preparing for release checklist](https://github.com/Automattic/vip-cli/blob/trunk/docs/RELEASING.md#preparing-for-release) is completed.

## Steps to Test

Outline the steps to test and verify the PR here.

Example:

1. Check out PR.
1. Run `npm run build`
1. Run `./dist/bin/vip-cookies.js nom`
1. Verify cookies are delicious.
