### PR TITLE
fix(dev-env): use -o so myloader drops existing tables before import

### DIFF
--- a/__tests__/commands/dev-env-import-sql.ts
+++ b/__tests__/commands/dev-env-import-sql.ts
@@ -1,0 +1,36 @@
+/**
+ * @format
+ */
+
+import { DevEnvImportSQLCommand } from '../../src/commands/dev-env-import-sql';
+import { SqlDumpType } from '../../src/lib/database';
+
+describe( 'commands/DevEnvImportSQLCommand', () => {
+	describe( '.getImportArgs', () => {
+		const command = new DevEnvImportSQLCommand(
+			'dump.sql',
+			{ inPlace: false, skipValidate: true, quiet: true },
+			'test-slug'
+		);
+
+		it( 'uses the mysql client for mysqldump files', () => {
+			const args = command.getImportArgs( { type: SqlDumpType.MYSQLDUMP, sourceDb: undefined } );
+			expect( args[ 0 ] ).toBe( 'db' );
+		} );
+
+		it( 'passes -o (not --overwrite-tables) to myloader for mydumper files', () => {
+			const args = command.getImportArgs( {
+				type: SqlDumpType.MYDUMPER,
+				sourceDb: 'some_db',
+			} );
+
+			expect( args[ 0 ] ).toBe( 'db-myloader' );
+			// `-o` drops existing tables on every myloader version;
+			// `--overwrite-tables` became a silent no-op in myloader >= 0.20.
+			expect( args ).toContain( '-o' );
+			expect( args ).not.toContain( '--overwrite-tables' );
+			expect( args ).toContain( '--source-db=some_db' );
+			expect( args ).toContain( '--stream' );
+		} );
+	} );
+} );

--- a/src/commands/dev-env-import-sql.ts
+++ b/src/commands/dev-env-import-sql.ts
@@ -164,7 +164,9 @@ export class DevEnvImportSQLCommand {
 
 			importArg = [
 				'db-myloader',
-				'--overwrite-tables',
+				// Drop existing tables before restoring. Do not use the long form:
+				// `--overwrite-tables` is a silent no-op on myloader >= 0.20.
+				'-o',
 				...( dumpDetails.sourceDb ? [ `--source-db=${ dumpDetails.sourceDb }` ] : [] ),
 				`--threads=${ threadCount }`,
 				'--max-threads-for-schema-creation=10',


### PR DESCRIPTION
### Problem

`vip dev-env import sql` fails for every MyDumper-format dump imported into an environment that has *any* pre-existing tables — which is all of them, since a fresh dev-env ships with the default WordPress tables. myloader exits with code 133 (SIGTRAP via GLib `g_error`) after:

```
** (myloader): CRITICAL **: Thread N using connection M - ERROR 1050: Table 'wp_...' already exists
** (myloader): ERROR **: Thread N: issue restoring ...-schema.sql
```

Retrying after a partial import fails instantly for the same reason.

### Root cause

[vip-container-images#1463](https://github.com/Automattic/vip-container-images/pull/1463) bumped mydumper 0.18.1 → 0.21.3 in the php image. In myloader ≥ 0.20, `--overwrite-tables` was deprecated in favor of `-o`/`--drop-table` and re-registered as a bare boolean that **no longer sets the purge mode**, which stays at its default `FAIL` ([myloader_arguments.c#L206](https://github.com/mydumper/mydumper/blob/v0.21.3-1/src/myloader/myloader_arguments.c#L206), [myloader_restore_job.c#L43](https://github.com/mydumper/mydumper/blob/v0.21.3-1/src/myloader/myloader_restore_job.c#L43)). No `DROP TABLE` is ever issued — the `overwrite_table()` switch falls through to its `This should not happen` branch — and the first colliding `CREATE TABLE` is fatal.

### Fix

Pass `-o` instead of the long flag in `getImportArgs()` (`src/commands/dev-env-import-sql.ts`). `-o` is correct on **every** myloader version:

| myloader | `-o` resolves to |
| --- | --- |
| ≤ 0.19 | short form of `--overwrite-tables` |
| ≥ 0.20 | short form of `--drop-table`, defaulting to `DROP` mode |

### Testing

- Reproduced the 133/`ERROR 1050` failure against a populated dev-env DB with `--overwrite-tables`; instant failure (<1s).
- With `-o`, myloader emits `Dropping table or view (if exists) ...` per table and a 201,721-table production-scale dump imports over a populated database end to end.

## Changelog Description

### Fixed

- Dev-env: Fixed SQL imports of MyDumper-format backups failing with `ERROR 1050: Table already exists` when the local database contains existing tables

### Related

- Refs PLTFRM-22 / PLTFRM-1032 (prior MyDumper import escalations)
- Companion PRs: #2872 (search-replace size fix), #2873 (ENGINE validation), #2874 (DB tuning)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
