### PR TITLE
fix(dev-env): avoid false use matches in SQL imports

### DIFF
--- a/__tests__/lib/validations/sql.js
+++ b/__tests__/lib/validations/sql.js
@@ -1,10 +1,8 @@
-/**
- * @format
- */
-
 import debugLib from 'debug';
 import fetch, { Response } from 'node-fetch';
-import path from 'path';
+import { mkdtemp, rm, writeFile } from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
 
 import { validate } from '../../../src/lib/validations/sql';
 
@@ -22,9 +20,68 @@ const mockExit = jest.spyOn( process, 'exit' ).mockImplementation( () => {} );
 const ERROR_CODE = 1;
 
 jest.mock( 'node-fetch' );
+jest.mock( '../../../src/lib/tracker', () => ( {
+	trackEvent: jest.fn().mockResolvedValue( [] ),
+} ) );
 fetch.mockReturnValue( Promise.resolve( new Response( 'ok' ) ) );
 
 describe( 'lib/validations/sql', () => {
+	describe( 'it validates SQL for dev-env without false-positive USE statements', () => {
+		let tempDir;
+		let sqlBytes;
+
+		beforeAll( async () => {
+			tempDir = await mkdtemp( path.join( os.tmpdir(), 'vip-cli-sql-validation-' ) );
+			const sqlFilePath = path.join( tempDir, 'u2028-use-string.sql' );
+			sqlBytes = Buffer.concat( [
+				Buffer.from(
+					'DROP TABLE IF EXISTS `wp_options`;\n' +
+						'CREATE TABLE `wp_options` (\n' +
+						'  `option_id` bigint(20) unsigned NOT NULL AUTO_INCREMENT,\n' +
+						"  `option_name` varchar(191) NOT NULL DEFAULT '',\n" +
+						'  `option_value` longtext NOT NULL,\n' +
+						"  `autoload` varchar(20) NOT NULL DEFAULT 'yes',\n" +
+						'  PRIMARY KEY (`option_id`)\n' +
+						') ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;\n' +
+						"INSERT INTO `wp_options` (`option_name`, `option_value`, `autoload`) VALUES ('siteurl', 'http://test.domain', 'yes');\n" +
+						"INSERT INTO `wp_options` (`option_name`, `option_value`, `autoload`) VALUES ('home', 'http://test.domain', 'yes');\n" +
+						"INSERT INTO `wp_options` (`option_name`, `option_value`, `autoload`) VALUES ('description', 'Line separator ",
+					'utf8'
+				),
+				Buffer.from( [ 0xe2, 0x80, 0xa8 ] ),
+				Buffer.from( "Use Cases for VIP CLI', 'yes');\n", 'utf8' ),
+			] );
+
+			await writeFile( sqlFilePath, sqlBytes );
+
+			output = '';
+			mockExit.mockClear();
+
+			let isolatedValidate;
+			jest.isolateModules( () => {
+				( { validate: isolatedValidate } = require( '../../../src/lib/validations/sql' ) );
+			} );
+
+			await isolatedValidate( sqlFilePath, {
+				isImport: false,
+				skipChecks: [],
+				extraCheckParams: { siteHomeUrlLando: 'test.domain' },
+			} );
+		} );
+
+		afterAll( async () => {
+			if ( tempDir ) {
+				await rm( tempDir, { recursive: true, force: true } );
+			}
+		} );
+
+		it( 'does not reject text after U+2028 inside an INSERT value as a USE statement', () => {
+			expect( sqlBytes.includes( Buffer.from( [ 0xe2, 0x80, 0xa8 ] ) ) ).toBe( true );
+			expect( mockExit ).not.toHaveBeenCalled();
+			expect( output ).not.toContain( 'USE <DATABASE_NAME> statement on' );
+		} );
+	} );
+
 	describe( 'it fails when the SQL has (using bad-sql-dump.sql)', () => {
 		beforeAll( async () => {
 			try {

--- a/src/lib/validations/line-by-line.ts
+++ b/src/lib/validations/line-by-line.ts
@@ -1,7 +1,6 @@
 import debugLib from 'debug';
-import { createReadStream } from 'node:fs';
+import { once } from 'node:events';
 import { open } from 'node:fs/promises';
-import { type Interface, createInterface } from 'node:readline';
 
 import * as exit from '../../lib/cli/exit';
 
@@ -20,7 +19,9 @@ export interface PostLineExecutionProcessingParams {
 	searchReplace?: string | string[];
 }
 
-export async function getReadInterface( filename: string ): Promise< Interface > {
+export async function getReadInterface(
+	filename: string
+): Promise< ReturnType< Awaited< ReturnType< typeof open > >[ 'readLines' ] > > {
 	let fd;
 	try {
 		fd = await open( filename );
@@ -30,9 +31,8 @@ export async function getReadInterface( filename: string ): Promise< Interface >
 		);
 	}
 
-	return createInterface( {
-		input: createReadStream( '', { fd } ),
-		output: undefined,
+	return fd.readLines( {
+		encoding: 'binary',
 	} );
 }
 
@@ -59,8 +59,7 @@ export async function fileLineValidations(
 	} );
 
 	// Block until the processing completes
-	await new Promise( resolve => readInterface.on( 'close', resolve ) );
-	readInterface.close();
+	await once( readInterface, 'close' );
 
 	return Promise.all(
 		validations.map( ( validation: PerLineValidationObject ) => {

--- a/src/lib/validations/sql.ts
+++ b/src/lib/validations/sql.ts
@@ -1,5 +1,6 @@
 import { stdout as log } from '@wwa/single-line-log';
 import chalk from 'chalk';
+import { once } from 'node:events';
 import path from 'node:path';
 
 import * as exit from '../../lib/cli/exit';
@@ -585,8 +586,7 @@ export const validate = async (
 	} );
 
 	// Block until the processing completes
-	await new Promise( resolve => readInterface.on( 'close', resolve ) );
-	readInterface.close();
+	await once( readInterface, 'close' );
 
 	await postLineExecutionProcessing( {
 		isImport: options.isImport,


### PR DESCRIPTION
## Description

Fixes a false positive in dev-env SQL validation where UTF-8 bytes for U+2028 inside SQL data could be decoded as line separators. When the following string content started with `Use `, the existing `USE` statement check saw a synthetic line and rejected the import.

The validator now reads SQL input with binary line decoding and waits for the reader close event before post-validation summaries. Related: PLTFRM-2430.

## Changelog Description

### Fixed

- Dev-env: Fixed false positive SQL import validation errors for exported dumps containing Unicode line-separator bytes inside string data.

## Pull request checklist

- [ ] Update [SETUP.md](https://github.com/Automattic/vip-cli/blob/trunk/docs/SETUP.md#list-of-environmental-variables) with any new environmental variables.
- [ ] Update [the documentation](https://github.com/Automattic/vip-cli/blob/trunk/docs).
- [ ] [Manually test](https://github.com/Automattic/vip-cli/blob/trunk/docs/TESTING.md#manual-testing) the relevant changes.
- [ ] Follow the [pull request checklist](https://github.com/Automattic/vip-cli/blob/trunk/docs/RELEASING.md#new-pull-requests)
- [x] Add/update [automated tests](https://github.com/Automattic/vip-cli/blob/trunk/docs/TESTING.md#automated-testing) as needed.

## New release checklist

- [x] [Automated tests](https://github.com/Automattic/vip-cli/blob/trunk/docs/TESTING.md#automated-testing) pass.
- [x] The [Preparing for release checklist](https://github.com/Automattic/vip-cli/blob/trunk/docs/RELEASING.md#preparing-for-release) is completed.

## Steps to Test

1. Check out this PR.
1. Run `npm run jest -- --runTestsByPath __tests__/lib/validations/sql.js`.
1. Confirm the SQL validation suite passes, including the regression coverage for raw `E2 80 A8` bytes followed by `Use Cases` inside an INSERT value.