### PR TITLE
fix(wp): guard readline calls against ERR_USE_AFTER_CLOSE on reconnect

### DIFF
--- a/__tests__/lib/wp/readline.ts
+++ b/__tests__/lib/wp/readline.ts
@@ -1,0 +1,124 @@
+import { createInterface as createReadlineInterface, type Interface } from 'node:readline';
+import { PassThrough } from 'node:stream';
+
+import {
+	isReadlineClosed,
+	safePause,
+	safePrompt,
+	safeResume,
+	safeWrite,
+	trackReadline,
+} from '../../../src/lib/wp/readline';
+
+function createInterface(): Interface {
+	const input = new PassThrough();
+	const output = new PassThrough();
+	return createReadlineInterface( { input, output, terminal: false } );
+}
+
+describe( 'vip-wp readline guards', () => {
+	describe( 'trackReadline / isReadlineClosed', () => {
+		test( 'an untracked interface is never reported as closed', () => {
+			const rl = createInterface();
+			rl.close();
+			expect( isReadlineClosed( rl ) ).toBe( false );
+		} );
+
+		test( 'a tracked interface is open until it closes', () => {
+			const rl = createInterface();
+			trackReadline( rl );
+			expect( isReadlineClosed( rl ) ).toBe( false );
+			rl.close();
+		} );
+
+		test( 'a tracked interface is closed after the close event', () => {
+			const rl = createInterface();
+			trackReadline( rl );
+			rl.close();
+			expect( isReadlineClosed( rl ) ).toBe( true );
+		} );
+
+		test( 'tracking reacts to input EOF, not just explicit close()', async () => {
+			const input = new PassThrough();
+			const output = new PassThrough();
+			const rl = createReadlineInterface( { input, output, terminal: false } );
+			const closed = new Promise< void >( resolve => rl.once( 'close', () => resolve() ) );
+			trackReadline( rl );
+
+			input.end();
+			await closed;
+
+			expect( isReadlineClosed( rl ) ).toBe( true );
+		} );
+
+		test( 'returns the same interface for chaining', () => {
+			const rl = createInterface();
+			expect( trackReadline( rl ) ).toBe( rl );
+			rl.close();
+		} );
+	} );
+
+	describe( 'when the interface is open', () => {
+		test.each( [
+			[ 'safeResume', safeResume, 'resume' ],
+			[ 'safePause', safePause, 'pause' ],
+			[ 'safePrompt', safePrompt, 'prompt' ],
+		] as const )( '%s calls through to the interface', ( _name, fn, method ) => {
+			const rl = trackReadline( createInterface() );
+			const spy = jest.spyOn( rl, method );
+
+			fn( rl );
+
+			expect( spy ).toHaveBeenCalledTimes( 1 );
+			rl.close();
+		} );
+
+		test( 'safeWrite calls through to the interface', () => {
+			const rl = trackReadline( createInterface() );
+			const spy = jest.spyOn( rl, 'write' );
+
+			safeWrite( rl, 'wp option list\n' );
+
+			expect( spy ).toHaveBeenCalledWith( 'wp option list\n', undefined );
+			rl.close();
+		} );
+	} );
+
+	describe( 'when the interface is closed', () => {
+		test( 'safeResume does not throw and does not call through', () => {
+			const rl = trackReadline( createInterface() );
+			rl.close();
+			const spy = jest.spyOn( rl, 'resume' );
+
+			expect( () => safeResume( rl ) ).not.toThrow();
+			expect( spy ).not.toHaveBeenCalled();
+		} );
+
+		test( 'safePause does not throw and does not call through', () => {
+			const rl = trackReadline( createInterface() );
+			rl.close();
+			const spy = jest.spyOn( rl, 'pause' );
+
+			expect( () => safePause( rl ) ).not.toThrow();
+			expect( spy ).not.toHaveBeenCalled();
+		} );
+
+		test( 'safePrompt does not throw and does not call through', () => {
+			const rl = trackReadline( createInterface() );
+			rl.close();
+			const spy = jest.spyOn( rl, 'prompt' );
+
+			expect( () => safePrompt( rl ) ).not.toThrow();
+			expect( spy ).not.toHaveBeenCalled();
+		} );
+
+		test( 'safeWrite does not throw and does not call through', () => {
+			const rl = trackReadline( createInterface() );
+			rl.close();
+			const spy = jest.spyOn( rl, 'write' );
+
+			expect( () => safeWrite( rl, 'wp option list\n' ) ).not.toThrow();
+			expect( spy ).not.toHaveBeenCalled();
+		} );
+	} );
+} );

--- a/src/bin/vip-wp.js
+++ b/src/bin/vip-wp.js
@@ -20,6 +20,7 @@ import { createProxyAgent } from '../lib/http/proxy-agent';
 import Token from '../lib/token';
 import { trackEvent } from '../lib/tracker';
 import { initState, resetState, stateMachine } from '../lib/wp/helpers';
