### PR TITLE
fix(upload): set duplex for stream retry bodies

### DIFF
--- a/__tests__/lib/fetch-with-retry-undici.js
+++ b/__tests__/lib/fetch-with-retry-undici.js
@@ -1,0 +1,27 @@
+/**
+ * @format
+ */
+
+import { Readable } from 'node:stream';
+
+import { fetchWithRetry } from '../../src/lib/client-file-uploader';
+import { getUndiciMockPool, resetUndiciMockAgent } from '../../test-utils/undici-mock';
+
+describe( 'fetchWithRetry() with real undici', () => {
+	afterEach( resetUndiciMockAgent );
+
+	it( 'should add duplex for stream bodies created per attempt', async () => {
+		const pool = getUndiciMockPool( 'https://upload.example.com' );
+		pool.intercept( { method: 'PUT', path: '/upload' } ).reply( 200, 'ok' );
+
+		const response = await fetchWithRetry(
+			'https://upload.example.com/upload',
+			{ method: 'PUT' },
+			0,
+			() => Readable.from( [ 'hello' ] )
+		);
+
+		expect( response.status ).toBe( 200 );
+		await expect( response.text() ).resolves.toBe( 'ok' );
+	} );
+} );

--- a/src/lib/client-file-uploader.ts
+++ b/src/lib/client-file-uploader.ts
@@ -34,6 +34,11 @@ export function parseEtagHeader( etag: string ): string {
 
 export type BodyFactory = () => RequestInit[ 'body' ];
 
+type RequestInitWithDuplex = RequestInit & { duplex?: 'half' };
+
+const isStreamBody = ( body: RequestInit[ 'body' ] ): boolean =>
+	typeof ( body as { pipe?: unknown } | null | undefined )?.pipe === 'function';
+
 /**
  * Wraps `fetch` with exponential-backoff retries.
  *
@@ -54,13 +59,17 @@ export async function fetchWithRetry(
 	retries = 3,
 	createBody?: BodyFactory
 ): Promise< Response > {
-	const bodyIsStream =
-		typeof ( init.body as { pipe?: unknown } | null | undefined )?.pipe === 'function';
+	const bodyIsStream = isStreamBody( init.body );
 	// Only retry when we can hand `fetch` a fresh, replayable body each attempt.
 	const maxAttempts = createBody || ! bodyIsStream ? retries : 0;
 
 	for ( let attempt = 0; attempt <= maxAttempts; attempt++ ) {
-		const requestInit = createBody ? { ...init, body: createBody() } : init;
+		const requestInit: RequestInitWithDuplex = createBody
+			? { ...init, body: createBody() }
+			: { ...init };
+		if ( isStreamBody( requestInit.body ) && ! requestInit.duplex ) {
+			requestInit.duplex = 'half';
+		}
 		try {
 			// eslint-disable-next-line no-await-in-loop
 			return await fetch( input, requestInit );


### PR DESCRIPTION
## Summary

- adds `duplex: 'half'` automatically in `fetchWithRetry` when an attempt uses a Node stream request body
- preserves caller-provided `duplex` values and keeps the one-shot stream retry guard from PR #2897
- adds a regression test that uses real `undici.fetch` with the repo's `MockAgent` test helper, so stream-body validation is exercised instead of mocked

## Why

Follow-up from the v4.0.6 upload fix: a customer upgraded from the original `Response body object should not be disturbed or locked` failure and then hit:

```text
RequestInit: duplex option is required when sending a body
```

PR #2897 correctly recreates stream bodies per retry, but the existing tests mock `undici.fetch`; they verify body recreation without exercising undici's real requirement that stream request bodies include `duplex: 'half'`.

## Testing

- `npm run jest -- __tests__/lib/fetch-with-retry-undici.js __tests__/lib/client-file-uploader.js --runInBand` (ran all non-e2e suites: 56 passed / 593 tests)
- `npm run check-types`
- `npm run cmd:lint -- src/lib/client-file-uploader.ts __tests__/lib/fetch-with-retry-undici.js`
- `npm run build`