### PR TITLE
fix(cli): restore parser compatibility

### DIFF
--- a/__tests__/devenv-e2e/005-update.spec.js
+++ b/__tests__/devenv-e2e/005-update.spec.js
@@ -127,45 +127,6 @@ describe( 'vip dev-env update', () => {
 		} );
 	} );
 
-	it( 'should not update multisiteness', async () => {
-		const slug = getProjectSlug();
-		const expectedMultiSite = true;
-
-		expect( await checkEnvExists( slug ) ).toBe( false );
-
-		// prettier-ignore
-		let result = await cliTest.spawn( [
-			process.argv[ 0 ], vipDevEnvCreate,
-			'--slug', slug,
-			'--multisite', `${ expectedMultiSite }`,
-		], { env }, true );
-
-		expect( result.rc ).toBe( 0 );
-		expect( await checkEnvExists( slug ) ).toBe( true );
-
-		const dataBefore = readEnvironmentData( slug );
-		expect( dataBefore ).toMatchObject( {
-			siteSlug: slug,
-			multisite: expectedMultiSite,
-		} );
-
-		// prettier-ignore
-		result = await cliTest.spawn( [
-			process.argv[ 0 ], vipDevEnvUpdate,
-			'--slug', slug,
-			'--multisite', `${ ! expectedMultiSite }`,
-		], { env }, true );
-
-		expect( result.rc ).toBe( 0 );
-		expect( await checkEnvExists( slug ) ).toBe( true );
-
-		const dataAfter = readEnvironmentData( slug );
-		expect( dataAfter ).toMatchObject( {
-			siteSlug: slug,
-			multisite: expectedMultiSite,
-		} );
-	} );
-
 	it( 'does not replace mariadb with mysql', async () => {
 		const slug = getProjectSlug();
 		const basePath = path.join( tmpPath, 'vip', 'dev-environment', slug );

--- a/__tests__/lib/cli/command.js
+++ b/__tests__/lib/cli/command.js
@@ -41,6 +41,87 @@ describe( 'utils/cli/command', () => {
 	} );
 
 	describe( 'subcommand dispatch', () => {
+		it( 'dispatches when child options appear before -- and subcommand follows separator', async () => {
+			const parentScript = path.join( process.cwd(), 'src/bin/vip.js' );
+			const childScript = path.join( process.cwd(), 'src/bin/vip-wp.js' );
+
+			const cmd = command( { requiredArgs: 0 } ).command( 'wp', 'Run WP-CLI commands.' );
+
+			await cmd.argv( [
+				process.execPath,
+				parentScript,
+				'@jdk-test.production',
+				'--yes',
+				'--',
+				'wp',
+				'option',
+				'get',
+				'home',
+			] );
+
+			expect( spawnSync ).toHaveBeenCalledWith(
+				process.execPath,
+				[ childScript, '@jdk-test.production', '--yes', '--', 'option', 'get', 'home' ],
+				{
+					stdio: 'inherit',
+					env: process.env,
+				}
+			);
+			expect( process.exit ).toHaveBeenCalledWith( 0 );
+		} );
+
+		it( 'requires -- separator for wp command arguments', async () => {
+			const parentScript = path.join( process.cwd(), 'src/bin/vip.js' );
+			const cmd = command( { requiredArgs: 0 } ).command( 'wp', 'Run WP-CLI commands.' );
+
+			await expect(
+				cmd.argv( [
+					process.execPath,
+					parentScript,
+					'@docs-multisite.develop',
+					'wp',
+					'post',
+					'list',
+					'--post_type=post',
+				] )
+			).rejects.toThrow( 'process.exit: 1' );
+
+			expect( console.error ).toHaveBeenCalledWith(
+				expect.stringContaining(
+					'A double dash ("--") must separate the arguments of "vip" from those of "wp".'
+				)
+			);
+			expect( spawnSync ).not.toHaveBeenCalled();
+		} );
+
+		it( 'dispatches when argv starts with alias then -- then subcommand', async () => {
+			const parentScript = path.join( process.cwd(), 'src/bin/vip.js' );
+			const childScript = path.join( process.cwd(), 'src/bin/vip-wp.js' );
+
+			const cmd = command( { requiredArgs: 0 } ).command( 'wp', 'Run WP-CLI commands.' );
+
+			await cmd.argv( [
+				process.execPath,
+				parentScript,
+				'@docs-multisite.develop',
+				'--',
+				'wp',
+				'post',
+				'list',
+				'--posts_per_page=10',
+			] );
+
+			expect( spawnSync ).toHaveBeenCalledWith(
+				process.execPath,
+				[ childScript, '@docs-multisite.develop', '--', 'post', 'list', '--posts_per_page=10' ],
+				{
+					stdio: 'inherit',
+					env: process.env,
+				}
+			);
+			expect( process.exit ).toHaveBeenCalledWith( 0 );
+		} );
+
 		it( 'forwards parent-level options and command payload to nested subcommands', async () => {
 			const parentScript = path.join( process.cwd(), 'src/bin/vip-dev-env.js' );
 			const childScript = path.join( process.cwd(), 'src/bin/vip-dev-env-shell.js' );
@@ -78,6 +159,81 @@ describe( 'utils/cli/command', () => {
 				}
 			);
 			expect( process.exit ).toHaveBeenCalledWith( 0 );
+		} );
+	} );
+
+	describe( 'option parsing', () => {
+		it( 'does not duplicate defaults when an explicit value matches the default', async () => {
+			const cmd = command( { requiredArgs: 0 } ).option( 'type', 'Log type', 'app' );
+
+			const options = await cmd.argv( [ process.execPath, '/path/to/vip-logs.js', '--type=app' ] );
+
+			expect( options.type ).toBe( 'app' );
+			expect( Array.isArray( options.type ) ).toBe( false );
+		} );
+
+		it( 'throws on unknown options', async () => {
+			const cmd = command( { requiredArgs: 0 } );
+
+			await expect(
+				cmd.argv( [ process.execPath, '/path/to/vip-dev-env-logs.js', '--xxx' ] )
+			).rejects.toThrow( 'process.exit: 1' );
+
+			expect( console.error ).toHaveBeenCalledWith(
+				expect.stringContaining( 'The option "xxx" is unknown.' )
+			);
+		} );
+
+		it( 'throws on unknown short options', async () => {
+			const cmd = command( { requiredArgs: 0 } );
+
+			await expect(
+				cmd.argv( [ process.execPath, '/path/to/vip-dev-env-logs.js', '-x' ] )
+			).rejects.toThrow( 'process.exit: 1' );
+
+			expect( console.error ).toHaveBeenCalledWith(
+				expect.stringContaining( 'The option "x" is unknown.' )
+			);
+		} );
+
+		it( 'allows unknown options for wildcard commands', async () => {
+			const cmd = command( { requiredArgs: 0, wildcardCommand: true } );
+
+			const options = await cmd.argv( [
+				process.execPath,
+				'/path/to/vip-wp.js',
+				'post',
+				'list',
+				'--post_type=post',
+			] );
+
+			expect( options ).toEqual(
+				expect.objectContaining( {
+					help: false,
+					version: false,
+				} )
+			);
+
+			expect( options ).not.toHaveProperty( 'postType' );
+			expect( options ).not.toHaveProperty( 'post_type' );
+
+			expect( console.error ).not.toHaveBeenCalled();
+		} );
+
+		it( 'parses short options using equals syntax without prefixing values', async () => {
+			const cmd = command( { requiredArgs: 0 } )
+				.option( [ 't', 'type' ], 'Log type', 'app' )
+				.option( [ 'l', 'limit' ], 'Limit', undefined, parseInt );
+
+			const options = await cmd.argv( [
+				process.execPath,
+				'/path/to/vip-logs.js',
+				'-t=app',
+				'-l=5',
+			] );
+
+			expect( options.type ).toBe( 'app' );
+			expect( options.limit ).toBe( 5 );
 		} );
 	} );
 } );

