### PR TITLE
test(upload): add real-undici tests for Expect-header stripping and retry via factory

### DIFF
--- a/__tests__/lib/fetch-with-retry-undici.js
+++ b/__tests__/lib/fetch-with-retry-undici.js
@@ -24,4 +24,46 @@ describe( 'fetchWithRetry() with real undici', () => {
 		expect( response.status ).toBe( 200 );
 		await expect( response.text() ).resolves.toBe( 'ok' );
 	} );
+
+	it( 'should strip the Expect header before dispatching through real undici', async () => {
+		// If fetchWithRetry does NOT strip the Expect header, undici throws
+		// NotSupportedError (UND_ERR_NOT_SUPPORTED) locally before the request
+		// reaches the MockAgent — the test fails because fetchWithRetry rejects.
+		// The afterEach assertNoPendingInterceptors() check is a secondary guard.
+		const pool = getUndiciMockPool( 'https://upload.example.com' );
+		pool.intercept( { method: 'POST', path: '/complete' } ).reply( 200, '<ok/>' );
+
+		const response = await fetchWithRetry( 'https://upload.example.com/complete', {
+			method: 'POST',
+			headers: { Expect: '100-continue', 'Content-Type': 'application/xml' },
+			body: '<CompleteMultipartUpload/>',
+		} );
+
+		await response.text(); // drain to avoid open handles
+		expect( response.status ).toBe( 200 );
+	} );
+
+	// Real undici creates promises that fake timers cannot advance reliably on
+	// all Node versions. Use real timers; the backoff delay is 1s so the test
+	// completes in ~1-2s well within the 8s timeout.
+	it( 'should retry a stream body factory through real undici on transient failure', async () => {
+		jest.useRealTimers();
+
+		const pool = getUndiciMockPool( 'https://upload.example.com' );
+		// First attempt fails; second succeeds. Both go through real undici dispatch.
+		pool
+			.intercept( { method: 'PUT', path: '/retry' } )
+			.replyWithError( new Error( 'socket hang up' ) );
+		pool.intercept( { method: 'PUT', path: '/retry' } ).reply( 200, 'ok' );
+
+		const response = await fetchWithRetry(
+			'https://upload.example.com/retry',
+			{ method: 'PUT' },
+			1, // 1 retry, ~1s backoff
+			() => Readable.from( [ 'retry-body' ] )
+		);
+
+		await response.text(); // drain to avoid open handles
+		expect( response.status ).toBe( 200 );
+	}, 8000 );
 } );


### PR DESCRIPTION
## Summary

Expands `__tests__/lib/fetch-with-retry-undici.js` with two additional real-undici test cases that the existing single test (duplex happy-path) does not cover.

Closes [PLTFRM-2496](https://linear.app/a8c/issue/PLTFRM-2496).

## Why

The mocked `undici.fetch` tests in `client-file-uploader.js` pass even if `Expect`-header stripping or the retry-via-factory path breaks, because the mock never routes through real undici validation. The v4.0.6 `duplex` regression was caught only by adding `fetch-with-retry-undici.js`; the same pattern applies to these two cases.

## What changed

**`__tests__/lib/fetch-with-retry-undici.js`** — 2 new real-undici test cases:

1. **`should strip the Expect header before dispatching through real undici`**
   Calls `fetchWithRetry` with `Expect: 100-continue` and a `MockAgent` intercept registered. If `Expect` is not stripped, undici throws `UND_ERR_NOT_SUPPORTED` locally before the request reaches the intercept; the test fails on the thrown error. `afterEach assertNoPendingInterceptors` is a secondary guard.

2. **`should retry a stream body factory through real undici on transient failure`**
   First `MockAgent` intercept `replyWithError`, second replies `200`. Verifies that the retry path dispatches a fresh factory body through real undici dispatch (including `duplex: 'half'` handling and stream consumption).

## Testing

All 57 suites / 614 tests pass. Lint and `check-types` clean.
