### PR TITLE
fix(database): optimise fixMyDumperTransform and skip metadata lines

### DIFF
--- a/__fixtures__/dev-env-e2e/mydumper-detection.expected.sql
+++ b/__fixtures__/dev-env-e2e/mydumper-detection.expected.sql
@@ -1,5 +1,5 @@
 
--- metadata.header -1
+-- metadata.header 198
 # Started dump at: 2024-07-26 03:00:36
 [config]
 quote_character = BACKTICK

--- a/src/lib/database.ts
+++ b/src/lib/database.ts
@@ -106,26 +106,15 @@ const getSqlFileStreamFromCompressedFile = async ( filePath: string ): Promise< 
 	throw new Error( 'Not a supported compressed file' );
 };
 
+// Replaces the byte-size value that mydumper embeds in chunk header comments (e.g. `-- tablename 1234`)
+// with -1. mydumper exports the original file size in those headers, but since we modify the dump,
+// the size is no longer accurate — setting it to -1 tells mydumper to ignore it.
+// Lines starting with `-- metadata` are left untouched as they use the same format but are not chunk headers.
 export const fixMyDumperTransform = () => {
-	const regex = /^-- ([^ ]+) \d+$/;
+	const regex = /^-- (?!metadata)([^ ]+) \d+$/gm;
 	return new Transform( {
 		transform( chunk: string, _encoding: BufferEncoding, callback: TransformCallback ) {
-			const chunkString = chunk.toString();
-			const lineEnding = chunkString.includes( '\r\n' ) ? '\r\n' : '\n';
-			const lines = chunk
-				.toString()
-				.split( lineEnding )
-				.map( line => {
-					const match = regex.exec( line );
-
-					if ( ! match ) {
-						return line;
-					}
-
-					const tablePart = match[ 1 ];
-					return `-- ${ tablePart } -1`;
-				} );
-			callback( null, lines.join( lineEnding ) );
+			callback( null, chunk.toString().replace( regex, '-- $1 -1' ) );
 		},
 	} );
 };


### PR DESCRIPTION
## Summary

- Replace the `split` → `map` → `join` approach in `fixMyDumperTransform` with a single `String.replace` call using a `gm` regex, reducing intermediate allocations (no split array, no mapped array, single `toString()` call)
- Add a negative lookahead `(?!metadata)` to the regex so `-- metadata` lines are skipped without a separate `startsWith` check
- Add a comment explaining the _why_: mydumper embeds the original file byte-size in chunk header comments (e.g. `-- tablename 1234`); since we modify the dump, those sizes are no longer accurate and must be set to `-1` so mydumper ignores them

Fixes: PLTFRM-2499

## How to test

Run the existing test suite. To manually verify, pipe a mydumper SQL dump through the transform and confirm that:
1. Chunk header lines (e.g. `-- tablename 1234`) are rewritten to `-- tablename -1`
2. Lines starting with `-- metadata` (e.g. `-- metadata.header 0`) are left unchanged