### PR TITLE
ci: update Automattic/vip-actions to address deprecation warnings

### DIFF
--- a/.github/workflows/ai-changelog.yml
+++ b/.github/workflows/ai-changelog.yml
@@ -20,7 +20,7 @@ jobs:
       github.event.comment.body == '/changelog'
     steps:
       - name: Generate changelog for PR
-        uses: Automattic/vip-actions/ai-changelog-generator@64cb27606455c925183e07065f050846d69b2120 # trunk
+        uses: Automattic/vip-actions/ai-changelog-generator@517cd5a53681c02f1eb4c490f1c2e095362de10f # trunk
         with:
           openai_api_key: ${{ secrets.OPENAI_API_KEY }}
   docs-doctor:
@@ -34,7 +34,7 @@ jobs:
       github.event.comment.body == '/docs-doctor'
     steps:
       - name: Generate Report
-        uses: Automattic/vip-actions/docs-doctor@64cb27606455c925183e07065f050846d69b2120 # trunk
+        uses: Automattic/vip-actions/docs-doctor@517cd5a53681c02f1eb4c490f1c2e095362de10f # trunk
         with:
           url: https://docs.wpvip.com
           sitemap_url: https://docs.wpvip.com/page-sitemap.xml

--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -18,7 +18,7 @@ jobs:
       pull-requests: read
     steps:
       - uses: actions/checkout@v6
-      - uses: Automattic/vip-actions/changelog@2bcb000c7bae0a75493afed7cf47f4529cdd2c8e
+      - uses: Automattic/vip-actions/changelog@517cd5a53681c02f1eb4c490f1c2e095362de10f # trunk
         with:
           endpoint: 'https://docs.wpvip.com/wp-json/wp/v2/changelogs'
           endpoint-token: ${{ secrets.CHANGELOG_DOCS_POST_TOKEN }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,7 +47,7 @@ jobs:
     name: Dependaban
     runs-on: ubuntu-latest
     steps:
-      - uses: Automattic/vip-actions/dependaban@1137b91acf0f5ea4e0db044bcf14ceabed9b068f # trunk
+      - uses: Automattic/vip-actions/dependaban@517cd5a53681c02f1eb4c490f1c2e095362de10f # trunk
 
   audit:
     name: Verify signatures and provenance statements

--- a/.github/workflows/git-hash-security-check.yml
+++ b/.github/workflows/git-hash-security-check.yml
@@ -20,4 +20,4 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Check for short git hashes in package.json
-        uses: Automattic/vip-actions/git-hash-security-check@7b98dcb98d652bf02037977b1b85abb971c345d0
+        uses: Automattic/vip-actions/git-hash-security-check@517cd5a53681c02f1eb4c490f1c2e095362de10f # trunk

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -12,4 +12,4 @@ jobs:
       issues: write
       pull-requests: write
     steps:
-      - uses: Automattic/vip-actions/stale@1137b91acf0f5ea4e0db044bcf14ceabed9b068f # trunk
+      - uses: Automattic/vip-actions/stale@517cd5a53681c02f1eb4c490f1c2e095362de10f # trunk


### PR DESCRIPTION
This PR fixes Node.js 20-related deprecation warnings:

> Node.js 20 actions are deprecated. The following actions are running on Node.js 20 and may not work as expected: actions/checkout@v4, actions/setup-node@v4. Actions will be forced to run with Node.js 24 by default starting June 2nd, 2026. Node.js 20 will be removed from the runner on September 16th, 2026. Please check if updated versions of these actions are available that support Node.js 24. To opt into Node.js 24 now, set the FORCE_JAVASCRIPT_ACTIONS_TO_NODE24=true environment variable on the runner or in your workflow file. Once Node.js 24 becomes the default, you can temporarily opt out by setting ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION=true. For more information see: https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/