### PR TITLE
fix(dev-env): restore update wizard prompts

### DIFF
--- a/__tests__/bin/vip-dev-env-update.js
+++ b/__tests__/bin/vip-dev-env-update.js
@@ -1,0 +1,138 @@
+jest.mock( '../../src/lib/cli/command', () => {
+	const command = jest.fn( () => commandMock );
+	command.registeredHandler = undefined;
+
+	const commandMock = {
+		option: () => commandMock,
+		examples: () => commandMock,
+		argv: ( _argv, handler ) => {
+			command.registeredHandler = handler;
+			return commandMock;
+		},
+	};
+
+	return command;
+} );
+
+jest.mock( '../../src/lib/dev-environment/dev-environment-cli', () => ( {
+	addDevEnvConfigurationOptions: jest.fn(),
+	getEnvTrackingInfo: jest.fn( () => ( { slug: 'example-site' } ) ),
+	getEnvironmentName: jest.fn( async () => 'example-site' ),
+	handleCLIException: jest.fn(),
+	processSlug: jest.fn( value => value ),
+	promptForArguments: jest.fn( async () => ( { wpTitle: 'Site Title' } ) ),
+	validateDependencies: jest.fn(),
+	ensureValidPathsInOptions: jest.fn(),
+	getDevEnvLogFile: jest.fn( () => '/tmp/dev-env.log' ),
+} ) );
+
+jest.mock( '../../src/lib/dev-environment/dev-environment-configuration-file', () => ( {
+	getConfigurationFileOptions: jest.fn( async () => ( {
+		overrides: 'services:\n  appserver:\n    environment:\n      FOO: bar',
+	} ) ),
+	mergeConfigurationFileOptions: jest.fn( ( cliOptions, configOptions ) => ( {
+		...configOptions,
+		...cliOptions,
+	} ) ),
+} ) );
+
+jest.mock( '../../src/lib/dev-environment/dev-environment-core', () => ( {
+	doesEnvironmentExist: jest.fn( async () => true ),
+	getEnvironmentPath: jest.fn( () => '/tmp/example-site' ),
+	readEnvironmentData: jest.fn( () => ( {
+		wpTitle: 'Current Title',
+		multisite: false,
+		appCode: { tag: 'demo' },
+		muPlugins: { tag: 'demo' },
+		wordpress: { tag: 'trunk' },
+		elasticsearch: false,
+		php: '8.2',
+		mariadb: '10.6',
+		phpmyadmin: false,
+		xdebug: false,
+		mailpit: false,
+		photon: false,
+		mediaRedirectDomain: '',
+		cron: false,
+		adminPassword: '',
+	} ) ),
+	updateEnvironment: jest.fn( async () => {} ),
+} ) );
+
+jest.mock( '../../src/lib/dev-environment/dev-environment-lando', () => ( {
+	bootstrapLando: jest.fn( async () => ( {} ) ),
+} ) );
+
+jest.mock( '../../src/lib/tracker', () => ( {
+	trackEvent: jest.fn( async () => {} ),
+} ) );
+
+import command from '../../src/lib/cli/command';
+import { promptForArguments } from '../../src/lib/dev-environment/dev-environment-cli';
+
+import '../../src/bin/vip-dev-env-update';
+
+function setStdinTTY( value ) {
+	Object.defineProperty( process.stdin, 'isTTY', {
+		configurable: true,
+		value,
+	} );
+}
+
+describe( 'vip dev-env update prompt suppression', () => {
+	beforeEach( () => {
+		jest.clearAllMocks();
+		process.exitCode = 0;
+	} );
+
+	afterEach( () => {
+		setStdinTTY( true );
+	} );
+
+	it( 'keeps wizard interactive for TTY even with metadata/config options present', async () => {
+		setStdinTTY( true );
+
+		await command.registeredHandler( [], {
+			slug: 'example-site',
+			metadata: { source: 'test' },
+		} );
+
+		expect( promptForArguments ).toHaveBeenCalledWith(
+			expect.any( Object ),
+			expect.any( Object ),
+			false,
+			false
+		);
+	} );
+
+	it( 'uses partial options as preselected values while keeping wizard interactive in TTY', async () => {
+		setStdinTTY( true );
+
+		await command.registeredHandler( [], {
+			slug: 'example-site',
+			php: '8.3',
+		} );
+
+		expect( promptForArguments ).toHaveBeenCalledWith(
+			expect.objectContaining( { php: '8.3' } ),
+			expect.any( Object ),
+			false,
+			false
+		);
+	} );
+
+	it( 'suppresses wizard prompts in non-TTY mode', async () => {
+		setStdinTTY( false );
+
+		await command.registeredHandler( [], {
+			slug: 'example-site',
+		} );
+
+		expect( promptForArguments ).toHaveBeenCalledWith(
+			expect.any( Object ),
+			expect.any( Object ),
+			true,
+			false
+		);
+	} );
+} );

