### PR TITLE
Ensure the Login URL is using HTTPS

### DIFF
--- a/src/lib/dev-environment/dev-environment-lando.ts
+++ b/src/lib/dev-environment/dev-environment-lando.ts
@@ -670,7 +670,7 @@ export async function landoInfo(
 
 		// Add login information
 		if ( frontEndUrl ) {
-			const loginURL = new URL( frontEndUrl );
+			const loginURL = new URL( `${ frontEndUrl }wp-admin/` );
 			if ( options.autologinKey ) {
 				loginURL.searchParams.set( 'vip-dev-autologin', options.autologinKey );
 			}

--- a/src/lib/dev-environment/dev-environment-lando.ts
+++ b/src/lib/dev-environment/dev-environment-lando.ts
@@ -4,7 +4,7 @@ import Dockerode from 'dockerode';
 import { execFile } from 'node:child_process';
 import { lookup } from 'node:dns/promises';
 import { mkdir, rename, unlink, stat, writeFile } from 'node:fs/promises';
-import { cpus, totalmem, userInfo } from 'node:os';
+import { cpus, EOL, totalmem, userInfo } from 'node:os';
 import path, { dirname } from 'node:path';
 import { promisify } from 'node:util';
 import { satisfies } from 'semver';
@@ -670,12 +670,18 @@ export async function landoInfo(
 
 		// Add login information
 		if ( frontEndUrl ) {
-			let loginUrl = `${ frontEndUrl.replace( /^http:/, 'https:' ) }wp-admin/`;
+			const loginURL = new URL( frontEndUrl );
 			if ( options.autologinKey ) {
-				loginUrl += `?vip-dev-autologin=${ options.autologinKey }`;
+				loginURL.searchParams.set( 'vip-dev-autologin', options.autologinKey );
 			}
 
-			appInfo[ 'Login URL' ] = loginUrl;
+			loginURL.protocol = 'http:';
+			const httpLoginUrl = loginURL.toString();
+
+			loginURL.protocol = 'https:';
+			const httpsLoginUrl = loginURL.toString();
+
+			appInfo[ 'Login URL' ] = [ httpsLoginUrl, httpLoginUrl ].join( EOL );
 			appInfo[ 'Default username' ] = 'vipgo';
 
 			// Get the stored password from instance data

--- a/src/lib/dev-environment/dev-environment-lando.ts
+++ b/src/lib/dev-environment/dev-environment-lando.ts
@@ -670,7 +670,7 @@ export async function landoInfo(
 
 		// Add login information
 		if ( frontEndUrl ) {
-			let loginUrl = `${ frontEndUrl }wp-admin/`;
+			let loginUrl = `${ frontEndUrl.replace( /^http:/, 'https:' ) }wp-admin/`;
 			if ( options.autologinKey ) {
 				loginUrl += `?vip-dev-autologin=${ options.autologinKey }`;
 			}


### PR DESCRIPTION
## Description

One of our developers had a frustrating experience after following the login URL from `vip dev-env info` and found the resulting editing experience slightly broken when using the currently linked plaintext HTTP WordPress dashboard. This approach assumes there will be a working HTTPS connection available, which may not always be the case. But for the majority of our developers, offering an HTTPS login URL is better and would lead to reduced frustration.

## Changelog Description

- Prefer HTTPS for dev environment login URL.

### Changed

- Show both HTTP and HTTPS versions of the login URL.

## Pull request checklist

- [ ] Update [SETUP.md](https://github.com/Automattic/vip-cli/blob/trunk/docs/SETUP.md#list-of-environmental-variables) with any new environmental variables.
- [ ] Update [the documentation](https://github.com/Automattic/vip-cli/blob/trunk/docs).
- [x] [Manually test](https://github.com/Automattic/vip-cli/blob/trunk/docs/TESTING.md#manual-testing) the relevant changes.
- [x] Follow the [pull request checklist](https://github.com/Automattic/vip-cli/blob/trunk/docs/RELEASING.md#new-pull-requests)
- [ ] Add/update [automated tests](https://github.com/Automattic/vip-cli/blob/trunk/docs/TESTING.md#automated-testing) as needed.

## Steps to Test

1. Check out PR.
1. Run `npm run build`
1. Run `npm link`
1. Run `./dist/bin/vip.js dev-env info`
1. Verify Login URL starts with `https://`
