### PR TITLE
fix(keychain): load secure keychain export

### DIFF
--- a/src/lib/keychain.ts
+++ b/src/lib/keychain.ts
@@ -2,7 +2,7 @@ import debugLib from 'debug';
 
 import Insecure from './keychain/insecure';
 
-import type { Keychain, KeychainConstructor } from './keychain/keychain';
+import type { Keychain } from './keychain/keychain';
 
 let keychain: Keychain;
 const debug = debugLib( '@automattic/vip:keychain' );
@@ -10,7 +10,7 @@ const debug = debugLib( '@automattic/vip:keychain' );
 try {
 	// Try using Secure keychain ("keytar") first
 	// eslint-disable-next-line @typescript-eslint/no-require-imports
-	const Secure = require( './keychain/secure' ) as KeychainConstructor;
+	const Secure = ( require( './keychain/secure' ) as typeof import('./keychain/secure') ).default;
 	keychain = new Secure();
 } catch ( error ) {
 	debug( 'Cannot use Secure keychain; falling back to Insecure keychain (Details: %o)', error );


### PR DESCRIPTION
## Description

### Purpose and Context

The credential store should prefer the secure keychain backend when available and fall back to configstore otherwise. The dynamic require path was reading the secure backend with the wrong module shape, causing the CLI to use the insecure fallback even when the secure backend could be loaded.

### Key Changes

- Read the default export from the secure keychain module when requiring it dynamically.
- Remove the unused constructor type import.

### Impact and Considerations

Login credentials are stored in the secure keychain when that backend is available. The existing configstore fallback remains available for environments without secure keychain support.

If the secure keychain is available, the users will have to re-login to have their credentials migrated from the configstore to the

## Changelog Description

### Fixed

- Secure keychain will be used if available.

## Pull request checklist

- [ ] Update [SETUP.md](https://github.com/Automattic/vip-cli/blob/trunk/docs/SETUP.md#list-of-environmental-variables) with any new environmental variables.
- [ ] Update [the documentation](https://github.com/Automattic/vip-cli/blob/trunk/docs).
- [ ] [Manually test](https://github.com/Automattic/vip-cli/blob/trunk/docs/TESTING.md#manual-testing) the relevant changes.
- [ ] Follow the [pull request checklist](https://github.com/Automattic/vip-cli/blob/trunk/docs/RELEASING.md#new-pull-requests)
- [ ] Add/update [automated tests](https://github.com/Automattic/vip-cli/blob/trunk/docs/TESTING.md#automated-testing) as needed.

## New release checklist

- [ ] [Automated tests](https://github.com/Automattic/vip-cli/blob/trunk/docs/TESTING.md#automated-testing) pass.
- [ ] The [Preparing for release checklist](https://github.com/Automattic/vip-cli/blob/trunk/docs/RELEASING.md#preparing-for-release) is completed.

## Steps to Test

`DEBUG=@automattic/vip:keychain vip` must not show "Cannot use Secure keychain; falling back to Insecure keychain (Details: TypeError: Secure is not a constructor"