--- a/src/bin/vip-dev-env-sync-sql.js
+++ b/src/bin/vip-dev-env-sync-sql.js
@@ -83,7 +83,9 @@ command( {
 	)
 	.option(
 		'site-id',
-		'The ID of a network site to include in the partial database sync. Accepts an integer value (can be passed more than once with different values), or multiple integer values in a comma-separated list.'
+		'The ID of a network site to include in the partial database sync. Accepts an integer value (can be passed more than once with different values), or multiple integer values in a comma-separated list.',
+		undefined,
+		parseInt
 	)
 	.option(
 		'wpcli-command',

--- a/src/bin/vip-dev-env-sync-sql.js
+++ b/src/bin/vip-dev-env-sync-sql.js
@@ -85,7 +85,7 @@ command( {
 		'site-id',
 		'The ID of a network site to include in the partial database sync. Accepts an integer value (can be passed more than once with different values), or multiple integer values in a comma-separated list.',
 		undefined,
-		parseInt
+		Number.parseInt
 	)
 	.option(
 		'wpcli-command',

--- a/src/bin/vip-export-sql.js
+++ b/src/bin/vip-export-sql.js
@@ -85,7 +85,9 @@ command( {
 	)
 	.option(
 		'site-id',
-		'The ID of a network site to include in the partial database export. Accepts an integer value and can be passed more than once with a different value, or add multiple values in a comma-separated list.'
+		'The ID of a network site to include in the partial database export. Accepts an integer value and can be passed more than once with a different value, or add multiple values in a comma-separated list.',
+		undefined,
+		parseInt
 	)
 	.option(
 		'wpcli-command',

--- a/src/bin/vip-export-sql.js
+++ b/src/bin/vip-export-sql.js
@@ -87,7 +87,7 @@ command( {
 		'site-id',
 		'The ID of a network site to include in the partial database export. Accepts an integer value and can be passed more than once with a different value, or add multiple values in a comma-separated list.',
 		undefined,
-		parseInt
+		Number.parseInt
 	)
 	.option(
 		'wpcli-command',

--- a/src/bin/vip-logs.js
+++ b/src/bin/vip-logs.js
@@ -246,7 +246,9 @@ command( {
 	// The default limit is set manually in the validateInputs function to address validation issues, avoiding incorrect replacement of the default value.
 	.option(
 		'limit',
-		`The maximum number of entries to return. Accepts an integer value between 1 and 5000 (defaults to ${ LIMIT_DEFAULT }).`
+		`The maximum number of entries to return. Accepts an integer value between 1 and 5000 (defaults to ${ LIMIT_DEFAULT }).`,
+		undefined,
+		parseInt
 	)
 	.option( 'follow', 'Output new entries as they are generated.' )
 	.option(

--- a/src/bin/vip-logs.js
+++ b/src/bin/vip-logs.js
@@ -248,7 +248,7 @@ command( {
 		'limit',
 		`The maximum number of entries to return. Accepts an integer value between 1 and 5000 (defaults to ${ LIMIT_DEFAULT }).`,
 		undefined,
-		parseInt
+		Number.parseInt
 	)
 	.option( 'follow', 'Output new entries as they are generated.' )
 	.option(

--- a/src/bin/vip-slowlogs.ts
+++ b/src/bin/vip-slowlogs.ts
@@ -197,7 +197,8 @@ void command( {
 	.option(
 		'limit',
 		'Set the maximum number of log entries. Accepts an integer value between 1 and 500.',
-		500
+		500,
+		parseInt
 	)
 	.examples( [
 		{

--- a/src/bin/vip-slowlogs.ts
+++ b/src/bin/vip-slowlogs.ts
@@ -186,6 +186,8 @@ export const appQuery = `
 	}
 `;
 
+const parseLimit = ( value: unknown ): number => Number.parseInt( String( value ), 10 );
+
 void command( {
 	appContext: true,
 	appQuery,
@@ -198,7 +200,7 @@ void command( {
 		'limit',
 		'Set the maximum number of log entries. Accepts an integer value between 1 and 500.',
 		500,
-		parseInt
+		parseLimit
 	)
 	.examples( [
 		{

--- a/src/lib/cli/command.js
+++ b/src/lib/cli/command.js
@@ -122,6 +122,7 @@ function createOptionDefinition( name, description, defaultValue, parseFn, usedS
 		description,
 		defaultValue,
 		parser,
+		normalizedShortName,
 	};
 }
 
@@ -137,12 +138,17 @@ class CommanderArgsCompat {
 		this.sub = [];
 		this.examplesList = [];
 		this.usedShortNames = new Set();
+		this.shortOptionsExpectingValue = new Set();
+		this.longOptionsExpectingValue = new Set();
+		this.knownShortOptions = new Set();
+		this.knownLongOptions = new Set();
 		this._opts = opts;
 		this.program = new Command();
 		this.program.allowUnknownOption( true );
 		this.program.allowExcessArguments( true );
 		this.program.helpOption( false );
 		normalizeUsage( this.program, this._opts.usage );
+		this.optionDefaults = new Map();
 	}
 
 	option( name, description, defaultValue, parseFn ) {
@@ -153,10 +159,30 @@ class CommanderArgsCompat {
 			parseFn,
 			this.usedShortNames
 		);
-		const { flags, parser } = definition;
+		const { flags, parser, normalizedShortName } = definition;
+		const normalizedLongName = String( Array.isArray( name ) ? name[ 1 ] : name )
+			.trim()
+			.replace( /^--?/, '' );
+		const isValueOption = typeof defaultValue !== 'boolean';
+		this.knownLongOptions.add( normalizedLongName );
 
+		if ( normalizedShortName ) {
+			this.knownShortOptions.add( normalizedShortName );
+		}
+
+		if ( isValueOption && normalizedShortName ) {
+			this.shortOptionsExpectingValue.add( normalizedShortName );
+		}
+
+		if ( isValueOption ) {
+			this.longOptionsExpectingValue.add( normalizedLongName );
+		}
+
+		// When there's a parser, track the default separately and don't pass it to Commander.
+		// This prevents the parser from incorrectly accumulating the default value with the first explicit value.
 		if ( parser && defaultValue !== undefined ) {
-			this.program.option( flags, description, parser, defaultValue );
+			this.optionDefaults.set( normalizedLongName, defaultValue );
+			this.program.option( flags, description, parser );
 		} else if ( parser ) {
 			this.program.option( flags, description, parser );
 		} else if ( defaultValue !== undefined ) {
@@ -233,16 +259,50 @@ class CommanderArgsCompat {
 	}
 
 	parse( argv ) {
-		this.program.parse( argv, { from: 'node' } );
+		this.program.parse( this.normalizeShortOptionEqualsSyntax( argv ), { from: 'node' } );
 		this.sub = this.program.args.slice();
-		return this.program.opts();
+		const opts = this.program.opts();
+
+		// Apply tracked defaults for options with parsers
+		for ( const [ optionName, defaultValue ] of this.optionDefaults ) {
+			if ( opts[ optionName ] === undefined ) {
+				opts[ optionName ] = defaultValue;
+			}
+		}
+
+		return opts;
+	}
+
+	normalizeShortOptionEqualsSyntax( argv ) {
+		const normalizedArgv = argv.slice( 0, 2 );
+
+		for ( const arg of argv.slice( 2 ) ) {
+			const shortOptionEqualsMatch = /^-([A-Za-z0-9])=(.*)$/.exec( arg );
+			if ( ! shortOptionEqualsMatch ) {
+				normalizedArgv.push( arg );
+				continue;
+			}
+
+			const shortOptionName = shortOptionEqualsMatch[ 1 ];
+			const optionValue = shortOptionEqualsMatch[ 2 ];
+
+			if ( ! this.shortOptionsExpectingValue.has( shortOptionName ) ) {
+				normalizedArgv.push( arg );
+				continue;
+			}
+
+			normalizedArgv.push( `-${ shortOptionName }`, optionValue );
+		}
+
+		return normalizedArgv;
 	}
 
 	findSubcommand( argv ) {
-		const dashDashIndex = argv.indexOf( '--', 2 );
+		const searchStart = argv[ 2 ] === '--' ? 3 : 2;
+		const dashDashIndex = argv.indexOf( '--', searchStart );
 		const searchEnd = dashDashIndex === -1 ? argv.length : dashDashIndex;
 
-		for ( let index = 2; index < searchEnd; index++ ) {
+		for ( let index = searchStart; index < searchEnd; index++ ) {
 			const arg = argv[ index ];
 			if ( this.isDefined( arg, 'commands' ) ) {
 				return { index, name: arg };
@@ -262,6 +322,75 @@ class CommanderArgsCompat {
 			}
 		}
 
+		if ( dashDashIndex > -1 && this.isDefined( argv[ dashDashIndex + 1 ], 'commands' ) ) {
+			return { index: dashDashIndex + 1, name: argv[ dashDashIndex + 1 ] };
+		}
+
+		return null;
+	}
+
+	findUnknownOption( argv ) {
+		const dashDashIndex = argv.indexOf( '--', 2 );
+		const searchEnd = dashDashIndex === -1 ? argv.length : dashDashIndex;
+
+		for ( let index = 2; index < searchEnd; index++ ) {
+			const arg = argv[ index ];
+			if ( ! isOptionToken( arg ) ) {
+				continue;
+			}
+
+			if ( arg.startsWith( '--' ) ) {
+				const [ tokenName ] = arg.slice( 2 ).split( '=' );
+				if ( ! this.knownLongOptions.has( tokenName ) ) {
+					return tokenName;
+				}
+
+				const hasInlineValue = arg.includes( '=' );
+				const nextArg = argv[ index + 1 ];
+				if (
+					this.longOptionsExpectingValue.has( tokenName ) &&
+					! hasInlineValue &&
+					nextArg &&
+					! isOptionToken( nextArg )
+				) {
+					index++;
+				}
+
+				continue;
+			}
+
+			const shortEqualsMatch = /^-([A-Za-z0-9])=(.*)$/.exec( arg );
+			if ( shortEqualsMatch ) {
+				const shortName = shortEqualsMatch[ 1 ];
+				if ( ! this.knownShortOptions.has( shortName ) ) {
+					return shortName;
+				}
+
+				continue;
+			}
+
+			const shortMatch = /^-([A-Za-z0-9])$/.exec( arg );
+			if ( shortMatch ) {
+				const shortName = shortMatch[ 1 ];
+				if ( ! this.knownShortOptions.has( shortName ) ) {
+					return shortName;
+				}
+
+				const nextArg = argv[ index + 1 ];
+				if (
+					this.shortOptionsExpectingValue.has( shortName ) &&
+					nextArg &&
+					! isOptionToken( nextArg )
+				) {
+					index++;
+				}
+
+				continue;
+			}
+
+			return arg.replace( /^-+/, '' );
+		}
+
 		return null;
 	}
 
@@ -274,9 +403,21 @@ class CommanderArgsCompat {
 			? `${ baseScriptPath }-${ subcommandName }${ extension }`
 			: `${ baseScriptPath }-${ subcommandName }`;
 		const aliasFromRawArgv = argv.slice( 2 ).find( arg => isAlias( arg ) );
+		const rawArgsBeforeSubcommand = parsedAlias.argv.slice( 2, subcommand.index );
+		const hasSeparatorBeforeSubcommand = rawArgsBeforeSubcommand.includes( '--' );
+		const argsBeforeSubcommand = rawArgsBeforeSubcommand.filter( arg => arg !== '--' );
+		const subcommandArgs = parsedAlias.argv.slice( subcommand.index + 1 );
+		const hasSeparator = argv.includes( '--' );
+		if ( subcommandName === 'wp' && subcommandArgs.length && ! hasSeparator ) {
+			exit.withError(
+				'A double dash ("--") must separate the arguments of "vip" from those of "wp". Run "vip wp --help" for examples.'
+			);
+		}
+
 		let childArgs = [
-			...parsedAlias.argv.slice( 2, subcommand.index ),
-			...parsedAlias.argv.slice( subcommand.index + 1 ),
+			...argsBeforeSubcommand,
+			...( hasSeparatorBeforeSubcommand ? [ '--' ] : [] ),
+			...subcommandArgs,
 		];
 
 		if ( aliasFromRawArgv ) {
@@ -339,6 +480,19 @@ CommanderArgsCompat.prototype.argv = async function ( argv, cb ) {
 	if ( dispatchSubcommand ) {
 		await this.executeSubcommand( argv, parsedAlias, dispatchSubcommand );
 		return {};
+	}
+
+	if ( ! _opts.wildcardCommand ) {
+		const unknownOption = this.findUnknownOption( parsedAlias.argv );
+		if ( unknownOption ) {
+			await trackEvent( 'command_validation_error', {
+				error: `Unknown option: ${ unknownOption }`,
+			} );
+
+			exit.withError(
+				`The option "${ unknownOption }" is unknown. Did you mean the following one?\n-h, --help  Retrieve a description, examples, and available options for a (sub)command.`
+			);
+		}
 	}
 
 	if ( _opts.format && ! options.format ) {


### PR DESCRIPTION
This commit fixes several regressions introduced during the commander migration:

- restore subcommand dispatch when parent-level options appear before `--`
- preserve `--` when forwarding to child commands so child options parse correctly
- enforce legacy `wp` separator behavior for command arguments
- restore unknown-option errors for non-wildcard commands
- keep wildcard commands compatible with downstream passthrough flags
- prevent default-value duplication in parsed options (`app,app`-style regressions)
- normalize short option equals syntax for value options (e.g. `-l=5`)

It also adds focused regression tests for parser behavior and updates numeric CLI options to parse integers where required.