--- a/src/bin/vip-dev-env-update.js
+++ b/src/bin/vip-dev-env-update.js
@@ -95,7 +95,6 @@ cmd.argv( process.argv, async ( arg, opt ) => {
 		};
 
 		const configurationFileOptions = await getConfigurationFileOptions();
-		const thereAreOptionsFromConfigFile = Object.keys( configurationFileOptions ).length > 0;
 		const finalPreselectedOptions = mergeConfigurationFileOptions(
 			preselectedOptions,
 			configurationFileOptions
@@ -122,11 +121,7 @@ cmd.argv( process.argv, async ( arg, opt ) => {
 			adminPassword: currentInstanceData.adminPassword,
 		};
 
-		const providedOptions = Object.keys( opt )
-			.filter( option => option.length > 1 ) // Filter out single letter aliases
-			.filter( option => ! [ 'debug', 'help', 'slug' ].includes( option ) ); // Filter out options that are not related to instance configuration
-
-		const suppressPrompts = providedOptions.length > 0 || thereAreOptionsFromConfigFile;
+		const suppressPrompts = ! process.stdin.isTTY;
 		const instanceData = await promptForArguments(
 			finalPreselectedOptions,
 			defaultOptions,


### PR DESCRIPTION
## Description
Fixes a regression where `vip dev-env update` stopped showing the wizard in interactive sessions.

The update flow was globally suppressing prompts based on broad option/config detection. This change makes suppression depend on TTY mode, so interactive sessions keep the wizard while non-interactive sessions remain non-interactive.

Linear: https://linear.app/a8c/issue/PLTFRM-2426/vip-cli-vip-dev-env-update-not-prompting-wizard

## Changelog Description

### Fixed
- Fixed a regression where `vip dev-env update` could skip wizard prompts in interactive sessions.
- Restored expected interactive behavior while preserving non-interactive behavior for non-TTY execution.

## Pull request checklist

- [x] Update [SETUP.md](https://github.com/Automattic/vip-cli/blob/trunk/docs/SETUP.md#list-of-environmental-variables) with any new environmental variables.
- [x] Update [the documentation](https://github.com/Automattic/vip-cli/blob/trunk/docs).
- [x] [Manually test](https://github.com/Automattic/vip-cli/blob/trunk/docs/TESTING.md#manual-testing) the relevant changes.
- [x] Follow the [pull request checklist](https://github.com/Automattic/vip-cli/blob/trunk/docs/RELEASING.md#new-pull-requests)
- [x] Add/update [automated tests](https://github.com/Automattic/vip-cli/blob/trunk/docs/TESTING.md#automated-testing) as needed.

## New release checklist

- [x] [Automated tests](https://github.com/Automattic/vip-cli/blob/trunk/docs/TESTING.md#automated-testing) pass.
- [ ] The [Preparing for release checklist](https://github.com/Automattic/vip-cli/blob/trunk/docs/RELEASING.md#preparing-for-release) is completed.

## Steps to Test

1. Check out this PR branch.
2. Run `npm ci`.
3. Run `npm run jest -- --runTestsByPath __tests__/bin/vip-dev-env-update.js`.
4. Run `npm run check-types`.
5. In interactive TTY, run `vip dev-env update --slug <slug>` and confirm wizard prompts are shown.
6. In non-TTY context, run the same command and confirm prompts are suppressed/non-interactive.
