### PR TITLE
fix(keychain): add local types for optional keytar module

### DIFF
--- a/types/@postman/node-keytar/index.d.ts
+++ b/types/@postman/node-keytar/index.d.ts
@@ -1,0 +1,10 @@
+declare module '@postman/node-keytar' {
+	interface KeytarModule {
+		getPassword( service: string, account: string ): Promise< string | null >;
+		setPassword( service: string, account: string, password: string ): Promise< void >;
+		deletePassword( service: string, account: string ): Promise< boolean >;
+	}
+
+	const keytar: KeytarModule;
+	export default keytar;
+}


### PR DESCRIPTION
## Description
Add a local TypeScript declaration for `@postman/node-keytar` so type checking does not fail when the optional native dependency is not installed in CI environments.

This keeps runtime behavior unchanged and preserves the existing secure-to-insecure keychain fallback behavior.

## Changelog Description

### Fixed
- Fixed a CI type-check failure (`TS2307`) by adding local typings for the optional `@postman/node-keytar` module used by secure keychain code paths.

## Pull request checklist

- [x] Update [SETUP.md](https://github.com/Automattic/vip-cli/blob/trunk/docs/SETUP.md#list-of-environmental-variables) with any new environmental variables.
- [x] Update [the documentation](https://github.com/Automattic/vip-cli/blob/trunk/docs).
- [x] [Manually test](https://github.com/Automattic/vip-cli/blob/trunk/docs/TESTING.md#manual-testing) the relevant changes.
- [x] Follow the [pull request checklist](https://github.com/Automattic/vip-cli/blob/trunk/docs/RELEASING.md#new-pull-requests)
- [x] Add/update [automated tests](https://github.com/Automattic/vip-cli/blob/trunk/docs/TESTING.md#automated-testing) as needed.

## New release checklist

- [x] [Automated tests](https://github.com/Automattic/vip-cli/blob/trunk/docs/TESTING.md#automated-testing) pass.
- [ ] The [Preparing for release checklist](https://github.com/Automattic/vip-cli/blob/trunk/docs/RELEASING.md#preparing-for-release) is completed.

## Steps to Test

1. Check out this branch.
2. Run `npm ci`.
3. Run `npm run check-types`.
4. Verify type checking succeeds and no `TS2307` error is reported for `@postman/node-keytar`.
