### PR TITLE
chore(dev-deps): remove `@types/tar`

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -127,7 +127,6 @@
         "@types/semver": "^7.5.5",
         "@types/shelljs": "^0.10.0",
         "@types/ssh2": "^1.15.4",
-        "@types/tar": "^7.0.87",
         "@types/xml2js": "^0.4.14",
         "dockerode": "^5.0.0",
         "jest": "^30.0.0",
@@ -4599,17 +4598,6 @@
       "integrity": "sha512-9aEbYZ3TbYMznPdcdr3SmIrLXwC/AKZXQeCf9Pgao5CKb8CyHuEX5jzWPTkvregvhRJHcpRO6BFoGW9ycaOkYw==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/@types/tar": {
-      "version": "7.0.87",
-      "resolved": "https://registry.npmjs.org/@types/tar/-/tar-7.0.87.tgz",
-      "integrity": "sha512-3IxNBV8LeY5oi2ZFpvAhOtW1+mHswkzM7BuisVrwJgPv67GBO2rkLPQlEKtzfHuLdhDDczhkCZeT+RuizMay4A==",
-      "deprecated": "This is a stub types definition. tar provides its own type definitions, so you do not need this installed.",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "tar": "*"
-      }
     },
     "node_modules/@types/triple-beam": {
       "version": "1.3.5",

--- a/package.json
+++ b/package.json
@@ -130,7 +130,6 @@
     "@types/semver": "^7.5.5",
     "@types/shelljs": "^0.10.0",
     "@types/ssh2": "^1.15.4",
-    "@types/tar": "^7.0.87",
     "@types/xml2js": "^0.4.14",
     "dockerode": "^5.0.0",
     "jest": "^30.0.0",


### PR DESCRIPTION
Remove `@types/tar` because these type definitions are a stub.

> npm warn deprecated @types/tar@7.0.87: This is a stub types definition.
> tar provides its own type definitions, so you do not need this installed.