+import { safePause, safePrompt, safeResume, safeWrite, trackReadline } from '../lib/wp/readline';
 
 const debug = debugLib( '@automattic/vip:wp' );
 
@@ -114,8 +115,8 @@ const bindStreamEvents = ( { subShellRl, commonTrackingParams, isSubShell, stdou
 			subShellRl.close();
 			process.exit();
 		}
-		subShellRl.resume();
-		subShellRl.prompt();
+		safeResume( subShellRl );
+		safePrompt( subShellRl );
 	} );
 };
 
@@ -239,7 +240,7 @@ const bindReconnectEvents = ( {
 		bindReconnectEvents( { cliCommand, inputToken, subShellRl, commonTrackingParams, isSubShell } );
 
 		// Resume readline interface
-		subShellRl.resume();
+		safeResume( subShellRl );
 	} );
 
 	currentJob.socket.on( 'retry', async () => {
@@ -442,6 +443,7 @@ commandWrapper( {
 		let seenWP = false;
 
 		const subShellRl = readline.createInterface( subShellSettings );
+		trackReadline( subShellRl );
 		subShellRl.on( 'line', async line => {
 			if ( commandRunning ) {
 				return;
@@ -449,7 +451,7 @@ commandWrapper( {
 
 			// Handle plain return / newline
 			if ( ! line ) {
-				subShellRl.prompt();
+				safePrompt( subShellRl );
 				return;
 			}
 
@@ -463,7 +465,7 @@ commandWrapper( {
 			if ( userCmdCancelled ) {
 				seenWP = false;
 				resetState( commandState );
-				subShellRl.prompt();
+				safePrompt( subShellRl );
 				return;
 			}
 
@@ -483,11 +485,11 @@ commandWrapper( {
 					chalk.red( 'Error:' ),
 					'invalid command, please pass a valid WP-CLI command.'
 				);
-				subShellRl.prompt();
+				safePrompt( subShellRl );
 				return;
 			}
 
-			subShellRl.pause();
+			safePause( subShellRl );
 
 			let result;
 			const wpCliCmd = commandState.command.replace( /^wp\s+/, '' );
@@ -512,7 +514,7 @@ commandWrapper( {
 					process.exit( 1 );
 				}
 
-				subShellRl.prompt();
+				safePrompt( subShellRl );
 				return;
 			}
 
@@ -591,10 +593,10 @@ commandWrapper( {
 
 		if ( ! isSubShell ) {
 			mutableStdout.muted = true;
-			subShellRl.write( `wp ${ cmd }\n` );
+			safeWrite( subShellRl, `wp ${ cmd }\n` );
 			mutableStdout.muted = false;
 			return;
 		}
 
-		subShellRl.prompt();
+		safePrompt( subShellRl );
 	} );

--- a/src/lib/wp/readline.ts
+++ b/src/lib/wp/readline.ts
@@ -1,0 +1,108 @@
+/**
+ * Safe wrappers around `readline.Interface` lifecycle methods.
+ *
+ * On Node.js >= 24, calling `resume()`, `pause()`, `prompt()`, or `write()` on a
+ * readline interface that has already been closed throws
+ * `Error [ERR_USE_AFTER_CLOSE]: readline was closed`. On Node 20/22 the same
+ * calls are silent no-ops.
+ *
+ * `vip wp` drives non-interactive, one-shot commands through a readline
+ * interface bound to `process.stdin`. When stdin is redirected from
+ * `/dev/null` (no TTY, e.g. CI or container runs) the interface receives EOF
+ * immediately and closes, while the command keeps streaming output. On a
+ * websocket reconnect during a long-running command the reconnect handler then
+ * calls `resume()` on the already-closed interface, crashing the process on
+ * Node 24.
+ *
+ * These helpers guard every such call so the interface is only driven while it
+ * is still open. Closure is tracked through the documented `'close'` event
+ * rather than any internal interface property, so the behaviour does not depend
+ * on Node.js implementation details.
+ *
+ * Register an interface with {@link trackReadline} once, right after it is
+ * created, so the `'close'` listener is attached before the interface can
+ * close. Calls made through the `safe*` helpers on an untracked-but-open
+ * interface still work; tracking only adds the closed-state guard.
+ *
+ * @see https://nodejs.org/api/readline.html#event-close
+ */
+import type { Interface } from 'node:readline';
+
+const closedInterfaces = new WeakSet< Interface >();
+
+/**
+ * Begin tracking a readline interface so its closed state can be detected.
+ *
+ * Attaches a one-time `'close'` listener that records the interface as closed.
+ * Safe to call more than once for the same interface.
+ *
+ * @param rl The readline interface to track.
+ * @returns The same interface, for convenient chaining.
+ */
+export function trackReadline( rl: Interface ): Interface {
+	rl.once( 'close', () => {
+		closedInterfaces.add( rl );
+	} );
+	return rl;
+}
+
+/**
+ * Whether a tracked readline interface has already emitted `'close'`.
+ *
+ * @param rl The readline interface to inspect.
+ * @returns `true` if the interface has been closed, otherwise `false`.
+ */
+export function isReadlineClosed( rl: Interface ): boolean {
+	return closedInterfaces.has( rl );
+}
+
+/**
+ * Resume the readline interface unless it has already been closed.
+ *
+ * @param rl The readline interface to resume.
+ */
+export function safeResume( rl: Interface ): void {
+	if ( ! isReadlineClosed( rl ) ) {
+		rl.resume();
+	}
+}
+
+/**
+ * Pause the readline interface unless it has already been closed.
+ *
+ * @param rl The readline interface to pause.
+ */
+export function safePause( rl: Interface ): void {
+	if ( ! isReadlineClosed( rl ) ) {
+		rl.pause();
+	}
+}
+
+/**
+ * Display the prompt unless the readline interface has already been closed.
+ *
+ * @param rl             The readline interface to prompt on.
+ * @param preserveCursor When `true`, prevents the cursor from being reset to 0.
+ */
+export function safePrompt( rl: Interface, preserveCursor?: boolean ): void {
+	if ( ! isReadlineClosed( rl ) ) {
+		rl.prompt( preserveCursor );
+	}
+}
+
+/**
+ * Write data into the readline interface unless it has already been closed.
+ *
+ * @param rl   The readline interface to write to.
+ * @param data The data to write.
+ * @param key  An optional key sequence, mirroring `Interface#write`.
+ */
+export function safeWrite(
+	rl: Interface,
+	data: string | Buffer,
+	key?: Parameters< Interface[ 'write' ] >[ 1 ]
+): void {
+	if ( ! isReadlineClosed( rl ) ) {
+		rl.write( data, key );
+	}
+}


### PR DESCRIPTION
## Description

Non-interactive `vip wp` runs (e.g. `vip @app -y -- wp <cmd>` with stdin from `/dev/null`) create a `readline` interface bound to `process.stdin`. With stdin redirected from `/dev/null`, the interface receives EOF and closes immediately, while the WP-CLI command keeps streaming output.

On a websocket reconnect during a long-running command, the reconnect handler calls `subShellRl.resume()` on the already-closed interface. On **Node.js >= 24** this throws `Error [ERR_USE_AFTER_CLOSE]: readline was closed` and crashes the process. On Node 20/22 the same call was a silent no-op, so the crash only surfaces on Node 24. Only long-running commands are affected, since short ones finish before any reconnect can occur.

This adds a small helper module, `src/lib/wp/readline.ts`, exposing guarded `safeResume`, `safePause`, `safePrompt`, and `safeWrite` wrappers that no-op once the interface is closed. Closed state is tracked via the **documented `readline` `'close'` event** (`trackReadline` registers a one-time listener when the interface is created), so the guard does not depend on any internal/undocumented interface property. All readline lifecycle calls in `vip-wp.js` now route through these helpers. `clearLine()` and `close()` are left untouched because they are safe on a closed interface.

A larger refactor (not creating a readline interface at all for one-shot, non-interactive runs) is possible as a follow-up; this PR is the minimal, surgical fix for the crash.

Fixes PLTFRM-2482.

## Changelog Description

### Fixed

- `vip wp`: Fixed a crash (`ERR_USE_AFTER_CLOSE`) on Node.js 24 when a websocket reconnect occurred during a long-running non-interactive command.

## Pull request checklist

- [ ] Update [SETUP.md](https://github.com/Automattic/vip-cli/blob/trunk/docs/SETUP.md#list-of-environmental-variables) with any new environmental variables.
- [ ] Update [the documentation](https://github.com/Automattic/vip-cli/blob/trunk/docs).
- [x] [Manually test](https://github.com/Automattic/vip-cli/blob/trunk/docs/TESTING.md#manual-testing) the relevant changes.
- [ ] Follow the [pull request checklist](https://github.com/Automattic/vip-cli/blob/trunk/docs/RELEASING.md#new-pull-requests)
- [x] Add/update [automated tests](https://github.com/Automattic/vip-cli/blob/trunk/docs/TESTING.md#automated-testing) as needed.

## New release checklist

- [x] [Automated tests](https://github.com/Automattic/vip-cli/blob/trunk/docs/TESTING.md#automated-testing) pass.
- [ ] The [Preparing for release checklist](https://github.com/Automattic/vip-cli/blob/trunk/docs/RELEASING.md#preparing-for-release) is completed.

## Steps to Test

The crash only reproduces on **Node.js >= 24**.

Unit tests (guard behavior):

1. Check out PR.
2. Run `npm ci`.
3. Run `./node_modules/.bin/jest __tests__/lib/wp/readline.ts`.
4. Verify the guards call through on an open interface and no-op (without throwing) on a closed one, and that closure is detected via the `'close'` event (including input EOF).

Behavioral reproduction of the original crash:

1. On Node 24, create a readline interface over an input stream, register it with `trackReadline`, then end the input (simulating `/dev/null` EOF).
2. Calling `resume()` directly on that closed interface throws `ERR_USE_AFTER_CLOSE`; calling `safeResume()` returns without throwing.
