### PR TITLE
fix(keychain): verify that the secure keychain actually works

### DIFF
--- a/__tests__/lib/keychain.js
+++ b/__tests__/lib/keychain.js
@@ -1,6 +1,6 @@
 import { randomBytes } from 'crypto';
 
-import Insecure from '../../src/lib/keychain/insecure';
+import { Insecure } from '../../src/lib/keychain/insecure';
 
 const account = 'vip-cli-test';
 const password = randomBytes( 256 ).toString();

--- a/src/lib/keychain.ts
+++ b/src/lib/keychain.ts
@@ -13,7 +13,7 @@ export async function getKeychain(): Promise< Keychain > {
 			const { Secure } = await import( './keychain/secure.js' );
 			const kc = new Secure();
 			// We don't know if the secure keychain is actually usable until we try to communicate with it.
-			await kc.getPassword( 'non-existant-password-fraude-perit-virtus' );
+			await kc.getPassword( 'non-existent-password-fraude-perit-virtus' );
 			debug( 'Using Secure keychain' );
 			keychain = kc;
 		} catch ( error ) {

--- a/src/lib/keychain.ts
+++ b/src/lib/keychain.ts
@@ -1,23 +1,26 @@
 import debugLib from 'debug';
 
-import Insecure from './keychain/insecure';
+import { Insecure } from './keychain/insecure';
 
 import type { Keychain } from './keychain/keychain';
 
 let keychain: Keychain;
 const debug = debugLib( '@automattic/vip:keychain' );
 
-try {
-	// Try using Secure keychain ("keytar") first
-	// eslint-disable-next-line @typescript-eslint/no-require-imports
-	const Secure = ( require( './keychain/secure' ) as typeof import('./keychain/secure') ).default;
-	keychain = new Secure();
-} catch ( error ) {
-	debug( 'Cannot use Secure keychain; falling back to Insecure keychain (Details: %o)', error );
+export async function getKeychain(): Promise< Keychain > {
+	if ( typeof keychain === 'undefined' ) {
+		try {
+			const { Secure } = await import( './keychain/secure.js' );
+			const kc = new Secure();
+			// We don't know if the secure keychain is actually usable until we try to communicate with it.
+			await kc.getPassword( 'non-existant-password-fraude-perit-virtus' );
+			debug( 'Using Secure keychain' );
+			keychain = kc;
+		} catch ( error ) {
+			debug( 'Cannot use Secure keychain; falling back to Insecure keychain (Details: %o)', error );
+			keychain = new Insecure( 'vip-go-cli' );
+		}
+	}
 
-	// Fallback to Insecure keychain if we can't
-	keychain = new Insecure( 'vip-go-cli' );
+	return keychain;
 }
-
-const exportedKeychain = keychain;
-export default exportedKeychain;

--- a/src/lib/keychain/insecure.ts
+++ b/src/lib/keychain/insecure.ts
@@ -2,7 +2,7 @@ import Configstore from 'configstore';
 
 import type { Keychain } from './keychain';
 
-export default class Insecure implements Keychain {
+export class Insecure implements Keychain {
 	private readonly configstore: Configstore;
 
 	constructor( private readonly file: string ) {

--- a/src/lib/keychain/secure.ts
+++ b/src/lib/keychain/secure.ts
@@ -2,7 +2,7 @@ import keytar from '@github/keytar';
 
 import type { Keychain } from './keychain';
 
-export default class Secure implements Keychain {
+export class Secure implements Keychain {
 	public getPassword( service: string ): Promise< string | null > {
 		return keytar.getPassword( service, service );
 	}

--- a/src/lib/token.ts
+++ b/src/lib/token.ts
@@ -2,7 +2,7 @@ import { jwtDecode } from 'jwt-decode';
 import { randomUUID } from 'node:crypto';
 
 import { API_HOST, PRODUCTION_API_HOST } from './api';
-import keychain from './keychain';
+import { getKeychain } from './keychain';
 
 interface Payload {
 	id?: number;
@@ -81,6 +81,7 @@ export default class Token {
 	public static async uuid(): Promise< string > {
 		const service = Token.getServiceName( '-uuid' );
 
+		const keychain = await getKeychain();
 		let _uuid = await keychain.getPassword( service );
 		if ( ! _uuid ) {
 			_uuid = randomUUID();
@@ -92,25 +93,26 @@ export default class Token {
 
 	public static async setUuid( _uuid: string ): Promise< void > {
 		const service = Token.getServiceName( '-uuid' );
+		const keychain = await getKeychain();
 		await keychain.setPassword( service, _uuid );
 	}
 
-	public static set( token: string ): Promise< boolean > {
+	public static async set( token: string ): Promise< boolean > {
 		const service = Token.getServiceName();
-
+		const keychain = await getKeychain();
 		return keychain.setPassword( service, token );
 	}
 
 	public static async get(): Promise< Token > {
 		const service = Token.getServiceName();
-
-		const token = ( await keychain.getPassword( service ) ) ?? '';
-		return new Token( token );
+		const keychain = await getKeychain();
+		const token = await keychain.getPassword( service );
+		return new Token( token ?? '' );
 	}
 
-	public static purge(): Promise< boolean > {
+	public static async purge(): Promise< boolean > {
 		const service = Token.getServiceName();
-
+		const keychain = await getKeychain();
 		return keychain.deletePassword( service );
 	}
 


### PR DESCRIPTION
## Description

This PR adds a check to ensure that the secure keychain is actually usable before advertising it as available. This fixes the issues that occur when the secure keychain module successfully initializes but then fails to communicate with the underlying secure storage. On Linux and WSL2, for example, this could be due to a missing DBus or an unclaimed `org.freedesktop.secrets` endpoint.

## Changelog Description

### Fixed

- Secure storage may be unavailable even if the keychain provider successfully initializes.

## Pull request checklist

- [ ] Update [SETUP.md](https://github.com/Automattic/vip-cli/blob/trunk/docs/SETUP.md#list-of-environmental-variables) with any new environmental variables.
- [ ] Update [the documentation](https://github.com/Automattic/vip-cli/blob/trunk/docs).
- [x] [Manually test](https://github.com/Automattic/vip-cli/blob/trunk/docs/TESTING.md#manual-testing) the relevant changes.
- [x] Follow the [pull request checklist](https://github.com/Automattic/vip-cli/blob/trunk/docs/RELEASING.md#new-pull-requests)
- [ ] Add/update [automated tests](https://github.com/Automattic/vip-cli/blob/trunk/docs/TESTING.md#automated-testing) as needed.

## New release checklist

- [ ] [Automated tests](https://github.com/Automattic/vip-cli/blob/trunk/docs/TESTING.md#automated-testing) pass.
- [ ] The [Preparing for release checklist](https://github.com/Automattic/vip-cli/blob/trunk/docs/RELEASING.md#preparing-for-release) is completed.

## Steps to Test

On Lunux/WSL2:

```shell
DBUS_SESSION_BUS_ADDRESS= DEBUG=@automattic/vip:keychain vip whoami
```

must show something like:

```
  @automattic/vip:keychain Cannot use Secure keychain; falling back to Insecure keychain (Details: [Error: The given address is empty]) +0ms
```

Previous versions of VIP CLI will fail.