### PR TITLE
fix: improve command and option parsing in generate-docs script

### DIFF
--- a/helpers/generate-docs.js
+++ b/helpers/generate-docs.js
@@ -65,11 +65,19 @@ const parseOutput = output => {
 		}
 
 		if ( currentSection === SECTION_COMMAND ) {
-			const [ , command, description ] = line.match( COMMAND_REGEXP );
-			result.commands.push( {
-				command,
-				description,
-			} );
+			const match = line.match( COMMAND_REGEXP );
+			if ( match ) {
+				const [ , command, description ] = match;
+				result.commands.push( {
+					command,
+					description,
+				} );
+			} else if ( result.commands.length ) {
+				// Continuation of a wrapped command description.
+				result.commands[ result.commands.length - 1 ].description += ' ' + line;
+			} else {
+				console.error( 'Unknown command line', line );
+			}
 			continue;
 		}
 		if ( currentSection === SECTION_OPTIONS ) {
@@ -79,8 +87,11 @@ const parseOutput = output => {
 					option,
 					description,
 				} );
+			} else if ( result.options.length ) {
+				// Continuation of a wrapped option description.
+				result.options[ result.options.length - 1 ].description += ' ' + line;
 			} else {
-				console.log( 'Unknown option', line );
+				console.error( 'Unknown option', line );
 			}
 			continue;
 		}


### PR DESCRIPTION
## Description

This pull request fixes the generate-docs.js script. The output is then ingested into our documentation site.

The `vip --help` output wraps long option/command descriptions across multiple lines (commander.js wraps to the terminal width, which is 80 columns when stdout is piped in CI). Two bugs resulted:

1. Corrupted JSON output — every wrapped continuation line (e.g. for a (sub)command. (default: false)) failed the OPTION_REGEXP match and hit console.log('Unknown option', line). That's console.log, so it wrote to stdout — polluting the /tmp/docs.json file the [publish-docs workflow](vscode-webview://04gbpbfcaarv4oerjgpmptedbsocsonhpicrjckr9i3qdmgfbius/.github/workflows/publish-docs.yml#L22) redirects to. The JSON was invalid.
2. Lost description text — the wrapped continuation lines were dropped entirely instead of being appended to their option's description.