### PR TITLE
CI: Fix prepare-release version output for shrinkwrap sync

### DIFF
--- a/.github/workflows/npm-prepare-release.yml
+++ b/.github/workflows/npm-prepare-release.yml
@@ -30,6 +30,11 @@ jobs:
 
       - name: Run npm-prepare-release
         uses: Automattic/vip-actions/npm-prepare-release@438cd00aac2463a2dbfb4a747ad7b1ac67a2575a # v0.7.5
+        env:
+          # The action captures `npm version` stdout to build the release branch name.
+          # Keep lifecycle script banners from polluting that value while still allowing
+          # the `version` script to sync npm-shrinkwrap.json.
+          NPM_CONFIG_LOGLEVEL: silent
         with:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           npm-version-type: ${{ inputs.npm-version-type }}


### PR DESCRIPTION
## Description

https://github.com/Automattic/vip-cli/actions/runs/29278478408/job/86913465276

Silence npm lifecycle banners in the prepare-release workflow so the vip-actions release script captures only the version string from `npm version`.

The version lifecycle script still syncs npm-shrinkwrap.json, but its npm banner output no longer pollutes the generated release branch name.