### PR TITLE
Fix fetch failed due to unsupported expect header

### DIFF
--- a/__tests__/lib/client-file-uploader.js
+++ b/__tests__/lib/client-file-uploader.js
@@ -15,6 +15,7 @@ import {
 	getFileMeta,
 	getPartBoundaries,
 	parseEtagHeader,
+	uploadImportFileToS3,
 	uploadParts,
 } from '../../src/lib/client-file-uploader';
 
@@ -331,5 +332,68 @@ describe( 'client-file-uploader', () => {
 			expect( progress.every( pct => parseInt( pct, 10 ) <= 100 ) ).toBe( true );
 			expect( progress[ progress.length - 1 ] ).toBe( '100%' );
 		}, 15000 );
+	} );
+
+	describe( 'uploadImportFileToS3()', () => {
+		let tmpDir;
+
+		const uploadOkResponse = {
+			status: 200,
+			text: async () => '',
+		};
+
+		const writeTempFile = ( name, contents ) => {
+			const fileName = path.join( tmpDir, name );
+			writeFileSync( fileName, contents );
+			return fileName;
+		};
+
+		beforeAll( () => {
+			tmpDir = mkdtempSync( path.join( os.tmpdir(), 'vip-cli-upload-import-' ) );
+		} );
+
+		afterAll( () => {
+			rmSync( tmpDir, { recursive: true, force: true } );
+		} );
+
+		beforeEach( () => {
+			fetch.mockReset();
+			http.mockReset();
+		} );
+
+		it( 'should strip unsupported Expect headers from presigned PutObject uploads', async () => {
+			const fileName = writeTempFile( 'small-deploy.zip', 'zip contents' );
+			const fileMeta = {
+				...( await getFileMeta( fileName ) ),
+				fileContent: Buffer.from( 'zip contents' ),
+			};
+
+			http.mockResolvedValue( {
+				status: 200,
+				json: async () => ( {
+					url: 'https://s3.example.com/upload',
+					options: {
+						method: 'PUT',
+						headers: {
+							Expect: '100-continue',
+							'x-amz-server-side-encryption': 'AES256',
+						},
+					},
+				} ),
+			} );
+			fetch.mockResolvedValue( uploadOkResponse );
+
+			await uploadImportFileToS3( {
+				app: { id: 1 },
+				env: { id: 2 },
+				fileMeta,
+			} );
+
+			expect( fetch ).toHaveBeenCalledTimes( 1 );
+			expect( fetch.mock.calls[ 0 ][ 1 ].headers ).toEqual( {
+				'Content-Length': `${ fileMeta.fileSize }`,
+				'x-amz-server-side-encryption': 'AES256',
+			} );
+		} );
 	} );
 } );

--- a/src/lib/client-file-uploader.ts
+++ b/src/lib/client-file-uploader.ts
@@ -9,7 +9,7 @@ import { setTimeout } from 'node:timers/promises';
 import os from 'os';
 import path from 'path';
 import { PassThrough } from 'stream';
-import { fetch, type HeadersInit, type RequestInit, type Response } from 'undici';
+import { fetch, Headers, type HeadersInit, type RequestInit, type Response } from 'undici';
 import { Parser as XmlParser } from 'xml2js';
 import { createGunzip, createGzip, Gunzip, ZlibOptions } from 'zlib';
 
@@ -39,6 +39,28 @@ type RequestInitWithDuplex = RequestInit & { duplex?: 'half' };
 const isStreamBody = ( body: RequestInit[ 'body' ] ): boolean =>
 	typeof ( body as { pipe?: unknown } | null | undefined )?.pipe === 'function';
 
+const stripUndiciUnsupportedHeaders = ( headers?: HeadersInit ): HeadersInit | undefined => {
+	if ( ! headers ) {
+		return headers;
+	}
+
+	const isSupportedHeader = ( name: string ) => name.toLowerCase() !== 'expect';
+
+	if ( headers instanceof Headers ) {
+		const sanitized = new Headers( headers );
+		sanitized.delete( 'expect' );
+		return sanitized;
+	}
+
+	if ( Array.isArray( headers ) ) {
+		return headers.filter( ( [ name ] ) => isSupportedHeader( name ) );
+	}
+
+	return Object.fromEntries(
+		Object.entries( headers ).filter( ( [ name ] ) => isSupportedHeader( name ) )
+	);
+};
+
 /**
  * Wraps `fetch` with exponential-backoff retries.
  *
@@ -67,6 +89,7 @@ export async function fetchWithRetry(
 		const requestInit: RequestInitWithDuplex = createBody
 			? { ...init, body: createBody() }
 			: { ...init };
+		requestInit.headers = stripUndiciUnsupportedHeaders( requestInit.headers );
 		if ( isStreamBody( requestInit.body ) && ! requestInit.duplex ) {
 			requestInit.duplex = 'half';
 		}


### PR DESCRIPTION
This pull request adds a new utility to strip unsupported HTTP headers (specifically the `Expect` header) from requests made to S3, and introduces a test to verify this behavior in the `uploadImportFileToS3` function. This ensures better compatibility with the `undici` HTTP client and S3 presigned URLs.

**Testing and Bug Fixes:**

* Added a test for `uploadImportFileToS3` in `__tests__/lib/client-file-uploader.js` to verify that unsupported `Expect` headers are stripped from presigned S3 uploads.
* Imported `uploadImportFileToS3` into the test file to enable testing of the new behavior.

**HTTP Header Handling Improvements:**

* Added the `stripUndiciUnsupportedHeaders` utility to remove unsupported headers (like `Expect`) from HTTP requests before sending them with `undici`.
* Updated `fetchWithRetry` to use `stripUndiciUnsupportedHeaders` on all outgoing requests, improving compatibility and preventing errors with S3 and the `undici` client.
* Included the `Headers` class from `undici` to support header manipulation.

## Pull request checklist

- [ ] Update [SETUP.md](https://github.com/Automattic/vip-cli/blob/trunk/docs/SETUP.md#list-of-environmental-variables) with any new environmental variables.
- [ ] Update [the documentation](https://github.com/Automattic/vip-cli/blob/trunk/docs).
- [ ] [Manually test](https://github.com/Automattic/vip-cli/blob/trunk/docs/TESTING.md#manual-testing) the relevant changes.
- [ ] Follow the [pull request checklist](https://github.com/Automattic/vip-cli/blob/trunk/docs/RELEASING.md#new-pull-requests)
- [ ] Add/update [automated tests](https://github.com/Automattic/vip-cli/blob/trunk/docs/TESTING.md#automated-testing) as needed.

## New release checklist

- [ ] [Automated tests](https://github.com/Automattic/vip-cli/blob/trunk/docs/TESTING.md#automated-testing) pass.
- [ ] The [Preparing for release checklist](https://github.com/Automattic/vip-cli/blob/trunk/docs/RELEASING.md#preparing-for-release) is completed.

## Steps to Test

Outline the steps to test and verify the PR here.

Example:

1. Check out PR.
1. Run `npm run build`
1. Run `./dist/bin/vip-cookies.js nom`
1. Verify cookies are delicious.
